### PR TITLE
Make gateway test less racey

### DIFF
--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -82,8 +82,8 @@ var _ = Describe("HTTP Gateway", func() {
 				message.Headers{server.CorrelationId: msg.Headers()[server.CorrelationId],
 					"Content-Type": []string{"bag/plastic"},
 				})
-			Eventually(msg.Headers()["Content-Type"]).Should(Equal([]string{"text/solid"}))
-			Eventually(msg.Headers()["Not-Propagated-Header"]).Should(BeNil())
+			Expect(msg.Headers()["Content-Type"]).To(Equal([]string{"text/solid"}))
+			Expect(msg.Headers()["Not-Propagated-Header"]).To(BeNil())
 		})
 
 		resp := doRequest(port, "foo", bytes.NewBufferString("world"), "Content-Type", "text/solid", "Not-Propagated-Header", "secret")
@@ -91,9 +91,9 @@ var _ = Describe("HTTP Gateway", func() {
 		b := make([]byte, 11)
 		resp.Body.Read(b)
 
-		Eventually(b).Should(Equal([]byte("hello world")))
-		Eventually(resp.Header.Get(server.CorrelationId)).Should(BeZero())
-		Eventually(resp.Header.Get("Content-Type")).Should(Equal("bag/plastic"))
+		Expect(b).To(Equal([]byte("hello world")))
+		Expect(resp.Header.Get(server.CorrelationId)).To(BeZero())
+		Expect(resp.Header.Get("Content-Type")).To(Equal("bag/plastic"))
 
 		defer resp.Body.Close()
 	})
@@ -103,14 +103,14 @@ var _ = Describe("HTTP Gateway", func() {
 		mockProducer.On("Send", "bar", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			defer GinkgoRecover()
 			msg := args[1].(message.Message)
-			Eventually(msg.Payload()).Should(Equal([]byte("world")))
-			Eventually(msg.Headers()["Content-Type"]).Should(Equal([]string{"text/solid"}))
-			Eventually(msg.Headers()["Not-Propagated-Header"]).Should(BeNil())
+			Expect(msg.Payload()).To(Equal([]byte("world")))
+			Expect(msg.Headers()["Content-Type"]).To(Equal([]string{"text/solid"}))
+			Expect(msg.Headers()["Not-Propagated-Header"]).To(BeNil())
 		})
 
 		resp := doMessage(port, "bar", bytes.NewBufferString("world"), "Content-Type", "text/solid", "Not-Propagated-Header", "secret")
 
-		Eventually(resp.StatusCode).Should(Equal(200))
+		Expect(resp.StatusCode).To(Equal(200))
 
 		defer resp.Body.Close()
 	})

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -143,10 +143,13 @@ func post(port int, path string, body io.Reader, headerKV ...string) *http.Respo
 }
 
 func waitForHttpGatewayToBeReady(port int) {
+	timeoutDuration := time.Second * 10
+	pollingInterval := time.Millisecond * 100
+
 	url := fmt.Sprintf("http://localhost:%d", port)
 
 	Eventually(func() error {
 		_, err := http.Get(url)
 		return err
-	}).Should(Succeed())
+	}, timeoutDuration, pollingInterval).Should(Succeed())
 }

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -127,17 +127,13 @@ func doMessage(port int, topic string, body io.Reader, headerKV ...string) *http
 func post(port int, path string, body io.Reader, headerKV ...string) *http.Response {
 	client := http.Client{}
 	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:%v%v", port, path), body)
-	if err != nil {
-		panic(err)
-	}
+	Expect(err).ToNot(HaveOccurred())
 
 	for i := 0; i < len(headerKV); i += 2 {
 		req.Header.Add(headerKV[i], headerKV[i+1])
 	}
 	resp, err := client.Do(req)
-	if err != nil {
-		panic(err)
-	}
+	Expect(err).ToNot(HaveOccurred())
 
 	return resp
 }

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -146,7 +146,7 @@ func waitForHttpGatewayToBeReady(port int) {
 	timeoutDuration := time.Second * 10
 	pollingInterval := time.Millisecond * 100
 
-	url := fmt.Sprintf("http://localhost:%d", port)
+	url := fmt.Sprintf("http://localhost:%d/application/status", port)
 
 	Eventually(func() error {
 		_, err := http.Get(url)

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"net"
 	"net/http"
 	"time"
 
@@ -67,7 +66,7 @@ var _ = Describe("HTTP Gateway", func() {
 
 		gw.Run(done)
 
-		waitForHttpGatewayToBeReady()
+		waitForHttpGatewayToBeReady(port)
 	})
 
 	AfterEach(func() {
@@ -143,18 +142,11 @@ func post(port int, path string, body io.Reader, headerKV ...string) *http.Respo
 	return resp
 }
 
-func waitForHttpGatewayToBeReady() {
-	attempts := 20
-	durationBetweenAttempts := time.Millisecond * 100
+func waitForHttpGatewayToBeReady(port int) {
+	url := fmt.Sprintf("http://localhost:%d", port)
 
-	for i := 0; i < attempts; i++ {
-		_, err := net.Dial("tcp", ":http")
-		if err != nil {
-			fmt.Print(".")
-			time.Sleep(durationBetweenAttempts)
-			continue
-		}
-
-		break
-	}
+	Eventually(func() error {
+		_, err := http.Get(url)
+		return err
+	}).Should(Succeed())
 }


### PR DESCRIPTION
The http-gateway tests work on local systems, but tend to fail on
CI. This appeared to be due largely to a race condition between
the code that starts the server and the tests themselves.

- Add waitForHttpGatewayToBeReady()
- Add error panics in post()
- Replace Expect/To with Eventually/Should
- Pull gw.Run(done) into JustBeforeEach

[Github projectriff/riff#305]