### PR TITLE
Add .TitleCase method to handler value template

### DIFF
--- a/riff-cli/cmd/create_test.go
+++ b/riff-cli/cmd/create_test.go
@@ -349,7 +349,7 @@ var _ = Describe("The create command", func() {
 
 		Expect(initOptions.FilePath).To(Equal(path))
 		Expect(initOptions.Artifact).To(Equal("demo.py"))
-		Expect(initOptions.Handler).To(Equal("demo"))
+		Expect(initOptions.Handler).To(Equal("Demo"))
 		Expect(initOptions.UserAccount).To(Equal("rifftest"))
 	})
 

--- a/riff-cli/pkg/initializer/initializer.go
+++ b/riff-cli/pkg/initializer/initializer.go
@@ -202,6 +202,14 @@ func resolveArtifacts(workdir string, invokers []projectriff_v1.Invoker) ([]stri
 	return keys, nil
 }
 
+type handlerOptions struct {
+	FunctionName string
+}
+
+func (h handlerOptions) TitleCase(s string) string {
+	return strings.Title(s)
+}
+
 func resolveOptions(opts *options.InitOptions, invoker projectriff_v1.Invoker) error {
 	if opts.Input == "" {
 		opts.Input = opts.FunctionName
@@ -216,7 +224,7 @@ func resolveOptions(opts *options.InitOptions, invoker projectriff_v1.Invoker) e
 	// }
 
 	if opts.Handler != "" {
-		handler, err := templateutils.Apply(opts.Handler, "opts.Handler", opts)
+		handler, err := templateutils.Apply(opts.Handler, "opts.Handler", handlerOptions{FunctionName: opts.FunctionName})
 		if err != nil {
 			return err
 		}

--- a/riff-cli/test_data/invokers/python2-function-invoker.yaml
+++ b/riff-cli/test_data/invokers/python2-function-invoker.yaml
@@ -9,7 +9,7 @@ spec:
   - "*.py"
   properties:
     handler:
-      default: "{{ .FunctionName }}"
+      default: "{{ .TitleCase .FunctionName }}"
       description: the name of the function handler
     function:
       protocol: grpc

--- a/riff-cli/test_data/invokers/python3-function-invoker.yaml
+++ b/riff-cli/test_data/invokers/python3-function-invoker.yaml
@@ -9,7 +9,7 @@ spec:
   - "*.py"
   properties:
     handler:
-      default: "{{ .FunctionName }}"
+      default: "{{ .TitleCase .FunctionName }}"
       description: the name of the function handler
     function:
       protocol: grpc

--- a/riff-cli/test_data/riff-init/matching-invoker-with-output-topic/Dockerfile
+++ b/riff-cli/test_data/riff-init/matching-invoker-with-output-topic/Dockerfile
@@ -1,5 +1,5 @@
 FROM projectriff/python3-function-invoker:0.0.5-snapshot
 ARG FUNCTION_MODULE=echo.py
-ARG FUNCTION_HANDLER=matching-invoker-with-output-topic
+ARG FUNCTION_HANDLER=Matching-Invoker-With-Output-Topic
 ADD ./echo.py /
 ENV FUNCTION_URI file:///${FUNCTION_MODULE}?handler=${FUNCTION_HANDLER}

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/Dockerfile
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected-no-artifact/Dockerfile
@@ -1,5 +1,5 @@
 FROM projectriff/python3-function-invoker:0.0.5-snapshot
 ARG FUNCTION_MODULE=echo.py
-ARG FUNCTION_HANDLER=multiple-matching-invokers-with-one-selected-no-artifact
+ARG FUNCTION_HANDLER=Multiple-Matching-Invokers-With-One-Selected-No-Artifact
 ADD ./echo.py /
 ENV FUNCTION_URI file:///${FUNCTION_MODULE}?handler=${FUNCTION_HANDLER}

--- a/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected/Dockerfile
+++ b/riff-cli/test_data/riff-init/multiple-matching-invokers-with-one-selected/Dockerfile
@@ -1,5 +1,5 @@
 FROM projectriff/python3-function-invoker:0.0.5-snapshot
 ARG FUNCTION_MODULE=echo.py
-ARG FUNCTION_HANDLER=multiple-matching-invokers-with-one-selected
+ARG FUNCTION_HANDLER=Multiple-Matching-Invokers-With-One-Selected
 ADD ./echo.py /
 ENV FUNCTION_URI file:///${FUNCTION_MODULE}?handler=${FUNCTION_HANDLER}


### PR DESCRIPTION
A handler's config in an Invoker resources can be:

```yaml
handler:
  default: "{{ .TitleCase .FunctionName }}"
  description: the name of the function handler (name of Exported go function)
```

Issue: #427