### PR TITLE
Abstract docker interaction behind an interface.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -21,6 +21,7 @@ import (
 	"github.com/projectriff/riff/riff-cli/global"
 	"fmt"
 	"os"
+	"github.com/projectriff/riff/riff-cli/pkg/docker"
 )
 
 var version = "Unknown"
@@ -28,7 +29,7 @@ var version = "Unknown"
 func main() {
 	global.CLI_VERSION = version
 
-	rootCmd := cmd.CreateAndWireRootCommand()
+	rootCmd := cmd.CreateAndWireRootCommand(docker.RealDocker(), docker.DryRunDocker())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/riff-cli/cmd/build_command_test.go
+++ b/riff-cli/cmd/build_command_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/projectriff/riff/riff-cli/pkg/osutils"
 	"github.com/spf13/cobra"
+	"github.com/projectriff/riff/riff-cli/pkg/docker"
 )
 
 func TestBuildCommandImplicitPath(t *testing.T) {
@@ -66,7 +67,7 @@ func TestBuildCommandWithUserAccountAndVersion(t *testing.T) {
 
 func setupBuildTest() (*cobra.Command, *cobra.Command, *BuildOptions) {
 	root := Root()
-	build, buildOptions := Build()
+	build, buildOptions := Build(docker.RealDocker(), docker.DryRunDocker())
 	root.AddCommand(build)
 	return root, build, buildOptions
 }

--- a/riff-cli/cmd/create_command_test.go
+++ b/riff-cli/cmd/create_command_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projectriff/riff/riff-cli/pkg/osutils"
 	"github.com/spf13/cobra"
 	"github.com/projectriff/riff/riff-cli/pkg/options"
+	"github.com/projectriff/riff/riff-cli/pkg/docker"
 )
 
 func TestCreateCommandImplicitPath(t *testing.T) {
@@ -138,7 +139,7 @@ func TestCreateJavaWithVersion(t *testing.T) {
 func setupCreateTest() (*cobra.Command, *options.InitOptions, *BuildOptions, *ApplyOptions) {
 	rootCmd, initOptions, initCommands := setupInitTest()
 
-	buildCmd, buildOptions := Build()
+	buildCmd, buildOptions := Build(docker.RealDocker(), docker.DryRunDocker())
 
 	applyCmd, applyOptions := Apply()
 

--- a/riff-cli/cmd/update_command_test.go
+++ b/riff-cli/cmd/update_command_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/projectriff/riff/riff-cli/pkg/osutils"
 	"github.com/spf13/cobra"
+	"github.com/projectriff/riff/riff-cli/pkg/docker"
 )
 
 func TestUpdateCommandImplicitPath(t *testing.T) {
@@ -47,7 +48,7 @@ func TestUpdateCommandExplicitPath(t *testing.T) {
 
 func setupUpdateTest() (*cobra.Command, *BuildOptions, *ApplyOptions) {
 	rootCmd := Root()
-	buildCmd, buildOptions := Build()
+	buildCmd, buildOptions := Build(docker.RealDocker(), docker.DryRunDocker())
 
 	applyCmd, applyOptions := Apply()
 

--- a/riff-cli/cmd/wiring.go
+++ b/riff-cli/cmd/wiring.go
@@ -18,11 +18,12 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/projectriff/riff/riff-cli/pkg/docker"
 )
 
 // CreateAndWireRootCommand creates all riff commands and sub commands, as well as the top-level 'root' command,
 // wires them together and returns the root command, ready to execute.
-func CreateAndWireRootCommand() *cobra.Command {
+func CreateAndWireRootCommand(readlDocker docker.Docker, dryRunDocker docker.Docker) *cobra.Command {
 
 	rootCmd := Root()
 
@@ -41,7 +42,7 @@ func CreateAndWireRootCommand() *cobra.Command {
 		initNodeCmd,
 	)
 
-	buildCmd, _ := Build()
+	buildCmd, _ := Build(readlDocker, dryRunDocker)
 
 	applyCmd, _ := Apply()
 

--- a/riff-cli/pkg/osutils/osutils.go
+++ b/riff-cli/pkg/osutils/osutils.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/projectriff/riff/riff-cli/pkg/ioutils"
-	"bufio"
 )
 
 func GetCWD() string {
@@ -86,27 +85,6 @@ func Path(filename string) string {
 		return path
 	}
 	return filepath.Join(strings.Split(path, "/")...)
-}
-
-func ExecWaitAndStreamOutput(cmdName string, cmdArgs []string) {
-
-	cmd := exec.Command(cmdName, cmdArgs...)
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
-	cmd.Start()
-	print(bufio.NewScanner(stdout),"[STDOUT]")
-	print(bufio.NewScanner(stderr),"[STDERR]")
-	cmd.Wait()
-}
-
-
-// to print the processed information when stdout gets a new line
-func print(scanner *bufio.Scanner, prefix string) {
-	scanner.Split(bufio.ScanLines)
-	for scanner.Scan() {
-		line := scanner.Text()
-		fmt.Printf("%s %s\n",prefix, line)
-	}
 }
 
 func Exec(cmdName string, cmdArgs []string, timeout time.Duration) ([]byte, error) {


### PR DESCRIPTION
Capture return value.
Make dry-run use that same interface



This is the first step towards having our tests verify actual
interaction with docker (and maybe doing just that, internal state then
not mattering as much is witnessed side effects are correctly verified).

Next step is to generate a mock for the interface introduced in this PR.
Baby steps.