### PR TITLE
readme changes for go CLI and the new shell invoker

### DIFF
--- a/Development-Helm-install.adoc
+++ b/Development-Helm-install.adoc
@@ -4,8 +4,6 @@
 
 * A running 1.7+ Kubernetes cluster
 
-TIP: If using Minikube, we recommend using Minikube v0.23.0 or v0.24.1 and avoiding v0.24.0 due to some DNS issues
-
 * Kubernetes CLI `kubectl` installed and on the local system PATH. We recommend using the same version or later as the Kubernetes cluster you are using.
 
 * Helm, you need helm installed, see instructions link:Getting-Started.adoc#helm[here]. 

--- a/Getting-Started.adoc
+++ b/Getting-Started.adoc
@@ -7,8 +7,6 @@ This guide covers installing riff using https://helm.sh/[Helm], which is a commo
 
 * A running 1.7+ Kubernetes cluster
 
-TIP: If using Minikube, we recommend using Minikube v0.23.0 or v0.24.1 and avoiding v0.24.0 due to some DNS issues
-
 * Kubernetes CLI `kubectl` installed and on the local system PATH. We recommend using the same version or later as the Kubernetes cluster you are using.
 
 * Docker, if you plan on building samples or your own functions then you will need Docker installed. We have used Docker version 17.x or later.

--- a/README.adoc
+++ b/README.adoc
@@ -100,7 +100,7 @@ This builds the Function Sidecar, HTTP Gateway, Topic Controller, Function Contr
 ./build-riff-cli
 ----
 
-==== Build the other function invokers
+==== Build the function invokers
 
 This builds the `java-function-invoker`, `node-function-invoker`, `shell-function-invoker`, and `python2-function-invoker`:
 

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ invokers and can be deployed using the new go CLI. See below for build instructi
 
 == Developer installation
 
-If you want to run the current development version (git master branch) of riff, read link:Development-Helm-install.adoc[Installing the riff development version using Helm].
+To install the current development version (git master branch) of riff, see link:Development-Helm-install.adoc[Installing the riff development version using Helm].
 
 === [[manual]] Manual install of riff
 

--- a/README.adoc
+++ b/README.adoc
@@ -43,7 +43,7 @@ https://github.com/projectriff/function-controller[function-controller],
 https://github.com/projectriff/topic-controller[topic-controller],
 https://github.com/projectriff/http-gateway[http-gateway],
 https://github.com/projectriff/shell-function-invoker[shell-function-invoker], and
-https://github.com/projectriff/shell-function-invoker[riff-cli] repositories.
+https://github.com/projectriff/riff-cli[riff-cli] repositories.
 +
 [source, bash]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -4,18 +4,21 @@ A FaaS for Kubernetes
 
 == Installation of latest release
 
-You can install the latest release using link:Getting-Started.adoc[a Helm chart]. 
+You can install the latest (v0.0.3) release using link:Getting-Started.adoc[a Helm chart].
 
-== Installation of the riff CLI
+The https://github.com/projectriff/riff/tree/v0.0.3/samples[Tag v0.0.3 samples] will work together
+with the https://github.com/projectriff/riff/releases[v0.0.3 CLI].
 
-You can install the riff CLI by following instructions for the https://github.com/projectriff/riff/releases[latest release].
+Samples on the git master branch of this repo have been updated to work with recently modified
+invokers and can be deployed using the new go CLI. See below for build instructions.
 
 == Developer installation
 
-If you want to run the current development version of riff read link:Development-Helm-install.adoc[Installing the riff development version using Helm].
-You can also link:#manual[build and deploy riff manually], this is the best option if you want to modify the riff components.
+If you want to run the current development version (git master branch) of riff, read link:Development-Helm-install.adoc[Installing the riff development version using Helm].
 
 === [[manual]] Manual install of riff
+
+This is the best option if you want to modify the riff components.
 
 ==== Prerequisites
 
