### PR TITLE
configurable sidecar image name

### DIFF
--- a/function-controller/config/deployment.yaml
+++ b/function-controller/config/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         env:
         - name: KAFKA_BROKERS
           value: kafka.riff-system:9092
-        - name: RIFF_FUNCTION_SIDECAR_IMAGE
+        - name: RIFF_FUNCTION_SIDECAR_REPOSITORY
           value: projectriff/function-sidecar
         - name: RIFF_FUNCTION_SIDECAR_TAG
           value: 0.0.5-snapshot

--- a/function-controller/config/deployment.yaml
+++ b/function-controller/config/deployment.yaml
@@ -32,6 +32,8 @@ spec:
         env:
         - name: KAFKA_BROKERS
           value: kafka.riff-system:9092
+        - name: RIFF_FUNCTION_SIDECAR_IMAGE
+          value: projectriff/function-sidecar
         - name: RIFF_FUNCTION_SIDECAR_TAG
           value: 0.0.5-snapshot
       serviceAccountName: riff-sa

--- a/function-controller/pkg/controller/deployer.go
+++ b/function-controller/pkg/controller/deployer.go
@@ -93,7 +93,11 @@ func (d *deployer) buildMainContainer(function *v1.Function) corev1.Container {
 
 func (d *deployer) buildSidecarContainer(function *v1.Function) corev1.Container {
 	c := corev1.Container{Name: "sidecar"}
-	c.Image = sidecarImage + ":" + os.Getenv("RIFF_FUNCTION_SIDECAR_TAG")
+	imageName := os.Getenv("RIFF_FUNCTION_SIDECAR_IMAGE")
+	if imageName == "" {
+		imageName = sidecarImage
+	}
+	c.Image = imageName + ":" + os.Getenv("RIFF_FUNCTION_SIDECAR_TAG")
 	outputDestination := function.Spec.Output
 	if outputDestination == "" {
 		outputDestination = "replies"

--- a/function-controller/pkg/controller/deployer.go
+++ b/function-controller/pkg/controller/deployer.go
@@ -93,7 +93,7 @@ func (d *deployer) buildMainContainer(function *v1.Function) corev1.Container {
 
 func (d *deployer) buildSidecarContainer(function *v1.Function) corev1.Container {
 	c := corev1.Container{Name: "sidecar"}
-	imageName := os.Getenv("RIFF_FUNCTION_SIDECAR_IMAGE")
+	imageName := os.Getenv("RIFF_FUNCTION_SIDECAR_REPOSITORY")
 	if imageName == "" {
 		imageName = sidecarImage
 	}

--- a/helm-charts/riff/templates/function-controller-deployment.yaml
+++ b/helm-charts/riff/templates/function-controller-deployment.yaml
@@ -38,6 +38,8 @@ spec:
           env:
           - name: KAFKA_BROKERS
             value: {{ .Values.kafka.broker.nodes }}
+          - name: RIFF_FUNCTION_SIDECAR_IMAGE
+            value: {{ .Values.functionController.sidecar.image.repository }}
           - name: RIFF_FUNCTION_SIDECAR_TAG
             value: {{ .Values.functionController.sidecar.image.tag }}
       serviceAccountName: {{ template "serviceAccountName" . }}

--- a/helm-charts/riff/templates/function-controller-deployment.yaml
+++ b/helm-charts/riff/templates/function-controller-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           env:
           - name: KAFKA_BROKERS
             value: {{ .Values.kafka.broker.nodes }}
-          - name: RIFF_FUNCTION_SIDECAR_IMAGE
+          - name: RIFF_FUNCTION_SIDECAR_REPOSITORY
             value: {{ .Values.functionController.sidecar.image.repository }}
           - name: RIFF_FUNCTION_SIDECAR_TAG
             value: {{ .Values.functionController.sidecar.image.tag }}

--- a/helm-charts/riff/values.yaml
+++ b/helm-charts/riff/values.yaml
@@ -25,6 +25,7 @@ functionController:
     pullPolicy: IfNotPresent
   sidecar:
     image:
+      repository: projectriff/function-sidecar
       tag: latest
 
 topicController:


### PR DESCRIPTION
function controller looks at environment variable RIFF_FUNCTION_SIDECAR_IMAGE 
uses that for the sidecar image config - still defaulting to "projectriff/function-sidecar"

also updated/tested helm yaml and non-helm config, and values.yaml.

