### PR TITLE
Fix python samples links

### DIFF
--- a/samples/README.adoc
+++ b/samples/README.adoc
@@ -13,7 +13,8 @@ To riff link:../README.adoc[README]
 * Node
   - link:node/square/README.adoc[square]
 * Python
-  - link:python/sentiments/README.adoc[sentiments]
+  - link:python/concat/README.adoc[concat]
+  - link:python/upper/README.adoc[upper]
 * Shell
   - link:shell/echo/README.adoc[echo]
   - link:shell/hello/README.adoc[hello]


### PR DESCRIPTION
* sentiments doesn't exist, and concat and upper are not mentioned.  Removed sentiments and added concat/upper.  Fixes #411