@@ -34,11 +37,13 @@ minikube start
 
 * A Java 8 environment.
 
-* A working Go environment, with clones of the 
-https://github.com/projectriff/function-sidecar[function-sidecar], 
+* A working Go environment with dep, and clones of the
+https://github.com/projectriff/function-sidecar[function-sidecar],
 https://github.com/projectriff/function-controller[function-controller],
-https://github.com/projectriff/topic-controller[topic-controller] and 
-https://github.com/projectriff/http-gateway[http-gateway] repositories.
+https://github.com/projectriff/topic-controller[topic-controller],
+https://github.com/projectriff/http-gateway[http-gateway],
+https://github.com/projectriff/shell-function-invoker[shell-function-invoker], and
+https://github.com/projectriff/shell-function-invoker[riff-cli] repositories.
 +
 [source, bash]
 ----
@@ -47,13 +52,14 @@ git clone -o upstream https://github.com/projectriff/function-sidecar src/github
 git clone -o upstream https://github.com/projectriff/function-controller src/github.com/projectriff/function-controller/
 git clone -o upstream https://github.com/projectriff/topic-controller src/github.com/projectriff/topic-controller/
 git clone -o upstream https://github.com/projectriff/http-gateway src/github.com/projectriff/http-gateway/
+git clone -o upstream https://github.com/projectriff/shell-function-invoker src/github.com/projectriff/shell-function-invoker/
+git clone -o upstream https://github.com/projectriff/riff-cli src/github.com/projectriff/riff-cli/
 ----
 
 * A clone of the 
 https://github.com/projectriff/riff[riff], 
 https://github.com/projectriff/java-function-invoker[java-function-invoker], 
 https://github.com/projectriff/node-function-invoker[node-function-invoker], 
-https://github.com/projectriff/shell-function-invoker[shell-function-invoker] and 
 https://github.com/projectriff/python2-function-invoker[python2-function-invoker] repos.
 +
 NOTE: These repos should be cloned under a unique root directory since we will be using relative paths during the build.
@@ -64,7 +70,6 @@ NOTE: These repos should be cloned under a unique root directory since we will b
 git clone -o upstream https://github.com/projectriff/riff.git
 git clone -o upstream https://github.com/projectriff/java-function-invoker.git
 git clone -o upstream https://github.com/projectriff/node-function-invoker.git
-git clone -o upstream https://github.com/projectriff/shell-function-invoker.git
 git clone -o upstream https://github.com/projectriff/python2-function-invoker.git
 ----
 
@@ -84,7 +89,7 @@ eval $(minikube docker-env)
 
 ==== Build the core riff components
 
-This builds the Function Sidecar, HTTP Gateway, Topic Controller, and Function Controller:
+This builds the Function Sidecar, HTTP Gateway, Topic Controller, Function Controller, and riff CLI:
 
 [source, bash]
 ----
@@ -92,9 +97,10 @@ This builds the Function Sidecar, HTTP Gateway, Topic Controller, and Function C
 ./build-http-gateway
 ./build-topic-controller
 ./build-function-controller
+./build-riff-cli
 ----
 
-==== Build the function invokers
+==== Build the other function invokers
 
 This builds the `java-function-invoker`, `node-function-invoker`, `shell-function-invoker`, and `python2-function-invoker`:
 

--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ cd riff
 eval $(minikube docker-env)
 ----
 
-==== Build the core riff components and CLI
+==== Build the riff core components, invokers and CLI
 
 [source, bash]
 ----
@@ -93,23 +93,17 @@ eval $(minikube docker-env)
 ./build-topic-controller
 ./build-function-controller
 ./build-riff-cli
+./build-shell-function-invoker
+./build-java-function-invoker 
+./build-node-function-invoker
+./build-python2-function-invoker
 ----
 
-Add the compiled riff CLI to your path or alias it.
+==== Add the compiled riff CLI to your path or alias it.
 
 [source, bash]
 ----
 alias riff="$(go env GOPATH)/src/github.com/projectriff/riff-cli/riff"
