### PR TITLE
Make default test output less verbose

### DIFF
--- a/function-sidecar/Makefile
+++ b/function-sidecar/Makefile
@@ -12,7 +12,7 @@ clean:
 	rm -f $(OUTPUT)
 
 test: ../vendor
-	go test -v ./...
+	go test ./...
 
 dockerize: $(GO_SOURCES) ../vendor
 	docker build .. --build-arg COMPONENT=function-sidecar -t projectriff/function-sidecar:$(TAG)

--- a/http-gateway/Makefile
+++ b/http-gateway/Makefile
@@ -7,7 +7,7 @@ TAG ?= $(shell cat ../VERSION)
 build: $(OUTPUT)
 
 test:
-	go test -v ./...
+	go test ./...
 
 $(OUTPUT): $(GO_SOURCES) ../vendor
 	go build cmd/http-gateway.go

--- a/message-transport/Makefile
+++ b/message-transport/Makefile
@@ -12,7 +12,7 @@ build: $(GO_SOURCES) ../vendor
 	go build $(PKGS)
 
 test: $(GO_SOURCES) ../vendor
-	go test -v ./...
+	go test ./...
 
 gen-mocks $(GENERATED_SOURCE): $(GO_SOURCES) ../vendor
 	go get -u github.com/vektra/mockery/.../

--- a/riff-cli/Makefile
+++ b/riff-cli/Makefile
@@ -7,7 +7,7 @@ VERSION ?= $(shell cat ../VERSION)
 build: $(OUTPUT)
 
 test: build
-	go test -v ./...
+	go test ./...
 
 $(OUTPUT): $(GO_SOURCES) ../vendor
 	go build -ldflags "-X main.version=$(VERSION)" -o $(OUTPUT) ../cli.go

--- a/topic-controller/Makefile
+++ b/topic-controller/Makefile
@@ -7,7 +7,7 @@ GO_SOURCES = $(shell find pkg cmd -type f -name '*.go')
 build: $(OUTPUT)
 
 test: ../vendor
-	go test -v ./...
+	go test ./...
 
 $(OUTPUT): $(GO_SOURCES) ../vendor
 	go build cmd/topic-controller.go


### PR DESCRIPTION
Now that we have cascading tests, verbosity is distracting.