### PR TITLE
Move away from all commands being global vars.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -19,11 +19,19 @@ package main
 import (
 	"github.com/projectriff/riff/riff-cli/cmd"
 	"github.com/projectriff/riff/riff-cli/global"
+	"fmt"
+	"os"
 )
 
 var version = "Unknown"
 
 func main() {
 	global.CLI_VERSION = version
-	cmd.Execute()
+
+	rootCmd := cmd.CreateAndWireRootCommand()
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/riff-cli/cmd/completion.go
+++ b/riff-cli/cmd/completion.go
@@ -21,17 +21,19 @@ import (
 	"os"
 )
 
-// completionCmd represents the completion command
-var completionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates bash completion scripts",
-	Long: `Generates bash completion scripts`,
-	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
-	},
+func Completion(rootCmd *cobra.Command) *cobra.Command {
+
+	// completionCmd represents the completion command
+	var completionCmd = &cobra.Command{
+		Use:   "completion",
+		Short: "Generates bash completion scripts",
+		Long: `Generates bash completion scripts`,
+		Hidden: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			rootCmd.GenBashCompletion(os.Stdout)
+		},
+	}
+	return completionCmd
+
 }
 
-func init() {
-	rootCmd.AddCommand(completionCmd)
-}

--- a/riff-cli/cmd/delete_command_test.go
+++ b/riff-cli/cmd/delete_command_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
 	"errors"
+	"github.com/projectriff/riff/riff-cli/cmd/opts"
 )
 
 var getFunctionCount, deleteFunctionCount, deleteTopicCount, deleteResourceCount int