-----
-
-==== Build the function invokers
-
-[source, bash]
-----
-./build-java-function-invoker 
-./build-node-function-invoker
-./build-shell-function-invoker
-./build-python2-function-invoker
 ----
 
 ==== Deploy Kafka/Zookeeper

--- a/README.adoc
+++ b/README.adoc
@@ -35,14 +35,10 @@ minikube start
 
 * A Java 8 environment.
 
-* A working Go environment with dep, and clones of the
-https://github.com/projectriff/function-sidecar[function-sidecar],
-https://github.com/projectriff/function-controller[function-controller],
-https://github.com/projectriff/topic-controller[topic-controller],
-https://github.com/projectriff/http-gateway[http-gateway],
-https://github.com/projectriff/shell-function-invoker[shell-function-invoker], and
-https://github.com/projectriff/riff-cli[riff-cli] repositories.
-+
+* A working Go environment with dep
+
+==== Clone the go components
+
 [source, bash]
 ----
 go get -d github.com/projectriff/function-sidecar
@@ -53,14 +49,10 @@ go get -d github.com/projectriff/shell-function-invoker
 go get -d github.com/projectriff/riff-cli
 ----
 
-* A clone of the 
-https://github.com/projectriff/riff[riff], 
-https://github.com/projectriff/java-function-invoker[java-function-invoker], 
-https://github.com/projectriff/node-function-invoker[node-function-invoker], 
-https://github.com/projectriff/python2-function-invoker[python2-function-invoker] repos.
-+
+==== Clone riff and the other (non-golang) repos
+
 NOTE: These repos should be cloned under a unique root directory since we will be using relative paths during the build.
-+
+
 [source, bash]
 ----
 #cd <some_root_dir>

--- a/README.adoc
+++ b/README.adoc
@@ -4,10 +4,10 @@ A FaaS for Kubernetes
 
 == Installation of latest release
 
-You can install the latest (v0.0.3) release using link:Getting-Started.adoc[a Helm chart].
+You can install the latest (0.0.3) release using link:Getting-Started.adoc[a Helm chart].
 
-The https://github.com/projectriff/riff/tree/v0.0.3/samples[Tag v0.0.3 samples] will work together
-with the https://github.com/projectriff/riff/releases[v0.0.3 CLI].
+The https://github.com/projectriff/riff/tree/v0.0.3/samples[0.0.3 samples] will work together
+with the https://github.com/projectriff/riff/releases[0.0.3 CLI].
 
 Samples on the git master branch of this repo have been updated to work with recently modified
 invokers and can be deployed using the new go CLI. See below for build instructions.

--- a/README.adoc
+++ b/README.adoc
@@ -84,9 +84,7 @@ cd riff
 eval $(minikube docker-env)
 ----
 
-==== Build the core riff components
-
-This builds the Function Sidecar, HTTP Gateway, Topic Controller, Function Controller, and riff CLI:
+==== Build the core riff components and CLI
 
 [source, bash]
 ----
@@ -106,11 +104,12 @@ alias riff="$(go env GOPATH)/src/github.com/projectriff/riff-cli/riff"
 
 ==== Build the function invokers
 
-This builds the `java-function-invoker`, `node-function-invoker`, `shell-function-invoker`, and `python2-function-invoker`:
-
 [source, bash]
 ----
-./build-function-invokers
+./build-java-function-invoker 
+./build-node-function-invoker
+./build-shell-function-invoker
+./build-python2-function-invoker
 ----
 
 ==== Deploy Kafka/Zookeeper

--- a/README.adoc
+++ b/README.adoc
@@ -45,13 +45,12 @@ https://github.com/projectriff/riff-cli[riff-cli] repositories.
 +
 [source, bash]
 ----
