### PR TITLE
Cascade tests from the top

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ build:
 	$(MAKE) -C topic-controller		build
 	$(MAKE) -C riff-cli				build
 
+test:
+	$(MAKE) -C message-transport	test
+	$(MAKE) -C function-controller	test
+	$(MAKE) -C function-sidecar		test
+	$(MAKE) -C http-gateway			test
+	$(MAKE) -C topic-controller		test
+	$(MAKE) -C riff-cli				test
+
 dockerize:
 	$(MAKE) -C function-controller	dockerize
 	$(MAKE) -C function-sidecar		dockerize

--- a/README.adoc
+++ b/README.adoc
@@ -80,7 +80,7 @@ kubectl apply -f config/rbac
 
 === To tear it all down
 
-Once you're done playing with riff (see samples below), you can destroy everything created above by running
+Once you're done playing with riff (see samples below), you can destroy everything created above by running:
 
 [source, bash]
 ----
@@ -90,6 +90,17 @@ Once you're done playing with riff (see samples below), you can destroy everythi
 == [[samples]]Try Some Samples
 
 With riff running try some of the link:samples/README.adoc[samples].
+
+== Running the tests
+
+To run all riff's unit and integration tests, ensure Kafka (with `auto.create.topics.enable=true`, which
+is the default) and Zookeeper are running locally, then issue:
+
+[source, bash]
+----
+KAFKA_BROKERS=localhost:9092 KAFKA_BROKER=localhost:9092 make test
+----
+
 
 == Contributing to riff
 

--- a/message-transport/README.adoc
+++ b/message-transport/README.adoc
@@ -34,7 +34,7 @@ make build
 
 === Testing
 
-Ensure Kafka (with `auto.create.topics.enable=true`, which is the default) and Zookeepr are running locally,
+Ensure Kafka (with `auto.create.topics.enable=true`, which is the default) and Zookeeper are running locally,
 then issue:
 [source, bash]
 ----


### PR DESCRIPTION
For now, we require two similar env vars to be set. This can be cleaned up
later, applying due care to avoid breaking CI.

Also fix a couple of typos.

Implements https://github.com/projectriff/riff/issues/374