### PR TITLE
`riff invokers` commands

### DIFF
--- a/riff-cli/cmd/completion.go
+++ b/riff-cli/cmd/completion.go
@@ -17,18 +17,19 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
 	"github.com/projectriff/riff/riff-cli/cmd/utils"
+	"github.com/spf13/cobra"
 )
 
 func Completion(rootCmd *cobra.Command) *cobra.Command {
 
 	var completionCmd = &cobra.Command{
-		Use:       "completion [bash|zsh]",
-		Short:     "Generate shell completion scripts",
-		Long:      "Generate shell completion scripts",
-		Example: 	`
+		Use:   "completion [bash|zsh]",
+		Short: "Generate shell completion scripts",
+		Long:  "Generate shell completion scripts",
+		Example: `
 To install completion for bash, assuming you have bash-completion installed:
 
     riff completion bash > /etc/bash_completion.d/riff     
@@ -54,4 +55,3 @@ Completion for zsh is a work in progress`,
 	return completionCmd
 
 }
-

--- a/riff-cli/cmd/invokers.go
+++ b/riff-cli/cmd/invokers.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	projectriff_v1 "github.com/projectriff/riff/kubernetes-crds/pkg/apis/projectriff.io/v1"
+	"github.com/projectriff/riff/riff-cli/cmd/utils"
+	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
+	"github.com/projectriff/riff/riff-cli/pkg/osutils"
+	"github.com/spf13/cobra"
+)
+
+func Invokers() *cobra.Command {
+
+	var invokersCmd = &cobra.Command{
+		Use:   "invokers",
+		Short: "Manage invokers in the cluster",
+	}
+
+	return invokersCmd
+}
+
+type InvokersApplyOptions struct {
+	Filename string
+	Name     string
+	Version  string
+}
+
+func InvokersApply(kubeCtl kubectl.KubeCtl) (*cobra.Command, *InvokersApplyOptions) {
+
+	var invokersApplyOptions = InvokersApplyOptions{}
+
+	var invokersApplyCmd = &cobra.Command{
+		Use:   "apply",
+		Short: "Install or update an invoker in the cluster",
+		Args:  utils.AliasFlagToSoleArg("filename"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			invokerURLs, err := resolveInvokerURLs(invokersApplyOptions.Filename)
+			if err != nil {
+				return err
+			}
+			if len(invokerURLs) == 0 {
+				return fmt.Errorf("No invokers found at %s", invokersApplyOptions.Filename)
+			}
+			if len(invokerURLs) > 1 && invokersApplyOptions.Name != "" {
+				return fmt.Errorf("Invoker name can only be set for a single invoker, found %d", len(invokerURLs))
+			}
+			invokersBytes, err := loadInvokers(invokerURLs)
+			for _, invokerBytes := range invokersBytes {
+				var invoker = projectriff_v1.Invoker{}
+				err = yaml.Unmarshal(invokerBytes, &invoker)
+				if err != nil {
+					return err
+				}
+				if invokersApplyOptions.Name != "" {
+					invoker.ObjectMeta.Name = invokersApplyOptions.Name
+				}
+				if invokersApplyOptions.Version != "" {
+					invoker.Spec.Version = invokersApplyOptions.Version
+				}
+
+				content, err := yaml.Marshal(invoker)
+				if err != nil {
+					return err
+				}
+
+				out, err := kubeCtl.ExecStdin([]string{"apply", "-f", "-"}, &content)
+				if err != nil {
+					return err
+				}
+				fmt.Print(out)
+			}
+			return nil
+		},
+	}
+
+	invokersApplyCmd.Flags().StringVarP(&invokersApplyOptions.Filename, "filename", "f", ".", "path to the invoker resource to install")
+	invokersApplyCmd.Flags().StringVarP(&invokersApplyOptions.Name, "name", "n", "", "name of the invoker (defaults to the name in the invoker resource)")
+	invokersApplyCmd.Flags().StringVarP(&invokersApplyOptions.Version, "version", "v", "", "version of the invoker (defaults to the version in the invoker resource)")
+
+	return invokersApplyCmd, &invokersApplyOptions
+}
+
+func InvokersList(kubeCtl kubectl.KubeCtl) *cobra.Command {
+
+	var invokersListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List invokers in the cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kubeCtlArgs := append([]string{
+				"get", "invokers",
+				"--sort-by=metadata.name",
+				"-o=custom-columns=NAME:.metadata.name,VERSION:.spec.version",
+			}, args...)
+			listing, err := kubeCtl.Exec(kubeCtlArgs)
+			if err != nil {
+				return err
+			}
+			fmt.Print(listing)
+			return nil
+		},
+	}
+
+	return invokersListCmd
+}
+
+type InvokersDeleteOptions struct {
+	All  bool
+	Name string
+}
+
+func InvokersDelete(kubeCtl kubectl.KubeCtl) (*cobra.Command, *InvokersDeleteOptions) {
+
+	var invokersDeleteOptions = InvokersDeleteOptions{}
+
+	var invokersDeleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Remove an invoker from the cluster",
+		Args:  utils.AliasFlagToSoleArg("name"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var kubeCtlArgs = []string{"delete", "invokers"}
+			if invokersDeleteOptions.All {
+				kubeCtlArgs = append(kubeCtlArgs, "--all")
+			} else if invokersDeleteOptions.Name == "" {
+				return fmt.Errorf("Invoker to delete must be specified")
+			} else {
+				kubeCtlArgs = append(kubeCtlArgs, invokersDeleteOptions.Name)
+			}
+			out, err := kubeCtl.Exec(kubeCtlArgs)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+
+	invokersDeleteCmd.Flags().BoolVar(&invokersDeleteOptions.All, "all", false, "remove all invokers from the cluster")
+	invokersDeleteCmd.Flags().StringVarP(&invokersDeleteOptions.Name, "name", "n", "", "invoker name to remove from the cluster")
+
+	return invokersDeleteCmd, &invokersDeleteOptions
+}
+
+func loadInvokers(urls []url.URL) ([][]byte, error) {
+	var invokersBytes = [][]byte{}
+	for _, url := range urls {
+		if url.Scheme == "file" {
+			file, err := ioutil.ReadFile(url.Path)
+			if err != nil {
+				return nil, err
+			}
+			invokersBytes = append(invokersBytes, file)
+		} else if url.Scheme == "http" || url.Scheme == "https" {
+			resp, err := http.Get(url.String())
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			invokersBytes = append(invokersBytes, body)
+		} else {
+			return nil, fmt.Errorf("Filename must be file, http or https, got %s", url.Scheme)
+		}
+	}
+	return invokersBytes, nil
+}
+
+func resolveInvokerURLs(filename string) ([]url.URL, error) {
+	u, err := url.Parse(filename)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "" {
+		u.Scheme = "file"
+	}
+	if u.Scheme == "http" || u.Scheme == "https" {
+		return []url.URL{*u}, nil
+	}
+	if u.Scheme == "file" {
+		if osutils.IsDirectory(u.Path) {
+			u.Path = filepath.Join(u.Path, "*-invoker.yaml")
+		}
+		filenames, err := filepath.Glob(u.Path)
+		if err != nil {
+			return nil, err
+		}
+		var urls = []url.URL{}
+		for _, f := range filenames {
+			urls = append(urls, url.URL{
+				Scheme: u.Scheme,
+				Path:   f,
+			})
+		}
+		return urls, nil
+	}
+	return nil, fmt.Errorf("Filename must be file, http or https, got %s", u.Scheme)
+}

--- a/riff-cli/cmd/invokers_test.go
+++ b/riff-cli/cmd/invokers_test.go
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	projectriff_v1 "github.com/projectriff/riff/kubernetes-crds/pkg/apis/projectriff.io/v1"
+	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
+)
+
+var _ = Describe("The invokers commands", func() {
+	var (
+		normalKubeCtl *kubectl.MockKubeCtl
+
+		rootCommand           *cobra.Command
+		invokersCommand       *cobra.Command
+		invokersApplyCommand  *cobra.Command
+		invokersListCommand   *cobra.Command
+		invokersDeleteCommand *cobra.Command
+
+		invokersApplyOptions  *InvokersApplyOptions
+		invokersDeleteOptions *InvokersDeleteOptions
+
+		oldCWD string
+	)
+
+	invokerWithNameAndVersion := func(name string, version string) func(stdin *[]byte) bool {
+		return func(stdin *[]uint8) bool {
+			invoker := projectriff_v1.Invoker{}
+			err := yaml.Unmarshal(*stdin, &invoker)
+			if err != nil {
+				return false
+			}
+			return invoker.ObjectMeta.Name == name && invoker.Spec.Version == version
+		}
+	}
+
+	BeforeEach(func() {
+		var err error
+
+		normalKubeCtl = new(kubectl.MockKubeCtl)
+
+		rootCommand = Root()
+		invokersCommand = Invokers()
+		invokersApplyCommand, invokersApplyOptions = InvokersApply(normalKubeCtl)
+		invokersListCommand = InvokersList(normalKubeCtl)
+		invokersDeleteCommand, invokersDeleteOptions = InvokersDelete(normalKubeCtl)
+
+		rootCommand.AddCommand(invokersCommand)
+		invokersCommand.AddCommand(
+			invokersApplyCommand,
+			invokersListCommand,
+			invokersDeleteCommand,
+		)
+
+		oldCWD, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		normalKubeCtl.AssertExpectations(GinkgoT())
+
+		os.Chdir(oldCWD)
+	})
+
+	Context("invokers apply", func() {
+
+		It("applies invokers from the current directory", func() {
+			os.Chdir("../test_data/invokers")
+
+			rootCommand.SetArgs([]string{"invokers", "apply"})
+
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("command", "0.0.5-snapshot"))).Return("", nil).Once()
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("java", "0.0.5-snapshot"))).Return("", nil).Once()
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("node", "0.0.5-snapshot"))).Return("", nil).Once()
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("python2", "0.0.5-snapshot"))).Return("", nil).Once()
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("python3", "0.0.5-snapshot"))).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("."))
+		})
+
+		It("applies a specific invoker from the current directory", func() {
+			os.Chdir("../test_data/invokers")
+
+			rootCommand.SetArgs([]string{"invokers", "apply", "-f", "command-function-invoker.yaml"})
+
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("command", "0.0.5-snapshot"))).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("command-function-invoker.yaml"))
+		})
+
+		It("applies a specific invoker from another directory", func() {
+			rootCommand.SetArgs([]string{"invokers", "apply", "-f", "../test_data/invokers/command-function-invoker.yaml"})
+
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("command", "0.0.5-snapshot"))).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("../test_data/invokers/command-function-invoker.yaml"))
+		})
+
+		It("applies a specific invoker with a custom version", func() {
+			rootCommand.SetArgs([]string{"invokers", "apply", "-v", "latest", "-f", "../test_data/invokers/command-function-invoker.yaml"})
+
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("command", "latest"))).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("../test_data/invokers/command-function-invoker.yaml"))
+			Expect(invokersApplyOptions.Version).To(Equal("latest"))
+		})
+
+		It("applies a specific invoker with a custom name", func() {
+			rootCommand.SetArgs([]string{"invokers", "apply", "-n", "foobar", "-f", "../test_data/invokers/command-function-invoker.yaml"})
+
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("foobar", "0.0.5-snapshot"))).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("../test_data/invokers/command-function-invoker.yaml"))
+			Expect(invokersApplyOptions.Name).To(Equal("foobar"))
+		})
+
+		It("fails to apply multiple invokers with a custom name", func() {
+			os.Chdir("../test_data/invokers")
+
+			rootCommand.SetArgs([]string{"invokers", "apply", "-n", "foobar"})
+
+			err := rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("."))
+			Expect(invokersApplyOptions.Name).To(Equal("foobar"))
+		})
+
+		// NOTE this test requires network access to GitHub and may break if history is rewritten
+		It("applies a specific invoker from a URL", func() {
+			goodURL := "https://github.com/projectriff/riff/raw/b81e42181f46bfcf7cb2e230485422be2d3807d3/riff-cli/test_data/invokers/command-function-invoker.yaml"
+
+			rootCommand.SetArgs([]string{"invokers", "apply", "-f", goodURL})
+
+			normalKubeCtl.On("ExecStdin", []string{"apply", "-f", "-"}, mock.MatchedBy(invokerWithNameAndVersion("command", "0.0.5-snapshot"))).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal(goodURL))
+		})
+
+		It("fails to apply a specific invoker from a bogus filepath", func() {
+			rootCommand.SetArgs([]string{"invokers", "apply", "-f", "bogus-invoker.yaml"})
+
+			err := rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal("bogus-invoker.yaml"))
+		})
+
+		It("fails to apply a specific invoker from a bogus URL", func() {
+			badURL := "https://github.com/projectriff/riff/raw/b81e42181f46bfcf7cb2e230485422be2d3807d3/riff-cli/test_data/invokers/bogus-invoker.yaml"
+			rootCommand.SetArgs([]string{"invokers", "apply", "-f", badURL})
+
+			err := rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+
+			Expect(invokersApplyOptions.Filename).To(Equal(badURL))
+		})
+
+	})
+
+	Context("invokers list", func() {
+
+		It("lists installed invokers", func() {
+			rootCommand.SetArgs([]string{"invokers", "list"})
+
+			normalKubeCtl.On(
+				"Exec",
+				[]string{
+					"get", "invokers",
+					"--sort-by=metadata.name",
+					"-o=custom-columns=NAME:.metadata.name,VERSION:.spec.version",
+				},
+			).Return("NAME      VERSION\n", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+
+	Context("invokers delete", func() {
+
+		It("removes the specified invoker", func() {
+			rootCommand.SetArgs([]string{"invokers", "delete", "command"})
+
+			normalKubeCtl.On("Exec", []string{"delete", "invokers", "command"}).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersDeleteOptions.All).To(BeFalse())
+			Expect(invokersDeleteOptions.Name).To(Equal("command"))
+		})
+
+		It("removes all invokers", func() {
+			rootCommand.SetArgs([]string{"invokers", "delete", "--all"})
+
+			normalKubeCtl.On("Exec", []string{"delete", "invokers", "--all"}).Return("", nil).Once()
+
+			err := rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(invokersDeleteOptions.All).To(BeTrue())
+			Expect(invokersDeleteOptions.Name).To(Equal(""))
+		})
+
+	})
+
+})

--- a/riff-cli/cmd/wiring.go
+++ b/riff-cli/cmd/wiring.go
@@ -52,6 +52,12 @@ func CreateAndWireRootCommand(realDocker docker.Docker, dryRunDocker docker.Dock
 
 	deleteCmd, _ := Delete(realKubeCtl, dryRunKubeCtl)
 
+	invokersCmd := Invokers()
+	invokersApplyCmd, _ := InvokersApply(realKubeCtl)
+	invokersListCmd := InvokersList(realKubeCtl)
+	invokersDeleteCmd, _ := InvokersDelete(realKubeCtl)
+	invokersCmd.AddCommand(invokersApplyCmd, invokersListCmd, invokersDeleteCmd)
+
 	rootCmd.AddCommand(
 		applyCmd,
 		buildCmd,
@@ -62,6 +68,7 @@ func CreateAndWireRootCommand(realDocker docker.Docker, dryRunDocker docker.Dock
 		Logs(),
 		Publish(),
 		Update(buildCmd, applyCmd),
+		invokersCmd,
 		Version(),
 	)
 

--- a/riff-cli/docs/riff.md
+++ b/riff-cli/docs/riff.md
@@ -22,6 +22,7 @@ the riff tool is used to create and manage function resources for the riff FaaS 
 * [riff create](riff_create.md)	 - Create a function (equivalent to init, build, apply)
 * [riff delete](riff_delete.md)	 - Delete function resources in the cluster
 * [riff init](riff_init.md)	 - Initialize a function
+* [riff invokers](riff_invokers.md)	 - Manage invokers in the cluster
 * [riff list](riff_list.md)	 - List function resources
 * [riff logs](riff_logs.md)	 - Display the logs for a running function
 * [riff publish](riff_publish.md)	 - Publish data to a topic using the http-gateway

--- a/riff-cli/docs/riff_invokers.md
+++ b/riff-cli/docs/riff_invokers.md
@@ -1,0 +1,27 @@
+## riff invokers
+
+Manage invokers in the cluster
+
+### Synopsis
+
+Manage invokers in the cluster
+
+### Options
+
+```
+  -h, --help   help for invokers
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.riff.yaml)
+```
+
+### SEE ALSO
+
+* [riff](riff.md)	 - Commands for creating and managing function resources
+* [riff invokers apply](riff_invokers_apply.md)	 - Install or update an invoker in the cluster
+* [riff invokers delete](riff_invokers_delete.md)	 - Remove an invoker from the cluster
+* [riff invokers list](riff_invokers_list.md)	 - List invokers in the cluster
+

--- a/riff-cli/docs/riff_invokers_apply.md
+++ b/riff-cli/docs/riff_invokers_apply.md
@@ -1,0 +1,31 @@
+## riff invokers apply
+
+Install or update an invoker in the cluster
+
+### Synopsis
+
+Install or update an invoker in the cluster
+
+```
+riff invokers apply [flags]
+```
+
+### Options
+
+```
+  -f, --filename string   path to the invoker resource to install (default ".")
+  -h, --help              help for apply
+  -n, --name string       name of the invoker (defaults to the name in the invoker resource)
+  -v, --version string    version of the invoker (defaults to the version in the invoker resource)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.riff.yaml)
+```
+
+### SEE ALSO
+
+* [riff invokers](riff_invokers.md)	 - Manage invokers in the cluster
+

--- a/riff-cli/docs/riff_invokers_delete.md
+++ b/riff-cli/docs/riff_invokers_delete.md
@@ -1,0 +1,30 @@
+## riff invokers delete
+
+Remove an invoker from the cluster
+
+### Synopsis
+
+Remove an invoker from the cluster
+
+```
+riff invokers delete [flags]
+```
+
+### Options
+
+```
+      --all           remove all invokers from the cluster
+  -h, --help          help for delete
+  -n, --name string   invoker name to remove from the cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.riff.yaml)
+```
+
+### SEE ALSO
+
+* [riff invokers](riff_invokers.md)	 - Manage invokers in the cluster
+

--- a/riff-cli/docs/riff_invokers_list.md
+++ b/riff-cli/docs/riff_invokers_list.md
@@ -1,0 +1,28 @@
+## riff invokers list
+
+List invokers in the cluster
+
+### Synopsis
+
+List invokers in the cluster
+
+```
+riff invokers list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default is $HOME/.riff.yaml)
+```
+
+### SEE ALSO
+
+* [riff invokers](riff_invokers.md)	 - Manage invokers in the cluster
+

--- a/riff-cli/pkg/kubectl/kubectl.go
+++ b/riff-cli/pkg/kubectl/kubectl.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,11 @@
 package kubectl
 
 import (
-	"github.com/projectriff/riff/riff-cli/pkg/osutils"
-	"time"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/projectriff/riff/riff-cli/pkg/osutils"
 )
 
 var EXEC_FOR_STRING = ExecForString
@@ -29,6 +30,7 @@ var EXEC_FOR_BYTES = ExecForBytes
 //go:generate mockery -name=KubeCtl -inpkg
 type KubeCtl interface {
 	Exec(cmdArgs []string) (string, error)
+	ExecStdin(cmdArgs []string, stdin *[]byte) (string, error)
 }
 
 // processKubeCtl interacts with kubernetes by spawning a process and running the kubectl
@@ -41,11 +43,21 @@ func (kc *processKubeCtl) Exec(cmdArgs []string) (string, error) {
 	return string(out), err
 }
 
+func (kc *processKubeCtl) ExecStdin(cmdArgs []string, stdin *[]byte) (string, error) {
+	out, err := osutils.ExecStdin("kubectl", cmdArgs, stdin, 20*time.Second)
+	return string(out), err
+}
+
 // dryRunKubeCtl only prints out the kubectl commands that *would* run.
 type dryRunKubeCtl struct {
 }
 
 func (kc *dryRunKubeCtl) Exec(cmdArgs []string) (string, error) {
+	fmt.Printf("%s command: kubectl %s\n", strings.Title(cmdArgs[0]), strings.Join(cmdArgs, " "))
+	return "", nil
+}
+
+func (kc *dryRunKubeCtl) ExecStdin(cmdArgs []string, stdin *[]byte) (string, error) {
 	fmt.Printf("%s command: kubectl %s\n", strings.Title(cmdArgs[0]), strings.Join(cmdArgs, " "))
 	return "", nil
 }

--- a/riff-cli/pkg/kubectl/mock_KubeCtl.go
+++ b/riff-cli/pkg/kubectl/mock_KubeCtl.go
@@ -28,3 +28,24 @@ func (_m *MockKubeCtl) Exec(cmdArgs []string) (string, error) {
 
 	return r0, r1
 }
+
+// ExecStdin provides a mock function with given fields: cmdArgs, stdin
+func (_m *MockKubeCtl) ExecStdin(cmdArgs []string, stdin *[]byte) (string, error) {
+	ret := _m.Called(cmdArgs, stdin)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func([]string, *[]byte) string); ok {
+		r0 = rf(cmdArgs, stdin)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]string, *[]byte) error); ok {
+		r1 = rf(cmdArgs, stdin)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/riff-cli/pkg/osutils/osutils.go
+++ b/riff-cli/pkg/osutils/osutils.go
@@ -88,6 +88,10 @@ func Path(filename string) string {
 }
 
 func Exec(cmdName string, cmdArgs []string, timeout time.Duration) ([]byte, error) {
+	return ExecStdin(cmdName, cmdArgs, nil, timeout)
+}
+
+func ExecStdin(cmdName string, cmdArgs []string, stdin *[]byte, timeout time.Duration) ([]byte, error) {
 	// Create a new context and add a timeout to it
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel() // The cancel should be deferred so resources are cleaned up
@@ -97,6 +101,9 @@ func Exec(cmdName string, cmdArgs []string, timeout time.Duration) ([]byte, erro
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+	if stdin != nil {
+		cmd.Stdin = bytes.NewBuffer(*stdin)
+	}
 	// This time we can simply use Output() to get the result.
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
    # list all invokers
    $ riff invokers list
    NAME      VERSION
    command   0.0.6-snapshot
    go        0.0.2-snapshot
    java      0.0.6-snapshot
    node      0.0.6-snapshot
    python2   0.0.6-snapshot
    python3   0.0.6-snapshot

    # install/update invoker (in current directory)
    $ riff invokers apply
    invoker "command" configured
    invoker "go" configured
    invoker "java" configured
    invoker "node" configured
    invoker "python2" configured
    invoker "python3" configured

    # install/update invoker (specific invoker)
    $ riff invokers apply -f node-invoker.yaml
    invoker "node" configured

    # install/update invoker (remote resource)
    $ riff invokers apply -f https://github.com/projectriff/node-function-invoker/raw/master/node-invoker.yaml
    invoker "node" configured

    # install/update invoker (name alias)
    $ riff invokers apply -f node-invoker.yaml --name node8
    invoker "node8" configured

    # install/update invoker (custom version)
    $ riff invokers apply -f node-invoker.yaml --version latest
    invoker "node" configured

    # remove single invoker
    $ riff invokers delete node8
    invoker "node8" deleted

    # remove all invokers
    $ riff invokers delete --all
    invoker "command" deleted
    invoker "go" deleted
    invoker "java" deleted
    invoker "node" deleted
    invoker "python2" deleted
    invoker "python3" deleted

Resolves #437