### PR TITLE
Fix references in READMEs

### DIFF
--- a/Development-Helm-install.adoc
+++ b/Development-Helm-install.adoc
@@ -4,11 +4,13 @@
 
 * A running 1.7+ Kubernetes cluster
 
-* Kubernetes CLI `kubectl` installed and on the local system PATH. We recommend using the same version or later as the Kubernetes cluster you are using.
+* Kubernetes CLI `kubectl` installed and on the local system PATH.
+We recommend using the same version or later as the Kubernetes cluster you are using.
 
 * Helm, you need helm installed, see instructions link:Getting-Started.adoc#helm[here]. 
 
-* Docker, you only need Docker when building custom versions of riff components or the samples. We have used Docker version 17.x or later.
+* Docker, you only need Docker when building custom versions of riff components or the samples.
+We have used Docker version 17.x or later.
 
 == Add the riff repository to your helm configuration
 
@@ -32,7 +34,9 @@ helm search riff -l
 
 == [[devel]]Install a riff development version on Minikube
 
-Starting with the 0.0.4 version we have separated the Kafka installation from the riff chart. This requires an extra step of installing Kafka in order yo use riff. You can use the single-node Kafka chart provided by riff or the three-node kafka/zookeeper service provided by the Kubeapps.
+Starting with the 0.0.4 version we have separated the Kafka installation from the riff chart.
+This requires an extra step of installing Kafka in order yo use riff.
+You can use the single-node Kafka chart provided by riff or the three-node kafka/zookeeper service provided by the Kubeapps.
 
 === Install Kafka chart
 
@@ -66,7 +70,8 @@ Just be aware that this chart requires significantly more resources to run.
 
 === Install "devel" version of riff chart
 
-Install the development version of the riff chart in the default namespace. When using Minikube configure the httpGateway to use `NodePort` with:
+Install the development version of the riff chart in the default namespace.
+When using Minikube configure the httpGateway to use `NodePort` with:
 
 [source, bash]
 ----
@@ -82,19 +87,25 @@ Alternatively, install riff in the `riff-system` namespace:
 helm install --name control --namespace riff-system riffrepo/riff --devel --set rbac.create=false --set httpGateway.service.type=NodePort
 ----
 
-If you do this you need to provide the `--namespace riff-system` option for the `riff publish` command since the `http-gateway` now runs in the `-riff-system` namespace.
+If you do this you need to provide the `--namespace riff-system` option for the `riff publish` command
+since the `http-gateway` now runs in the `-riff-system` namespace.
 ====
 
 [NOTE]
 ====
-For a cluster that supports `LoadBalancer` leave out the `--set httpGateway.service.type=NodePort` option. For a cluster that uses RBAC leave out the `--set rbac.create=false` option.
+For a cluster that supports `LoadBalancer` leave out the `--set httpGateway.service.type=NodePort` option.
+For a cluster that uses RBAC leave out the `--set rbac.create=false` option.
 ====
 
 === Customizing the Installation
 
-The Helm chart contains a https://github.com/projectriff/helm-charts/blob/master/riff/values.yaml[values.yaml] file that specifies the default values used when installing the chart. They can all be overridden by using the flag `--set` as described in the documentation for https://docs.helm.sh/helm/#helm-install[Helm Install].
+The Helm chart contains a https://github.com/projectriff/riff/blob/master/helm-charts/riff/values.yaml[values.yaml]
+file that specifies the default values used when installing the chart.
+They can all be overridden by using the flag `--set` as described in the documentation
+for https://docs.helm.sh/helm/#helm-install[Helm Install].
 
-Some values that you might want to override are listed in the https://github.com/projectriff/helm-charts/blob/master/riff/README.md#configuration[Configuration section of the README].
+Some values that you might want to override are listed in the
+https://github.com/projectriff/riff/blob/master/helm-charts/riff/README.md#configuration[Configuration section of the README].
 
 The following are some scenarios for customizing your installation:
 
@@ -111,7 +122,8 @@ helm install riffrepo/riff --name control --set functionController.image.tag=0.0
 
 * Overriding the image repository and version tag of a riff component with a custom built component image:
 +
-To set the image repository to `mycustom/function-controller` and the version tag to `0.0.5-test.1` for the `functionController`, use something like the following:
+To set the image repository to `mycustom/function-controller` and the version tag to `0.0.5-test.1` for
+the `functionController`, use something like the following:
 +
 [source, bash]
 ----
@@ -120,7 +132,8 @@ helm install riffrepo/riff --name control --set functionController.image.reposit
 
 * Overriding the version of the `sidecar` component:
 +
-The `sidecar` component is only used by the `functionController`, so to set the version for the `sidecar` to `0.0.5-build.1` use something like the following:
+The `sidecar` component is only used by the `functionController`, so to set the version for
+the `sidecar` to `0.0.5-build.1` use something like the following:
 +
 [source, bash]
 ----