-cd $(go env GOPATH)   #defaults to ~/go
-git clone -o upstream https://github.com/projectriff/function-sidecar src/github.com/projectriff/function-sidecar/
-git clone -o upstream https://github.com/projectriff/function-controller src/github.com/projectriff/function-controller/
-git clone -o upstream https://github.com/projectriff/topic-controller src/github.com/projectriff/topic-controller/
-git clone -o upstream https://github.com/projectriff/http-gateway src/github.com/projectriff/http-gateway/
-git clone -o upstream https://github.com/projectriff/shell-function-invoker src/github.com/projectriff/shell-function-invoker/
-git clone -o upstream https://github.com/projectriff/riff-cli src/github.com/projectriff/riff-cli/
+go get github.com/projectriff/function-sidecar
+go get github.com/projectriff/function-controller
+go get github.com/projectriff/topic-controller
+go get github.com/projectriff/http-gateway
+go get github.com/projectriff/shell-function-invoker
+go get github.com/projectriff/riff-cli
 ----
 
 * A clone of the 
@@ -65,10 +64,10 @@ NOTE: These repos should be cloned under a unique root directory since we will b
 [source, bash]
 ----
 #cd <some_root_dir>
-git clone -o upstream https://github.com/projectriff/riff.git
-git clone -o upstream https://github.com/projectriff/java-function-invoker.git
-git clone -o upstream https://github.com/projectriff/node-function-invoker.git
-git clone -o upstream https://github.com/projectriff/python2-function-invoker.git
+git clone https://github.com/projectriff/riff.git
+git clone https://github.com/projectriff/java-function-invoker.git
+git clone https://github.com/projectriff/node-function-invoker.git
+git clone https://github.com/projectriff/python2-function-invoker.git
 ----
 
 From now on, this README assumes you're running commands from the `riff` repository clone:

--- a/README.adoc
+++ b/README.adoc
@@ -25,9 +25,7 @@ This is the best option if you want to modify the riff components.
 You need:
 
 * A running 1.7+ Kubernetes cluster. These instructions assume minikube for now.
-+
-TIP: We recommend using Minikube v0.23.0 or v0.24.1 and avoiding v0.24.0 due to some DNS issues
-+
+
 [source,bash]
 ----
 minikube start

--- a/README.adoc
+++ b/README.adoc
@@ -45,12 +45,12 @@ https://github.com/projectriff/riff-cli[riff-cli] repositories.
 +
 [source, bash]
 ----
-go get github.com/projectriff/function-sidecar
-go get github.com/projectriff/function-controller
-go get github.com/projectriff/topic-controller
-go get github.com/projectriff/http-gateway
-go get github.com/projectriff/shell-function-invoker
-go get github.com/projectriff/riff-cli
+go get -d github.com/projectriff/function-sidecar
+go get -d github.com/projectriff/function-controller
+go get -d github.com/projectriff/topic-controller
+go get -d github.com/projectriff/http-gateway
+go get -d github.com/projectriff/shell-function-invoker
+go get -d github.com/projectriff/riff-cli
 ----
 
 * A clone of the 

--- a/README.adoc
+++ b/README.adoc
@@ -100,6 +100,14 @@ This builds the Function Sidecar, HTTP Gateway, Topic Controller, Function Contr
 ./build-riff-cli
 ----
 
+==== Alias the riff CLI
+Add the compiled riff CLI to your path or alias it.
+
+[source, bash]
+----
+alias riff="$(go env GOPATH)/src/github.com/projectriff/riff-cli/riff"
+----
+
 ==== Build the function invokers
 
 This builds the `java-function-invoker`, `node-function-invoker`, `shell-function-invoker`, and `python2-function-invoker`:

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ invokers and can be deployed using the new go CLI. See below for build instructi
 
 == Developer installation
 
-To install the current development version (git master branch) of riff, see link:Development-Helm-install.adoc[Installing the riff development version using Helm].
+To use Helm to install the current development version (git master branch) of riff, see link:Development-Helm-install.adoc[Installing the riff development version using Helm].
 
 === [[manual]] Manual install of riff
 

