### PR TITLE
Add values files to override provided values for Helm install

### DIFF
--- a/helm/values-nodeport.yaml
+++ b/helm/values-nodeport.yaml
@@ -1,0 +1,9 @@
+httpGateway:
+  service:
+    type: NodePort
+grafana:
+  service:
+    type: NodePort
+zipkin:
+  service:
+    type: NodePort

--- a/helm/values-snapshot.yaml
+++ b/helm/values-snapshot.yaml
@@ -1,0 +1,12 @@
+functionController:
+  image:
+    tag: 0.0.1-SNAPSHOT
+  sidecar:
+    image:
+      tag: 0.0.1-SNAPSHOT
+topicController:
+  image:
+    tag: 0.0.1-SNAPSHOT
+httpGateway:
+  image:
+    tag: 0.0.1-SNAPSHOT


### PR DESCRIPTION
- use values-nodeport.yaml for overriding service type of LoadBalancer with NodePort

- use values-snapshot.yaml for overriding riff component tag with SNAPSHOT build tags

- install using `helm install --name demo --values helm/values-snapshot.yaml,helm/values-nodeport.yaml riffrepo/riff`