### PR TITLE
Skip tests when building the java function invoker

### DIFF
--- a/build-java-function-invoker
+++ b/build-java-function-invoker
@@ -1,4 +1,4 @@
 #!/bin/bash
 pushd "$PWD/../java-function-invoker/"
-    ./mvnw clean package dockerfile:build
+    ./mvnw clean package dockerfile:build -Dmaven.test.skip=true
 popd


### PR DESCRIPTION
Previously, the java-function-invoker would take over 2 minutes to
build. After skipping tests, the build time drops to ~10 seconds.

Tests should be run at dev time and in CI, but are not needed at deploy
time.