### PR TITLE
Add header whitelist to gateway

### DIFF
--- a/http-gateway/README.adoc
+++ b/http-gateway/README.adoc
@@ -1,6 +1,14 @@
 == HTTP Gateway
 The *http gateway* accepts http requests posted to a `/messages/\{topic\}` endpoint, and trasforms those to messages emitted on the broker. Optionally, when posting to the `/requests/\{topic\}` endpoint, it waits for a reply correlated with the request on a dedicated internal topic, and marshalls that message as an http response.
 
+== Whitelisting HTTP Request Headers
+
+By default, the http-gateway filters out all HTTP request headers except for `Accept` and `Content-Type`.
+
+The http-gateway can read a whitelist of headers from `RIFF_HTTP_HEADERS_WHITELIST`.
+
+To configure this whitelist, you can update `config/deployment`, then run `make kubectl-apply`.
+
 == Development
 === Prerequisites
 The following tools are required to build this project:

--- a/http-gateway/config/deployment.yaml
+++ b/http-gateway/config/deployment.yaml
@@ -28,3 +28,5 @@ spec:
         env:
         - name: KAFKA_BROKERS
           value: kafka.riff-system:9092
+        - name: RIFF_HTTP_HEADERS_WHITELIST
+          value: # Add,A-Comma-Separated,List-Of,Headers,To-Whitelist,Here

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/projectriff/riff/message-transport/pkg/message"
 )
@@ -29,8 +31,6 @@ const (
 	ContentType = "Content-Type"
 	Accept      = "Accept"
 )
-
-var incomingHeadersToPropagate = [...]string{ContentType, Accept}
 
 // Function messageHandler is an http handler that sends the http body to the producer, replying
 // immediately with a successful http response.
@@ -57,6 +57,10 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func propagateIncomingHeaders(request *http.Request) message.Headers {
+	var defaultHeaders = []string{ContentType, Accept}
+	var whitelistedHeaders = strings.Split(os.Getenv("RIFF_HTTP_HEADERS_WHITELIST"), ",")
+	incomingHeadersToPropagate := append(defaultHeaders, whitelistedHeaders...)
+
 	header := make(message.Headers)
 	for _, h := range incomingHeadersToPropagate {
 		if vs, ok := request.Header[h]; ok {


### PR DESCRIPTION
* Introduces whitelist filtering of HTTP headers at the `http-gateway`
* Configuration is part of the Deployment