### PR TITLE
Adapt python uppercase sample to latest gRPC format

### DIFF
--- a/samples/python/uppercase/README.adoc
+++ b/samples/python/uppercase/README.adoc
@@ -21,7 +21,7 @@ pushd samples/python/uppercase; ./dockerize ; popd
 === Publish a Message to the Input Topic
 
 ```
-./publish greetings hello
+./request greetings hello
 ```
 
 === Tail the Sidecar Log

--- a/samples/python/uppercase/dockerize
+++ b/samples/python/uppercase/dockerize
@@ -8,7 +8,8 @@ if [ -e proto ]; then
 fi
 mkdir proto
 
-GIT_PATH=https://raw.githubusercontent.com/projectriff/function-proto/master
+#GIT_PATH=https://raw.githubusercontent.com/projectriff/function-proto/master
+GIT_PATH=https://raw.githubusercontent.com/ericbottard/function-proto/issue_5
 
 wget $GIT_PATH/fntypes.proto -P proto
 wget $GIT_PATH/function.proto -P proto

--- a/samples/python/uppercase/py/func.py
+++ b/samples/python/uppercase/py/func.py
@@ -11,16 +11,17 @@ from concurrent import futures
 This method’s semantics are a combination of those of the request-streaming method and the response-streaming method. 
 It is passed an iterator of request values and is itself an iterator of response values.
 '''
-class StringFunctionServicer(function.StringFunctionServicer):
+class MessageFunctionServicer(function.MessageFunctionServicer):
 
     def Call(self, request_iterator, context):
         for request in request_iterator:
-            reply = types.Reply()
-            reply.body = request.body.upper()
+            reply = types.Message()
+            reply.payload = request.payload.upper()
+            reply.headers['correlationId'].values[:] = request.headers['correlationId'].values[:]
             yield reply
 
 server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-function.add_StringFunctionServicer_to_server(StringFunctionServicer(), server)
+function.add_MessageFunctionServicer_to_server(MessageFunctionServicer(), server)
 server.add_insecure_port('%s:%s' % ('[::]', os.environ.get("GRPC_PORT","10382")))
 
 server.start()


### PR DESCRIPTION
Fixes #217 

See https://github.com/projectriff/function-proto/pull/6 and https://github.com/projectriff/function-sidecar/pull/36

Don't forget to change back URL in `dockerize`