### PR TITLE
default riff build tag should match sample yaml image tag

### DIFF
--- a/riff
+++ b/riff
@@ -247,7 +247,7 @@ done
 # ======================================= DEFAULTS ============================================
 FUNCTION="${FUNCTION:-${PWD##*/}}"
 FNPATH="${FNPATH:-.}"
-VERSION="${VERSION:-0.0.1}"
+VERSION="${VERSION:-0.0.2}"
 CONTAINER="${CONTAINER:-sidecar}"
 # ======================================= DEFAULTS END ========================================
 if [[ "${COMMAND}" == "build" ]]; then


### PR DESCRIPTION
Ran into this during a demo today - i like to cd to the sample and then `riff build` using the defaults.