### PR TITLE
Support generation of docs for a command subtree

### DIFF
--- a/riff-cli/Makefile
+++ b/riff-cli/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build clean test release verify-docs all gen-mocks
-OUTPUT = riff
+OUTPUT = ./riff
 OUTPUT_WINDOWS = $(OUTPUT).exe
 GO_SOURCES = $(shell find cmd pkg -type f -name '*.go' -not -name 'mock_*.go')
 VERSION ?= $(shell cat ../VERSION)
@@ -12,6 +12,11 @@ build: $(OUTPUT)
 
 test: build
 	go test ./...
+
+	rm -rf test_data/docs/*.md
+	RIFF_INVOKER_PATHS="test_data/invokers/command-function-invoker.yaml" $(OUTPUT) docs -d test_data/docs --command "init command"
+	RIFF_INVOKER_PATHS="test_data/invokers/command-function-invoker.yaml" $(OUTPUT) docs -d test_data/docs --command "create command"
+	git diff --exit-code test_data/docs
 
 $(OUTPUT): $(GO_SOURCES) ../vendor
 	go build -ldflags "-X main.version=$(VERSION)" -o $(OUTPUT) ../cli.go

--- a/riff-cli/pkg/initializer/initializer.go
+++ b/riff-cli/pkg/initializer/initializer.go
@@ -65,7 +65,6 @@ func loadInvokersFromDisk(invokerPaths []string) ([]projectriff_v1.Invoker, erro
 			continue
 		}
 		invokerBytes, err := ioutil.ReadFile(invokerPath)
-		fmt.Println(string(invokerBytes))
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +73,6 @@ func loadInvokersFromDisk(invokerPaths []string) ([]projectriff_v1.Invoker, erro
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println(invoker.ObjectMeta.Name)
 		invokers = append(invokers, invoker)
 	}
 	return invokers, nil

--- a/riff-cli/test_data/docs/riff_create_command.md
+++ b/riff-cli/test_data/docs/riff_create_command.md
@@ -1,0 +1,52 @@
+## riff create command
+
+Create a command function
+
+### Synopsis
+
+Create the function based on the executable command specified as the filename, using the name
+and version specified for the function image repository and tag.
+
+For example, from a directory named 'echo' containing a function 'echo.sh', you can simply type :
+
+    riff create command -f echo
+
+  or
+
+    riff create command
+
+to create the resource definitions, and apply the resources, using sensible defaults.
+
+
+```
+riff create command [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for command
+      --invoker-version string   the version of invoker to use when building containers (default "0.0.5-snapshot")
+      --namespace string         the namespace used for the deployed resources (defaults to kubectl's default)
+      --push                     push the image to Docker registry
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --artifact string      path to the function artifact, source code or jar file
+      --config string        config file (default is $HOME/.riff.yaml)
+      --dry-run              print generated function artifacts content to stdout only
+  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
+      --force                overwrite existing functions artifacts
+  -i, --input string         the name of the input topic (defaults to function name)
+  -n, --name string          the name of the function (defaults to the name of the current directory)
+  -o, --output string        the name of the output topic (optional)
+  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string       the version of the function image (default "0.0.1")
+```
+
+### SEE ALSO
+
+* [riff create](https://github.com/projectriff/riff/blob/master/riff-cli/docs/riff_create.md)	 - Create a function (equivalent to init, build, apply)
+

--- a/riff-cli/test_data/docs/riff_init_command.md
+++ b/riff-cli/test_data/docs/riff_init_command.md
@@ -1,0 +1,50 @@
+## riff init command
+
+Initialize a command function
+
+### Synopsis
+
+Generate the function based on the executable command specified as the filename, using the name
+and version specified for the function image repository and tag.
+
+For example, from a directory named 'echo' containing a function 'echo.sh', you can simply type :
+
+    riff init command -f echo
+
+  or
+
+    riff init command
+
+to generate the resource definitions using sensible defaults.
+
+
+```
+riff init command [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for command
+      --invoker-version string   the version of invoker to use when building containers (default "0.0.5-snapshot")
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --artifact string      path to the function artifact, source code or jar file
+      --config string        config file (default is $HOME/.riff.yaml)
+      --dry-run              print generated function artifacts content to stdout only
+  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
+      --force                overwrite existing functions artifacts
+  -i, --input string         the name of the input topic (defaults to function name)
+  -n, --name string          the name of the function (defaults to the name of the current directory)
+  -o, --output string        the name of the output topic (optional)
+  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string       the version of the function image (default "0.0.1")
+```
+
+### SEE ALSO
+
+* [riff init](https://github.com/projectriff/riff/blob/master/riff-cli/docs/riff_init.md)	 - Initialize a function
+


### PR DESCRIPTION
Invokers should be able to genreate docs for the `riff init [invoker]`
and `riff create [invoker]` commands without generating docs for *all*
riff commands.

    # generate docs for `riff init command` and `riff create command`
    $ RIFF_INVOKER_PATHS="command-invoker.yaml" riff docs -d docs --command "init command"
    $ RIFF_INVOKER_PATHS="command-invoker.yaml" riff docs -d docs --command "create command"

Refs #454