@@ -145,7 +158,8 @@ eval $(minikube docker-env)
 
 Build the riff components following the link:README.adoc#manual[manual build and deploy] instructions.
 
-To install locally built Docker images with Helm on minikube, use the `values-snapshot.yaml` file, which overrides image tags with snapshot versions:
+To install locally built Docker images with Helm on minikube, use the `values-snapshot.yaml` file,
+which overrides image tags with snapshot versions:
 
 [source, bash]
 ----

--- a/Function-Invokers.adoc
+++ b/Function-Invokers.adoc
@@ -4,56 +4,81 @@
 
 === HTTP
 
-A function invoker must listen on port 8080 for request-response style interactions via a HTTP POST. The HTTP headers have a content-type that can be used to decode the request body.
+A function invoker must listen on port 8080 for request-response style interactions via a HTTP POST. The HTTP headers
+have a content-type that can be used to decode the request body.
 
 === gRPC
 
-A function invoker can also be implemented as a bi-directional stream (as opposed to request-response) in gRPC. The carrier type is a generic `function.Message` defined in the https://github.com/projectriff/function-proto[Function Proto] project. There are language-specific bindings to the `Message` type defined alongside the protobuffer declarations.
+A function invoker can also be implemented as a bi-directional stream (as opposed to request-response) in gRPC.
+The carrier type is a generic `function.Message` defined in the
+https://github.com/projectriff/riff/tree/master/function-proto[Function Proto] project.
+There are language-specific bindings to the `Message` type defined alongside the protobuffer declarations.
 
 == Testing a Function Invoker
 
-For HTTP you should be able to just POST some data to `localhost:8080` and get a response. It is advisable to include a `Content-Type` header, but the function invoker is free to ignore it. The function invoker can make all the decisions it likes about content negotiation, and marshalling the request and response bodies. Any kind of sensible response with 200 OK should be fine - the sidecar takes care of headers in a live Riff system, and copies the response body bytes verbatim.
+For HTTP you should be able to just POST some data to `localhost:8080` and get a response.
+It is advisable to include a `Content-Type` header, but the function invoker is free to ignore it.
+The function invoker can make all the decisions it likes about content negotiation, and marshalling the request
+and response bodies. Any kind of sensible response with 200 OK should be fine - the sidecar takes care of headers in a
+live Riff system, and copies the response body bytes verbatim.
 
-For gRPC the invoker can still make any decision it likes about content negotiation, and even how many messages to send in response. The function invoker can be tested by writing a tiny gRPC client and sending it a stream of `function.Message`. You would call it a success if you got any kind of messages back, depending on the semantics of the function. If you are supporting request-response, precisely *one* of the response messages must contain the same `correlationId` header as the incoming messages.
+For gRPC the invoker can still make any decision it likes about content negotiation, and even how many messages to
+send in response. The function invoker can be tested by writing a tiny gRPC client and sending it a stream of
+`function.Message`. You would call it a success if you got any kind of messages back, depending on the semantics of the
+function. If you are supporting request-response, precisely *one* of the response messages must contain the same
+`correlationId` header as the incoming messages.
 
 == Running the Gateway Locally
 
-Instead of writing custom gRPC test clients, you can run the gateway locally. You will need Kafka, the Riff gateway, a Riff sidecar, and your Function Invoker. Then you can POST messages to the gateway and they will flow through to the function invoker and back through Kafka. This can be useful for end-to-end testing, especially with gRPC function invokers, since there is nothing as convenient as `curl` for ad hoc testing.
+Instead of writing custom gRPC test clients, you can run the gateway locally. You will need Kafka, the riff gateway, a
+riff sidecar, and your Function Invoker. Then you can POST messages to the gateway and they will flow through to the
+function invoker and back through Kafka. This can be useful for end-to-end testing, especially with gRPC function
+invokers, since there is nothing as convenient as `curl` for ad hoc testing.
 
 One way to run kafka is to use Spring Cloud CLI, or you could use docker. Using docker would look like this
 
-```
+[source, bash]
+----
 docker run -e ADVERTISED_HOST=localhost -p 9092:9092 -ti spotify/kafka
-```
+----
 
 Then clone and run the gateway. This requires golang 1.9 or later, so check
 your `go env` and set `GOPATH` and `GOROOT` env vars accordingly. Then
 do this:
 
-```
-$ go get github.com/projectriff/http-gateway
-$ cd $GOPATH/src/github.com/projectriff/http-gateway
-$ export KAFKA_BROKERS=localhost:9092
-$ go run cmd/http-gateway.go 
-2018/02/20 16:20:14 Listening on :8080
-```
+[source, bash]
+----
+go get github.com/projectriff/riff/
+cd $(go env GOPATH)/src/github.com/projectriff/riff/http-gateway
+export KAFKA_BROKERS=localhost:9092
+go run cmd/http-gateway.go
+----
 
 Then get your function invoker running, and make sure it doesn't try and listen on port 8080 (where the gateway is already running).
 
 And, once you have the function invoker running, do the same with the sidecar:
 