@@ -99,8 +100,8 @@ func TestDeleteCommandImplicitPath(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("../test_data/shell/echo", DeleteAllOptions.FilePath)
-	as.Equal("default", DeleteAllOptions.Namespace)
+	as.Equal("../test_data/shell/echo", opts.DeleteAllOptions.FilePath)
+	as.Equal("default", opts.DeleteAllOptions.Namespace)
 	as.Equal(0, getFunctionCount)
 	as.Equal(1, deleteFunctionCount)
 	as.Equal(0, deleteTopicCount)
@@ -113,8 +114,8 @@ func TestDeleteCommandExplicitPath(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("../test_data/shell/echo", DeleteAllOptions.FilePath)
-	as.Equal("default", DeleteAllOptions.Namespace)
+	as.Equal("../test_data/shell/echo", opts.DeleteAllOptions.FilePath)
+	as.Equal("default", opts.DeleteAllOptions.Namespace)
 	as.Equal(0, getFunctionCount)
 	as.Equal(1, deleteFunctionCount)
 	as.Equal(0, deleteTopicCount)
@@ -128,8 +129,8 @@ func TestDeleteCommandExplicitFile(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("../test_data/shell/echo/echo-topics.yaml", DeleteAllOptions.FilePath)
-	as.Equal("default", DeleteAllOptions.Namespace)
+	as.Equal("../test_data/shell/echo/echo-topics.yaml", opts.DeleteAllOptions.FilePath)
+	as.Equal("default", opts.DeleteAllOptions.Namespace)
 	as.Equal(0, getFunctionCount)
 	as.Equal(1, deleteResourceCount)
 	as.Equal(0, deleteTopicCount)
@@ -152,7 +153,7 @@ func TestDeleteCommandWithNameDoesNotExist(t *testing.T) {
 	rootCmd.SetArgs([]string{"delete", "--name", "square"})
 	_, err := rootCmd.ExecuteC()
 	as.Error(err)
-	as.Equal("square", DeleteAllOptions.FunctionName)
+	as.Equal("square", opts.DeleteAllOptions.FunctionName)
 	as.Equal(1, getFunctionCount)
 	as.Equal(0, deleteFunctionCount)
 	as.Equal(0, deleteTopicCount)
@@ -167,9 +168,9 @@ func TestDeleteCommandAllFlag(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("../test_data/shell/echo", DeleteAllOptions.FilePath)
-	as.Equal(true, DeleteAllOptions.All)
-	as.Equal("default", DeleteAllOptions.Namespace)
+	as.Equal("../test_data/shell/echo", opts.DeleteAllOptions.FilePath)
+	as.Equal(true, opts.DeleteAllOptions.All)
+	as.Equal("default", opts.DeleteAllOptions.Namespace)
 	as.Equal(0, getFunctionCount)
 	as.Equal(1, deleteResourceCount)
 	as.Equal(0, deleteTopicCount)
@@ -188,9 +189,9 @@ func TestDeleteCommandFromCwdAllFlag(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("", DeleteAllOptions.FilePath)
-	as.Equal(true, DeleteAllOptions.All)
-	as.Equal("default", DeleteAllOptions.Namespace)
+	as.Equal("", opts.DeleteAllOptions.FilePath)
+	as.Equal(true, opts.DeleteAllOptions.All)
+	as.Equal("default", opts.DeleteAllOptions.Namespace)
 	as.Equal(0, getFunctionCount)
 	as.Equal(1, deleteResourceCount)
 	as.Equal(0, deleteTopicCount)
@@ -209,9 +210,9 @@ func TestDeleteCommandFromCwdAllFlagNoResources(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("", DeleteAllOptions.FilePath)
-	as.Equal(true, DeleteAllOptions.All)
-	as.Equal("default", DeleteAllOptions.Namespace)
+	as.Equal("", opts.DeleteAllOptions.FilePath)
+	as.Equal(true, opts.DeleteAllOptions.All)
+	as.Equal("default", opts.DeleteAllOptions.Namespace)
 	as.Equal(0, getFunctionCount)
 	as.Equal(0, deleteResourceCount)
 	as.Equal(0, deleteTopicCount)
@@ -238,8 +239,8 @@ func TestDeleteCommandWithNamespace(t *testing.T) {
 
 	_, err := rootCmd.ExecuteC()
 	as.NoError(err)
-	as.Equal("../test_data/shell/echo", DeleteAllOptions.FilePath)
-	as.Equal("test-test", DeleteAllOptions.Namespace)
+	as.Equal("../test_data/shell/echo", opts.DeleteAllOptions.FilePath)
+	as.Equal("test-test", opts.DeleteAllOptions.Namespace)
 }
 
 func resetTestState() {
@@ -248,7 +249,7 @@ func resetTestState() {
 	deleteTopicCount = 0
 	deleteResourceCount = 0
 
-	DeleteAllOptions = options.DeleteAllOptions{}
+	opts.DeleteAllOptions = options.DeleteAllOptions{}
 	deleteCmd.ResetFlags()
 	utils.CreateDeleteFlags(deleteCmd.Flags())
 }

--- a/riff-cli/cmd/docs_generator.go
+++ b/riff-cli/cmd/docs_generator.go
@@ -25,30 +25,27 @@ import (
 )
 
 var directory string
-var createDir bool
 
-var docsCmd = &cobra.Command{
-	Use:   "docs",
-	Short: "generate riff-cli command documentation",
-	Long:  `Generate riff-cli command documentation`,
-	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
+func Docs(rootCmd *cobra.Command) *cobra.Command {
 
-		if !osutils.IsDirectory(directory) {
-			os.Mkdir(directory,0744)
-		}
+	var docsCmd = &cobra.Command{
+		Use:    "docs",
+		Short:  "generate riff-cli command documentation",
+		Long:   `Generate riff-cli command documentation`,
+		Hidden: true,
+		Run: func(cmd *cobra.Command, args []string) {
 
-		err := doc.GenMarkdownTree(rootCmd, directory)
-		if err != nil {
-			ioutils.Errorf("Doc generation failed %v\n", err)
-			os.Exit(1)
-		}
-	},
-}
+			if !osutils.IsDirectory(directory) {
+				os.Mkdir(directory, 0744)
+			}
 
-
-func init() {
-	rootCmd.AddCommand(docsCmd)
-	docsCmd.Flags().StringVarP(&directory, "dir", "d", osutils.Path(osutils.GetCWD()+"/docs"),"the output directory for the docs.")
-
+			err := doc.GenMarkdownTree(rootCmd, directory)
+			if err != nil {
+				ioutils.Errorf("Doc generation failed %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+	docsCmd.Flags().StringVarP(&directory, "dir", "d", osutils.Path(osutils.GetCWD()+"/docs"), "the output directory for the docs.")
+	return docsCmd
 }

--- a/riff-cli/cmd/init.go
+++ b/riff-cli/cmd/init.go
@@ -27,142 +27,130 @@ import (
 	"github.com/projectriff/riff/riff-cli/pkg/initializers"
 )
 
-/*
- * init Command
- * TODO: Use cmd.Example
- */
+func Init() *cobra.Command {
 
-var initCmd = &cobra.Command{
-	Use:   "init [language]",
-	Short: "Initialize a function",
-	Long:  utils.InitCmdLong(),
+	var initCmd = &cobra.Command{
+		Use:   "init [language]",
+		Short: "Initialize a function",
+		Long:  utils.InitCmdLong(),
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := initializers.Initialize(opts.InitOptions)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		opts.InitOptions = opts.CreateOptions.InitOptions
-		if !opts.CreateOptions.Initialized {
-			opts.InitOptions = opts.CreateOptions.InitOptions
-			var flagset pflag.FlagSet
-			if cmd.Parent() == rootCmd {
-				flagset = *cmd.PersistentFlags()
-			} else {
-				flagset = *cmd.Parent().PersistentFlags()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := initializers.Initialize(opts.InitOptions)
+			if err != nil {
+				return err
 			}
-			utils.MergeInitOptions(flagset, &opts.InitOptions)
-
-			if len(args) > 0 {
-				if len(args) == 1 && opts.InitOptions.FilePath == "" {
-					opts.InitOptions.FilePath = args[0]
+			return nil
+		},
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			opts.InitOptions = opts.CreateOptions.InitOptions
+			if !opts.CreateOptions.Initialized {
+				opts.InitOptions = opts.CreateOptions.InitOptions
+				var flagset pflag.FlagSet
+				if cmd.Parent() == cmd.Root()  {
+					flagset = *cmd.PersistentFlags()
 				} else {
-					ioutils.Errorf("Invalid argument(s) %v\n", args)
-					cmd.Usage()
+					flagset = *cmd.Parent().PersistentFlags()
+				}
+				utils.MergeInitOptions(flagset, &opts.InitOptions)
+
+				if len(args) > 0 {
+					if len(args) == 1 && opts.InitOptions.FilePath == "" {
+						opts.InitOptions.FilePath = args[0]
+					} else {
+						ioutils.Errorf("Invalid argument(s) %v\n", args)
+						cmd.Usage()
+						os.Exit(1)
+					}
+				}
+
+				err := options.ValidateAndCleanInitOptions(&opts.InitOptions)
+				if err != nil {
+					ioutils.Error(err)
 					os.Exit(1)
 				}
+
+				opts.CreateOptions.Initialized = true
 			}
-
-			err := options.ValidateAndCleanInitOptions(&opts.InitOptions)
-			if err != nil {
-				ioutils.Error(err)
-				os.Exit(1)
-			}
-
-			opts.CreateOptions.Initialized = true
-		}
-	},
-}
-
-/*
- * init java Command
- */
-
-var initJavaCmd = &cobra.Command{
-	Use:   "java",
-	Short: "Initialize a Java function",
-	Long:  utils.InitJavaCmdLong(),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		opts.InitOptions.Handler = utils.GetHandler(cmd)
-		err := initializers.Java().Initialize(opts.InitOptions)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-}
-/*
- * init shell ommand
- */
-
-var initShellCmd = &cobra.Command{
-	Use:   "shell",
-	Short: "Initialize a shell script function",
-	Long:  utils.InitShellCmdLong(),
-
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := initializers.Shell().Initialize(opts.InitOptions)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-}
-/*
- * init node Command
- */
-
-var initNodeCmd = &cobra.Command{
-	Use:   "node",
-	Short: "Initialize a node.js function",
-	Long:  utils.InitNodeCmdLong(),
-
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := initializers.Node().Initialize(opts.InitOptions)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-	Aliases: []string{"js"},
-}
-
-/*
- * init python Command
- */
-
-var initPythonCmd = &cobra.Command{
-	Use:   "python",
-	Short: "Initialize a Python function",
-	Long:  utils.InitPythonCmdLong(),
-
-	RunE: func(cmd *cobra.Command, args []string) error {
-		opts.InitOptions.Handler = utils.GetHandler(cmd)
-		if opts.InitOptions.Handler == "" {
-			opts.InitOptions.Handler = opts.InitOptions.FunctionName
-		}
-		err := initializers.Python().Initialize(opts.InitOptions)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(initCmd)
+		},
+	}
 	utils.CreateInitFlags(initCmd.PersistentFlags())
 
-	initCmd.AddCommand(initJavaCmd)
-	initCmd.AddCommand(initNodeCmd)
-	initCmd.AddCommand(initPythonCmd)
-	initCmd.AddCommand(initShellCmd)
+	return initCmd
+}
 
+func InitJava() *cobra.Command {
+	var initJavaCmd = &cobra.Command{
+		Use:   "java",
+		Short: "Initialize a Java function",
+		Long:  utils.InitJavaCmdLong(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.InitOptions.Handler = utils.GetHandler(cmd)
+			err := initializers.Java().Initialize(opts.InitOptions)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 	initJavaCmd.Flags().String("handler", "", "the fully qualified class name of the function handler")
 	initJavaCmd.MarkFlagRequired("handler")
 
+	return initJavaCmd
+}
+
+func InitShell() *cobra.Command {
+	var initShellCmd = &cobra.Command{
+		Use:   "shell",
+		Short: "Initialize a shell script function",
+		Long:  utils.InitShellCmdLong(),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := initializers.Shell().Initialize(opts.InitOptions)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return initShellCmd
+}
+
+func InitNode() *cobra.Command {
+	var initNodeCmd = &cobra.Command{
+		Use:   "node",
+		Short: "Initialize a node.js function",
+		Long:  utils.InitNodeCmdLong(),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := initializers.Node().Initialize(opts.InitOptions)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Aliases: []string{"js"},
+	}
+	return initNodeCmd
+}
+
+func InitPython() *cobra.Command {
+	var initPythonCmd = &cobra.Command{
+		Use:   "python",
+		Short: "Initialize a Python function",
+		Long:  utils.InitPythonCmdLong(),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.InitOptions.Handler = utils.GetHandler(cmd)
+			if opts.InitOptions.Handler == "" {
+				opts.InitOptions.Handler = opts.InitOptions.FunctionName
+			}
+			err := initializers.Python().Initialize(opts.InitOptions)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
 	initPythonCmd.Flags().String("handler", "", "the name of the function handler")
+	return initPythonCmd
 }

--- a/riff-cli/cmd/list.go
+++ b/riff-cli/cmd/list.go
@@ -29,36 +29,35 @@ type ListOptions struct {
 	namespace string
 }
 
-var listOptions ListOptions
+func List() *cobra.Command {
 
-// listCmd represents the list command
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List function resources",
-	Long: `List the currently defined function resources.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	var listOptions ListOptions
+	// listCmd represents the list command
+	var listCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List function resources",
+		Long:  `List the currently defined function resources.`,
+		Run: func(cmd *cobra.Command, args []string) {
 
-		// get the viper value from env var, config file or flag option
-		listOptions.namespace = utils.GetStringValueWithOverride("namespace", *cmd.Flags())
+			// get the viper value from env var, config file or flag option
+			listOptions.namespace = utils.GetStringValueWithOverride("namespace", *cmd.Flags())
 
-		fmt.Printf("Listing function resources in namespace %v\n\n", listOptions.namespace)
+			fmt.Printf("Listing function resources in namespace %v\n\n", listOptions.namespace)
 
-		cmdArgs := []string{"get", "--namespace", listOptions.namespace, "functions"}
+			cmdArgs := []string{"get", "--namespace", listOptions.namespace, "functions"}
 
-		output, err := kubectl.ExecForString(cmdArgs)
+			output, err := kubectl.ExecForString(cmdArgs)
 
-		if err != nil {
-			ioutils.Errorf("Error: %v\n", err)
-			return
-		}
+			if err != nil {
+				ioutils.Errorf("Error: %v\n", err)
+				return
+			}
 
-		fmt.Printf("%v\n", output)
+			fmt.Printf("%v\n", output)
 
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(listCmd)
+		},
+	}
 
 	listCmd.Flags().StringP("namespace", "", "default", "the namespace used for the deployed resources")
+	return listCmd
 }

--- a/riff-cli/cmd/opts/option_vars.go
+++ b/riff-cli/cmd/opts/option_vars.go
@@ -16,10 +16,13 @@
 
 package opts
 
-import "github.com/projectriff/riff/riff-cli/pkg/options"
+import (
+	"github.com/projectriff/riff/riff-cli/pkg/options"
+)
 
 var (
-	InitOptions   options.InitOptions
-	CreateOptions options.CreateOptions
-	Handler       string
+	InitOptions      options.InitOptions
+	CreateOptions    options.CreateOptions
+	DeleteAllOptions options.DeleteAllOptions
+	Handler          string
 )

--- a/riff-cli/cmd/root.go
+++ b/riff-cli/cmd/root.go
@@ -26,48 +26,36 @@ import (
 	"github.com/projectriff/riff/riff-cli/global"
 )
 
-var cfgFile string
+type config struct {
+	file string
+}
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "riff",
-	Short: "Commands for creating and managing function resources",
-	Long: `riff is for functions
+func Root() *cobra.Command {
+	var cfg config
+
+
+	// rootCmd represents the base command when called without any subcommands
+	var rootCmd = &cobra.Command{
+		Use:   "riff",
+		Short: "Commands for creating and managing function resources",
+		Long: `riff is for functions
 
 the riff tool is used to create and manage function resources for the riff FaaS platform https://projectriff.io/`,
-	SilenceErrors: true,
-	DisableAutoGenTag: true,
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		SilenceErrors: true,
+		DisableAutoGenTag: true,
 	}
-}
 
-func init() {
-
-	cobra.OnInitialize(initConfig)
-
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.riff.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	cobra.OnInitialize(cfg.initConfig, initGlobal)
+	rootCmd.PersistentFlags().StringVar(&cfg.file, "config", "", "config file (default is $HOME/.riff.yaml)")
+	return rootCmd
 }
 
 // initConfig reads in config file and ENV variables if set.
-func initConfig() {
+func (c config) initConfig() {
 
-	if cfgFile != "" {
+	if c.file != "" {
 		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
+		viper.SetConfigFile(c.file)
 	} else {
 		// Find home directory.
 		home, err := homedir.Dir()
@@ -86,11 +74,9 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	viper.ReadInConfig()
-
-	InitGlobal()
 }
 
-func InitGlobal() {
+func initGlobal() {
 
 	if os.Getenv("RIFF_VERSION") != "" {
 		global.RIFF_VERSION = os.Getenv("RIFF_VERSION")

--- a/riff-cli/cmd/update.go
+++ b/riff-cli/cmd/update.go
@@ -26,56 +26,54 @@ import (
 	"os"
 )
 
-var updateChainCmd = utils.CommandChain(buildCmd, applyCmd)
 
-// updateCmd represents the update command
-var updateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update a function",
-	Long: `Build the function based on the code available in the path directory, using the name and version specified 
+func Update(updateChainCmd *cobra.Command) *cobra.Command {
+
+	// updateCmd represents the update command
+	var updateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update a function",
+		Long: `Build the function based on the code available in the path directory, using the name and version specified 
   for the image that is built. Then Apply the resource definition[s] included in the path.`,
-	Example: `  riff update -n <name> -v <version> -f <path> [--push]`,
+		Example: `  riff update -n <name> -v <version> -f <path> [--push]`,
 
-	RunE:   updateChainCmd.RunE,
-	PreRun: updateChainCmd.PreRun,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if !opts.CreateOptions.Initialized {
-			opts.CreateOptions = options.CreateOptions{}
-			var flagset pflag.FlagSet
-			if cmd.Parent() == rootCmd {
-				flagset = *cmd.PersistentFlags()
-			} else {
-				flagset = *cmd.Parent().PersistentFlags()
-			}
-
-			utils.MergeInitOptions(flagset, &opts.CreateOptions.InitOptions)
-			utils.MergeBuildOptions(flagset, &opts.CreateOptions)
-			utils.MergeApplyOptions(flagset, &opts.CreateOptions)
-
-			if len(args) > 0 {
-				if len(args) == 1 && opts.CreateOptions.FilePath == "" {
-					opts.CreateOptions.FilePath = args[0]
+		RunE:   updateChainCmd.RunE,
+		PreRun: updateChainCmd.PreRun,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if !opts.CreateOptions.Initialized {
+				opts.CreateOptions = options.CreateOptions{}
+				var flagset pflag.FlagSet
+				if cmd.Parent() == cmd.Root()  {
+					flagset = *cmd.PersistentFlags()
 				} else {
-					ioutils.Errorf("Invalid argument(s) %v\n", args)
-					cmd.Usage()
+					flagset = *cmd.Parent().PersistentFlags()
+				}
+
+				utils.MergeInitOptions(flagset, &opts.CreateOptions.InitOptions)
+				utils.MergeBuildOptions(flagset, &opts.CreateOptions)
+				utils.MergeApplyOptions(flagset, &opts.CreateOptions)
+
+				if len(args) > 0 {
+					if len(args) == 1 && opts.CreateOptions.FilePath == "" {
+						opts.CreateOptions.FilePath = args[0]
+					} else {
+						ioutils.Errorf("Invalid argument(s) %v\n", args)
+						cmd.Usage()
+						os.Exit(1)
+					}
+				}
+
+				err := options.ValidateAndCleanInitOptions(&opts.CreateOptions.InitOptions)
+				if err != nil {
+					ioutils.Error(err)
 					os.Exit(1)
 				}
+				opts.CreateOptions.Initialized = true
 			}
-
-			err := options.ValidateAndCleanInitOptions(&opts.CreateOptions.InitOptions)
-			if err != nil {
-				ioutils.Error(err)
-				os.Exit(1)
-			}
-			opts.CreateOptions.Initialized = true
-		}
-		updateChainCmd.PersistentPreRun(cmd, args)
-	},
-}
-
-
-func init() {
-	rootCmd.AddCommand(updateCmd)
+			updateChainCmd.PersistentPreRun(cmd, args)
+		},
+	}
 	utils.CreateBuildFlags(updateCmd.PersistentFlags())
 	utils.CreateApplyFlags(updateCmd.PersistentFlags())
+	return updateCmd
 }

--- a/riff-cli/cmd/version.go
+++ b/riff-cli/cmd/version.go
@@ -23,20 +23,19 @@ import (
 	"github.com/projectriff/riff/riff-cli/global"
 )
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display the riff version",
-	Long: `Display the riff version`,
-	Example: `  riff version`,
+func Version() *cobra.Command {
+	// versionCmd represents the version command
+	var versionCmd = &cobra.Command{
+		Use:     "version",
+		Short:   "Display the riff version",
+		Long:    `Display the riff version`,
+		Example: `  riff version`,
 
-	Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, args []string) {
 
-		fmt.Printf("riff CLI version: %v\n", global.CLI_VERSION)
-		fmt.Printf("riff function invoker version: %v\n", global.RIFF_VERSION)
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(versionCmd)
+			fmt.Printf("riff CLI version: %v\n", global.CLI_VERSION)
+			fmt.Printf("riff function invoker version: %v\n", global.RIFF_VERSION)
+		},
+	}
+	return versionCmd
 }

--- a/riff-cli/cmd/wiring.go
+++ b/riff-cli/cmd/wiring.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/projectriff/riff/riff-cli/cmd/utils"
+)
+
+// CreateAndWireRootCommand creates all riff commands and sub commands, as well as the top-level 'root' command,
+// wires them together and returns the root command, ready to execute.
+func CreateAndWireRootCommand() *cobra.Command {
+
+	rootCmd := Root()
+
+	applyCmd := Apply()
+	rootCmd.AddCommand(applyCmd)
+
+	buildCmd := Build()
+	rootCmd.AddCommand(buildCmd)
+
+	rootCmd.AddCommand(List())
+
+
+	initCmd := Init()
+	rootCmd.AddCommand(initCmd)
+
+	initJavaCmd := InitJava()
+	initCmd.AddCommand(initJavaCmd)
+
+	initNodeCmd := InitNode()
+	initCmd.AddCommand(initNodeCmd)
+
+	initPythonCmd := InitPython()
+	initCmd.AddCommand(initPythonCmd)
+
+	initShellCmd := InitShell()
+	initCmd.AddCommand(initShellCmd)
+
+
+	createChainCmd := utils.CommandChain(initCmd, buildCmd, applyCmd)
+	createCmd := Create(createChainCmd)
+	rootCmd.AddCommand(createCmd)
+
+	createNodeChainCmd := utils.CommandChain(initNodeCmd, buildCmd, applyCmd)
+	createCmd.AddCommand(CreateNode(createNodeChainCmd))
+
+	createJavaChainCmd := utils.CommandChain(initJavaCmd, buildCmd, applyCmd)
+	createCmd.AddCommand(CreateJava(createJavaChainCmd))
+
+	createPythonChainCmd := utils.CommandChain(initPythonCmd, buildCmd, applyCmd)
+	createCmd.AddCommand(CreatePython(createPythonChainCmd))
+
+	createShellChainCmd := utils.CommandChain(initShellCmd, buildCmd, applyCmd)
+	createCmd.AddCommand(CreateShell(createShellChainCmd))
+
+	deleteCmd := Delete()
+	rootCmd.AddCommand(deleteCmd)
+
+	rootCmd.AddCommand(Completion(rootCmd))
+	rootCmd.AddCommand(Docs(rootCmd))
+
+	rootCmd.AddCommand(Publish())
+
+	updateChainCmd := utils.CommandChain(buildCmd, applyCmd)
+	rootCmd.AddCommand(Update(updateChainCmd))
+	
+	logsCmd := Logs()
+	rootCmd.AddCommand(logsCmd)
+
+	rootCmd.AddCommand(Version())
+	return rootCmd
+}

--- a/riff-cli/cmd/wiring_test.go
+++ b/riff-cli/cmd/wiring_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+// Temporary global variables and workarounds so that tests as they were written continue to work
+
+var (
+	rootCmd = CreateAndWireRootCommand()
+
+	initCmd         = locate("init")
+	createCmd       = locate("create")
+	initJavaCmd     = locate("init", "java")
+	createJavaCmd   = locate("create", "java")
+	initPythonCmd   = locate("init", "python")
+	createPythonCmd = locate("create", "python")
+	createShellCmd  = locate("create", "shell")
+	createNodeCmd   = locate("create", "node")
+	deleteCmd       = locate("delete")
+)
+
+func locate(a ... string) *cobra.Command {
+	command, _, err := rootCmd.Find(a)
+	if err != nil {
+		panic(err)
+	}
+	return command
+}


### PR DESCRIPTION
Move away from use of init() functions.

Some commands still mutate state that is kept globally (in opts package). TBC
Tests still refer to commands as global vars. Added temporary workarounds for that

Fixes #350