### PR TITLE
updates after 0.0.1 release

### DIFF
--- a/config/function-controller-deployment.yaml
+++ b/config/function-controller-deployment.yaml
@@ -12,7 +12,7 @@ spec:
         component: function-controller
     spec:
       containers:
-      - image: projectriff/function-controller:0.0.1
+      - image: projectriff/function-controller:0.0.2-snapshot
         name: function-controller
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -37,5 +37,5 @@ spec:
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
           value: zookeeper:2181
         - name: RIFF_FUNCTION_SIDECAR_TAG
-          value: 0.0.1
+          value: 0.0.2-snapshot
       serviceAccountName: riff-sa

--- a/config/http-gateway-deployment.yaml
+++ b/config/http-gateway-deployment.yaml
@@ -12,7 +12,7 @@ spec:
         component: http-gateway
     spec:
       containers:
-      - image: projectriff/http-gateway:0.0.1
+      - image: projectriff/http-gateway:0.0.2-snapshot
         name: http-gateway
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/config/topic-controller-deployment.yaml
+++ b/config/topic-controller-deployment.yaml
@@ -12,7 +12,7 @@ spec:
         component: topic-controller
     spec:
       containers:
-      - image: projectriff/topic-controller:0.0.1
+      - image: projectriff/topic-controller:0.0.2-snapshot
         name: topic-controller
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/helm/values-snapshot.yaml
+++ b/helm/values-snapshot.yaml
@@ -1,12 +1,12 @@
 functionController:
   image:
-    tag: 0.0.1-SNAPSHOT
+    tag: 0.0.2-snapshot
   sidecar:
     image:
-      tag: 0.0.1-SNAPSHOT
+      tag: 0.0.2-snapshot
 topicController:
   image:
-    tag: 0.0.1-SNAPSHOT
+    tag: 0.0.2-snapshot
 httpGateway:
   image:
-    tag: 0.0.1-SNAPSHOT
+    tag: 0.0.2-snapshot

--- a/samples/slack/slack-command/Dockerfile
+++ b/samples/slack/slack-command/Dockerfile
@@ -1,3 +1,3 @@
-FROM sk8s/node-function-invoker:0.0.7
+FROM sk8s/node-function-invoker:0.0.1
 ENV FUNCTION_URI /functions/function.js
 ADD slack_command.js ${FUNCTION_URI}


### PR DESCRIPTION
- Dockerfiles for samples all use 0.0.1 function invoker base images
- local config yaml for riff components all use 0.0.2-snapshot
- the values-snapshot.yaml used local helm install overrides also uses 0.0.2-snapshot