-```
-$ go get github.com/projectriff/function-sidecar
-$ cd $GOPATH/src/github.com/projectriff/function-sidecar
-$ go run cmd/function-sidecar.go -brokers=localhost:9092 -inputs=inputs -outputs=replies -group=default -protocol=grpc
+[source, bash]
+----
+go get github.com/projectriff/riff
+cd $(go env GOPATH)/src/github.com/projectriff/riff/function-sidecar
+go run cmd/function-sidecar.go -brokers=localhost:9092 -inputs=inputs -outputs=replies -group=default -protocol=grpc
+----
+
+yields
+
+[source, bash]
+----
 2018/02/20 16:33:27 Sidecar for function 'default' (inputs->outputs) using grpc dispatcher starting
 2018/02/20 16:33:27 Rebalanced: &{Type:rebalance start Claimed:map[] Released:map[] Current:map[]}
 2018/02/20 16:33:27 Rebalanced: &{Type:rebalance OK Claimed:map[inputs:[0]] Released:map[] Current:map[inputs:[0]]}
-```
+----
 
-The name of the "inputs" channel is arbitrary, and will be used below in constructing the URI for addressing the gateway. The "ouputs" has to be "replies" for the request-reply pattern to work.
+The name of the "inputs" channel is arbitrary, and will be used below in constructing the URI for addressing the gateway.
+The "ouputs" has to be "replies" for the request-reply pattern to work.
 
-At this point you can POST messages into the gateway and they will flow through kafka to the sidecar and then into the function invoker and back. There are 2 endpoints on the gateway:
+At this point you can POST messages into the gateway and they will flow through kafka to the sidecar and then into the
+function invoker and back. There are 2 endpoints on the gateway:
 
 |===
 
@@ -64,15 +89,18 @@ At this point you can POST messages into the gateway and they will flow through 
 
 |===
 
-For both endpoints remember to include a `Content-Type` header. The "channel" name is the name of the "inputs" command line option when you started the sidecar. Example: 
+For both endpoints remember to include a `Content-Type` header. The "channel" name is the name of the "inputs" command
+line option when you started the sidecar. Example:
 
-```
-$ curl localhost:8080/requests/inputs -H "Content-Type: text/plain" -d World
+[source, bash]
+----
+curl localhost:8080/requests/inputs -H "Content-Type: text/plain" -d World
 Hello World
-```
+----
 
 You will see the messages flowing through the sidecar in logs, e.g.
 
-```
+[source, bash]
+----
 2018/02/20 16:34:47 <<< Message{Hello World, map[Accept:[*/*] Content-Type:[text/plain] timestamp:[1519144487664] correlationId:[b1a97d11-c2e1-4eb5-8919-92a859dcbf43]]}
-```
+----

--- a/function-controller/README.adoc
+++ b/function-controller/README.adoc
@@ -24,8 +24,8 @@ If you would like to run tests using the `ginkgo` command, install:
 === Get the source
 [source, bash]
 ----
-cd $(go env GOPATH)   #defaults to ~/go
-git clone -o upstream https://github.com/projectriff/function-controller src/github.com/projectriff/function-controller
+go get github.com/projectriff/riff
+cd $(go env GOPATH)/github.com/projectriff/riff/function-controller
 ----
 
 === Building

--- a/function-proto/README.adoc
+++ b/function-proto/README.adoc
@@ -1,10 +1,15 @@
-== Function Proto
+= Function Proto
 
-This repository contains https://grpc.io/docs/guides/[gRPC] service definitions used by the riff https://github.com/projectriff/function-sidecar[function-sidecar] to support gRPC streaming between the sidecar and the function.
+This directory contains https://grpc.io/docs/guides/[gRPC] service definitions used by the
+riff https://github.com/projectriff/riff/tree/master/function-sidecar[function-sidecar] to support gRPC streaming
+between the sidecar and the function.
 
-To enable gRPC streaming, specify the `grpc` protocol in your function yaml. Additionally, your function must implement a gRPC server, using language specific service implementations generated from the interface defined in the `.proto` files provided in this repository.
+To enable gRPC streaming, specify the `grpc` protocol in your function yaml.
+Additionally, your function must implement a gRPC server, using language specific service implementations generated
+from the interface defined in the `.proto` files provided in this directory.
 