--- a/README.adoc
+++ b/README.adoc
@@ -100,7 +100,6 @@ This builds the Function Sidecar, HTTP Gateway, Topic Controller, Function Contr
 ./build-riff-cli
 ----
 
-==== Alias the riff CLI
 Add the compiled riff CLI to your path or alias it.
 
 [source, bash]

--- a/build-function-invokers
+++ b/build-function-invokers
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e -v
-
-./build-java-function-invoker 
-./build-node-function-invoker
-./build-shell-function-invoker
-./build-python2-function-invoker
-

--- a/build-riff-cli
+++ b/build-riff-cli
@@ -1,0 +1,4 @@
+#!/bin/bash
+pushd "$(go env GOPATH)/src/github.com/projectriff/riff-cli/"
+    make
+popd

--- a/build-shell-function-invoker
+++ b/build-shell-function-invoker
@@ -1,4 +1,4 @@
 #!/bin/bash
-pushd "$PWD/../shell-function-invoker/"
+pushd "$(go env GOPATH)/src/github.com/projectriff/shell-function-invoker/"
     make dockerize
 popd

--- a/samples/java/greeter/README.adoc
+++ b/samples/java/greeter/README.adoc
@@ -9,7 +9,7 @@
 === prerequisites
 
 1. riff is deployed
-2. the `riff` script is on your PATH
+2. the `riff` CLI is on your PATH
 3. the working directory is `samples/java/greeter`
 
 === compile the Java code and build the JAR

--- a/samples/node/square/README.adoc
+++ b/samples/node/square/README.adoc
@@ -3,7 +3,7 @@
 [horizontal]
 *Language*:: JavaScript
 *Function*:: link:square.js[square.js]
-*Protocol*:: HTTP
+*Protocol*:: grpc
 *Input*:: numbers
 
 === prerequisites

--- a/samples/node/square/README.adoc
+++ b/samples/node/square/README.adoc
@@ -9,7 +9,7 @@
 === prerequisites
 
 1. riff is deployed
-2. the `riff` script is on your PATH
+2. the `riff` CLI is on your PATH
 3. the working directory is `samples/node/square`
 
 === create the function and its input topic

--- a/samples/python/sentiments/README.adoc
+++ b/samples/python/sentiments/README.adoc
@@ -9,7 +9,7 @@
 === prerequisites
 
 1. riff is deployed
-2. the `riff` script is on your PATH
+2. the `riff` CLI is on your PATH
 3. the working directory is `samples/python/sentiments`
 
 === create the function and its input topic

--- a/samples/shell/echo/README.adoc
+++ b/samples/shell/echo/README.adoc
@@ -3,7 +3,7 @@
 [horizontal]
 *Language*:: Shell
 *Function*:: link:echo.sh[echo.sh]
-*Protocol*:: stdio
+*Protocol*:: grpc
 *Input*:: greetings
 
 === prerequisites

--- a/samples/shell/echo/README.adoc
+++ b/samples/shell/echo/README.adoc
@@ -9,7 +9,7 @@
 === prerequisites
 
 1. riff is deployed
-2. the `riff` script is on your PATH
+2. the `riff` CLI is on your PATH
 3. the working directory is `samples/shell/echo`
 
 === create the function and its input topic

--- a/samples/shell/wordcount/README.adoc
+++ b/samples/shell/wordcount/README.adoc
@@ -9,7 +9,7 @@
 === prerequisites
 
 1. riff is deployed
-2. the `riff` script is on your PATH
+2. the `riff` CLI is on your PATH
 3. the working directory is `samples/shell/wordcount`
 
 === create the function and its input topic


### PR DESCRIPTION
Users who try to use the samples from master with the 0.0.3 riff will experience issues.

This makes the riff README more correct for developers trying out riff with the new shell invoker and new go CLI. The README will need to be changed again for the 0.0.4 release.


