### PR TITLE
Better artifact resolution for specified invoker

### DIFF
--- a/riff-cli/cmd/init_test.go
+++ b/riff-cli/cmd/init_test.go
@@ -85,6 +85,22 @@ var _ = Describe("The init command", func() {
 			Expect(".").NotTo(HaveUnstagedChanges())
 		})
 
+		It("should find an artifact based on an invoker", func() {
+			os.Chdir("../test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact")
+
+			invokers, err := stubInvokers("invokers/*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rootCommand, _, _, _, err := setupInitTest(invokers)
+			Expect(err).NotTo(HaveOccurred())
+
+			rootCommand.SetArgs(append([]string{"init", "python3"}, commonRiffArgs...))
+
+			err = rootCommand.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(".").NotTo(HaveUnstagedChanges())
+		})
+
 		It("should fail when multiple invokers match", func() {
 			os.Chdir("../test_data/riff-init/multiple-matching-invokers")
 

--- a/riff-cli/pkg/initializer/initializer.go
+++ b/riff-cli/pkg/initializer/initializer.go
@@ -79,6 +79,9 @@ func resolveInvoker(invokers []projectriff_v1.Invoker, opts *options.InitOptions
 		if resolvedInvoker.ObjectMeta.Name == "" {
 			return projectriff_v1.Invoker{}, fmt.Errorf("Invoker %s not found", opts.InvokerName)
 		}
+
+		// restrict future searches to the resolved invoker
+		invokers = []projectriff_v1.Invoker{resolvedInvoker}
 	}
 
 	if opts.Artifact == "" {

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/Dockerfile
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/Dockerfile
@@ -1,0 +1,5 @@
+FROM projectriff/python3-function-invoker:0.0.5-snapshot
+ARG FUNCTION_MODULE=echo.py
+ARG FUNCTION_HANDLER=multiple-matching-invokers-with-one-selected-no-artifact
+ADD ./echo.py /
+ENV FUNCTION_URI file:///${FUNCTION_MODULE}?handler=${FUNCTION_HANDLER}

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/invokers/command-function-invoker.yaml
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/invokers/command-function-invoker.yaml
@@ -1,0 +1,1 @@
+../../../invokers/command-function-invoker.yaml

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/invokers/python3-function-invoker.yaml
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/invokers/python3-function-invoker.yaml
@@ -1,0 +1,1 @@
+../../../invokers/python3-function-invoker.yaml

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/multiple-matching-invokers-with-one-selected-no-artifact-function.yaml
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/multiple-matching-invokers-with-one-selected-no-artifact-function.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: projectriff.io/v1
+kind: Function
+metadata:
+  name: multiple-matching-invokers-with-one-selected-no-artifact
+spec:
+  container:
+    image: rifftest/multiple-matching-invokers-with-one-selected-no-artifact:0.0.1
+  input: multiple-matching-invokers-with-one-selected-no-artifact
+  protocol: grpc

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/multiple-matching-invokers-with-one-selected-no-artifact-topics.yaml
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/multiple-matching-invokers-with-one-selected-no-artifact-topics.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: projectriff.io/v1
+kind: Topic
+metadata:
+  name: multiple-matching-invokers-with-one-selected-no-artifact


### PR DESCRIPTION
When an invoker is specified, we only need to search for an artifact
matching the specified invoker rather than looking at all invokers.

Fixes #448