-riff currently supports only https://grpc.io/docs/guides/concepts.html[gRPC bidirectional streaming]. Language specific instructions for implementing a gRPC server are provided in the links below.
+riff currently supports only https://grpc.io/docs/guides/concepts.html[gRPC bidirectional streaming].
+Language specific instructions for implementing a gRPC server are provided in the links below.
 
 link:go/README.adoc[Go]
 

--- a/function-proto/node/package.json
+++ b/function-proto/node/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/projectriff/function-proto.git"
+    "url": "git+https://github.com/projectriff/riff.git"
   },
   "keywords": [
     "projectriff",
@@ -21,9 +21,9 @@
   "author": "Scott Andrews",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/projectriff/function-proto/issues"
+    "url": "https://github.com/projectriff/riff/issues"
   },
-  "homepage": "https://github.com/projectriff/function-proto#readme",
+  "homepage": "https://github.com/projectriff/riff#readme",
   "peerDependencies": {
     "grpc": "^1.8.4"
   },

--- a/function-sidecar/README.adoc
+++ b/function-sidecar/README.adoc
@@ -1,15 +1,56 @@
 = Function Sidecar image:https://ci.projectriff.io/api/v1/teams/main/pipelines/riff/jobs/build-function-sidecar-container/badge[Function Sidecar Status, link=https://ci.projectriff.io/teams/main/pipelines/riff/jobs/build-function-sidecar-container/builds/latest]
 
-== Building
-```
-cd $GOPATH
-git clone https://github.com/projectriff/function-sidecar src/github.com/projectriff/function-sidecar
-cd src/github.com/projectriff/function-sidecar
-make dockerize
-```
+== Purpose
+The *function sidecar* runs alongside the function container in the function pod(s) and takes care of consuming input
+events from the broker. It then forwards those events to the function (via the *invoker*) using gRPC (recommended)
+or other "dispatcher" mechanisms such as `http` (legacy). Likewise, the sidecar marshalls function output back to the
+broker.
 
-== Tests (including integration with Kafka)
+== Development
+=== Prerequisites
+The following tools are required to build this project:
+
+- `make`
+- Docker
+- https://github.com/Masterminds/glide#install[Glide] for dependency management
+
+If you intend to re-generate mocks for testing, install:
+
+- https://github.com/vektra/mockery#installation[Mockery]
+
+If you would like to run tests using the `ginkgo` command, install:
+
+- http://onsi.github.io/ginkgo/[Ginkgo]
+
+=== Get the source
+[source, bash]
+----
+go get github.com/projectriff/riff
+cd $(go env GOPATH)/github.com/projectriff/riff/function-sidecar
+----
+
+=== Building
+* To build locally (this will produce a binary named `function-sidecar` on _your_ machine):
++
+[source, bash]
+----
+make build
+----
+
+* To build for docker (and deploy as part of the whole https://github.com/projectriff/riff#-manual-install-of-riff[riff]
+installation):
++
+[source, bash]
+----
+make dockerize
+----
+This assumes that your docker client is correctly configured to target the daemon where you want the image built.
+
+* To run tests:
++
 Assuming kafka is running locally on port 9092,
-```
+[source, bash]
+----
 KAFKA_BROKER=localhost:9092 make test
-```
+----
+

--- a/http-gateway/README.adoc
+++ b/http-gateway/README.adoc
@@ -24,8 +24,8 @@ If you would like to run tests using the `ginkgo` command, install:
 === Get the source
 [source, bash]
 ----
-cd $(go env GOPATH)   #defaults to ~/go
-git clone -o upstream https://github.com/projectriff/http-gateway src/github.com/projectriff/http-gateway
+go get github.com/projectriff/riff
+cd $(go env GOPATH)/github.com/projectriff/riff/http-gateway
 ----
 
 === Building

--- a/message-transport/README.adoc
+++ b/message-transport/README.adoc
@@ -15,17 +15,18 @@ The code in this repository is written in Go.
 === Get the source
 [source, bash]
 ----
-cd $(go env GOPATH)
-git clone -o upstream https://github.com/projectriff/message-transport src/github.com/projectriff/message-transport
+go get github.com/projectriff/riff
+cd $(go env GOPATH)/github.com/projectriff/riff/message-transport
 ----
 
 === Building
 
-This repository is a dependency of the https://github.com/projectriff/http-gateway[http-gateway]
-and https://github.com/projectriff/function-sidecar[function-sidecar] repositories
+This library is a dependency of the
+https://github.com/projectriff/riff/tree/master/http-gateway[http-gateway]
+and https://github.com/projectriff/riff/tree/master/function-sidecar[function-sidecar] components
 and is built by them.
 
-You can check that the code in this repository compiles cleanly by issuing:
+You can check that the code in this library compiles cleanly by issuing:
 [source, bash]
 ----
 make build


### PR DESCRIPTION
There are still references to old package names and vendoring of old stuff,
this comes from mocks. Will address in another PR.