### PR TITLE
Add kafka chart as a conditional dependency to riff chart

### DIFF
--- a/Development-Helm-install.adoc
+++ b/Development-Helm-install.adoc
@@ -32,33 +32,26 @@ Run the following command to see that the `riff` chart is available and also wha
 helm search riff -l
 ----
 
-== [[devel]]Install a riff development version on Minikube
+== [[devel]]Install a riff development version
 
-Starting with the 0.0.4 version we have separated the Kafka installation from the riff chart.
-This requires an extra step of installing Kafka in order yo use riff.
-You can use the single-node Kafka chart provided by riff or the three-node kafka/zookeeper service provided by the Kubeapps.
+We provide a lightweight single node Kafka installation with the `projectriff/kafka` chart. 
+This works well for development purposes and it can be installed together with the riff chart by providing `--set kafka.create=true` when installing the riff chart.
 
-=== Install Kafka chart
+=== Create riff-system namespace
 
-We provide a lightweight single node Kafka installation in the `projectriff/kafka` chart. This works well for development purposes.
+All riff components willbe deployed into a `riff-system` namespace. 
+Any functions that are developed can be deployed into any other namespace including the `default` namespace.
 
-Create the `riff-system` namespace:
+To create the `riff-system` namespace run:
 
 [source, bash]
 ----
 kubectl create namespace riff-system
 ----
 
-Install the kafka/zookeeper service provided by riff using:
-
-[source, bash]
-----
-helm install --name transport --namespace riff-system projectriff/kafka
-----
-
 [TIP]
 ====
-Alternatively, install the three-node kafka/zookeeper service provided by the Kubeapps `incubator/kafka` chart using:
+If you want to install Kafka using the three-node kafka/zookeeper service provided by the Kubeapps `incubator/kafka` chart, then you should use:
 
 [source, bash]
 ----
@@ -66,23 +59,61 @@ helm install --name transport --namespace riff-system incubator/kafka
 ----
 
 Just be aware that this chart requires significantly more resources to run.
+
+When you install the riff chart during the next step, you need to add some config settings so that the riff components can find the Kafka service.
+Add the following config settings instead of `--set kafka.create=true` to the `helm install` command that you use:
+
+[source, bash]
+----
+--set kafka.broker.nodes=transport-kafka.riff-system:9092 --set kafka.zookeeper.nodes=transport-zookeeper.riff-system:2181
+----
+
 ====
 
 === Install "devel" version of riff chart
 
+Choose one of the following installations options:
+
+- *Install "devel" version of riff chart with published snapshot builds of the components*
++
 Install the development version of the riff chart in the `riff-system` namespace.
 When using Minikube configure the httpGateway to use `NodePort` with:
-
++
 [source, bash]
 ----
-helm install --name control --namespace riff-system projectriff/riff --devel --set rbac.create=false --set httpGateway.service.type=NodePort
+helm install --name projectriff --namespace riff-system projectriff/riff --devel --set rbac.create=false --set kafka.create=true --set httpGateway.service.type=NodePort
 ----
-
++
 [NOTE]
 ====
 For a cluster that supports `LoadBalancer` leave out the `--set httpGateway.service.type=NodePort` option.
 For a cluster that uses RBAC leave out the `--set rbac.create=false` option.
 ====
+
+- *Install "devel" version of riff chart with locally built snapshot components with Minikube*
++
+Clone the https://github.com/projectriff/riff[riff] repository.
+The `helm install` commands in this section assume you are in the root directory of that project.
++
+[TIP]
+====
+
+Configure Docker to use the Docker environment running in minikube:
+
+[source, bash]
+----
+eval $(minikube docker-env)
+----
+====
++
+Build the riff components following the link:README.adoc#manual[manual build and deploy] instructions.
++
+To install locally built Docker images with Helm on minikube, use the `--devel` option which uses the chart version that has snapshot versions:
++
+[source, bash]
+----
+helm install projectriff/riff --name projectriff --namespace riff-system --devel --set rbac.create=false --set kafka.create=true --set httpGateway.service.type=NodePort
+----
 
 === Customizing the Installation
 
@@ -96,65 +127,40 @@ https://github.com/projectriff/riff/blob/master/helm-charts/riff/README.md#confi
 
 The following are some scenarios for customizing your installation:
 
-NOTE: The same commands work for all of the riff components: `functionController`, `topicController`, and `httpGateway`
+NOTE: The same customizations work for all of the riff components: `functionController`, `topicController`, and `httpGateway`
 
-* Overriding the version of a riff component:
+- *Overriding the version of a riff component:*
 +
 To set the version tag for the `functionController` to `0.0.5-build.1` use something like the following:
 +
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system --set functionController.image.tag=0.0.5-build.1 --devel --set rbac.create=false --set httpGateway.service.type=NodePort
+helm install projectriff/riff --name projectriff --namespace riff-system --set functionController.image.tag=0.0.5-build.1 --devel --set rbac.create=false --set kafka.create=true --set httpGateway.service.type=NodePort
 ----
 
-* Overriding the image repository and version tag of a riff component with a custom built component image:
+- *Overriding the image repository and version tag of a riff component with a custom built component image:*
 +
 To set the image repository to `mycustom/function-controller` and the version tag to `0.0.5-test.1` for
 the `functionController`, use something like the following:
 +
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system --set functionController.image.repository=mycustom/function-controller --set functionController.image.tag=0.0.5-test.1 --devel --set rbac.create=false --set httpGateway.service.type=NodePort
+helm install projectriff/riff --name projectriff --namespace riff-system --set functionController.image.repository=mycustom/function-controller --set functionController.image.tag=0.0.5-test.1 --devel --set rbac.create=false --set kafka.create=true --set httpGateway.service.type=NodePort
 ----
 
-* Overriding the version of the `sidecar` component:
+- *Overriding the version of the `sidecar` component:*
 +
 The `sidecar` component is only used by the `functionController`, so to set the version for
 the `sidecar` to `0.0.5-build.1` use something like the following:
 +
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system --set functionController.sidecar.image.tag=0.0.5-build.1 --devel --set rbac.create=false --set httpGateway.service.type=NodePort
-----
-
-==== Installing locally built snapshot components with Minikube
-
-Clone the https://github.com/projectriff/riff[riff] repository.
-The `helm install` commands in this section assume you are in the root directory of that project.
-
-[TIP]
-====
-
-Configure Docker to use the Docker environment running in minikube:
-
-[source, bash]
-----
-eval $(minikube docker-env)
-----
-====
-
-Build the riff components following the link:README.adoc#manual[manual build and deploy] instructions.
-
-To install locally built Docker images with Helm on minikube, use the `--devel` option which uses the chart version that has snapshot versions:
-
-[source, bash]
-----
-helm install projectriff/riff --name control --namespace riff-system --devel --set rbac.create=false --set httpGateway.service.type=NodePort
+helm install projectriff/riff --name projectriff --namespace riff-system --set functionController.sidecar.image.tag=0.0.5-build.1 --devel --set rbac.create=false --set kafka.create=true --set httpGateway.service.type=NodePort
 ----
 
 === To tear it all down
 
 [source, bash]
 ----
-helm delete --purge control
+helm delete --purge projectriff
 ----

--- a/Getting-Started.adoc
+++ b/Getting-Started.adoc
@@ -61,29 +61,24 @@ helm search riff -l
 
 == [[current]]Install the current riff release
 
-We have separated the Kafka installation from the riff chart. This requires an extra step of installing Kafka in order to use riff. You can use the single-node Kafka chart provided by riff or the three-node kafka/zookeeper service provided by Kubeapps.
+We provide a lightweight single node Kafka installation with the `projectriff/kafka` chart. 
+This works well for development purposes and it can be installed together with the riff chart by providing `--set kafka.create=true` when installing the riff chart.
 
-=== Install Kafka chart
+=== Create riff-system namespace
 
-We provide a lightweight single node Kafka installation in the `projectriff/kafka` chart. This works well for development purposes.
+All riff components willbe deployed into a `riff-system` namespace. 
+Any functions that are developed can be deployed into any other namespace including the `default` namespace.
 
-Create the `riff-system` namespace:
+To create the `riff-system` namespace run:
 
 [source, bash]
 ----
 kubectl create namespace riff-system
 ----
 
-Install the kafka/zookeeper service provided by riff using:
-
-[source, bash]
-----
-helm install --name transport --namespace riff-system projectriff/kafka
-----
-
 [TIP]
 ====
-Alternatively, install the three-node kafka/zookeeper service provided by the Kubeapps `incubator/kafka` chart using:
+If you want to install Kafka using the three-node kafka/zookeeper service provided by the Kubeapps `incubator/kafka` chart, then you should use:
 
 [source, bash]
 ----
@@ -91,6 +86,15 @@ helm install --name transport --namespace riff-system incubator/kafka
 ----
 
 Just be aware that this chart requires significantly more resources to run.
+
+When you install the riff chart during the next step, you need to add some config settings so that the riff components can find the Kafka service.
+Add the following config settings instead of `--set kafka.create=true` to the `helm install` command that you use:
+
+[source, bash]
+----
+--set kafka.broker.nodes=transport-kafka.riff-system:9092 --set kafka.zookeeper.nodes=transport-zookeeper.riff-system:2181
+----
+
 ====
 
 === Install riff using a Kubernetes cluster supporting LoadBalancer
@@ -101,7 +105,7 @@ For an install with default configuration and no RBAC enabled use:
 
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system --set rbac.create=false
+helm install projectriff/riff --name projectriff --namespace riff-system --set kafka.create=true --set rbac.create=false
 ----
 
 [NOTE]
@@ -110,7 +114,7 @@ For a cluster that has RBAC enabled, use the following (since `rbac.create` is `
 
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system
+helm install projectriff/riff --name projectriff --namespace riff-system --set kafka.create=true
 ----
 ====
 
@@ -120,7 +124,7 @@ For `NodePort` service types (e.g. running on Minikube) configure the httpGatewa
 
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system --set rbac.create=false --set httpGateway.service.type=NodePort
+helm install projectriff/riff --name projectriff --namespace riff-system --set kafka.create=true --set rbac.create=false --set httpGateway.service.type=NodePort
 ----
 
 [NOTE]
@@ -129,7 +133,7 @@ For a cluster that has RBAC enabled, use the following (since `rbac.create` is `
 
 [source, bash]
 ----
-helm install projectriff/riff --name control --namespace riff-system --set httpGateway.service.type=NodePort
+helm install projectriff/riff --name projectriff --namespace riff-system --set kafka.create=true --set httpGateway.service.type=NodePort
 ----
 ====
 
@@ -139,12 +143,16 @@ You should see a number of resources get created in your cluster. You can see th
 
 [source, bash]
 ----
-kubectl get svc,deployments,pods,functions,topics
+kubectl get -n riff-system crd,svc,deploy,pod
 ----
 
 === Components installed by the chart
 
 The provided Helm chart installs the following components:
+
+* CustomResourceDefinitions for invokers, functions and topics
+
+* Optional Kafka single-node development cluster with Zookeeper (can be substituted for external Kafka service)
 
 * Topic Controller - the controller that watches the Topic resources and creates new topics in Kafka
 
@@ -154,14 +162,14 @@ The provided Helm chart installs the following components:
 
 === To upgrade to a new version
 
-Assuming that you named your release `control` you can run the following command to upgrade to the latest released version:
+Assuming that you named your release `projectriff` you can run the following command to upgrade to the latest released version:
 
-TIP: Older instructions used `demo` for the release name and `riffrepo` as the name for riff's Helm repository. You should substitute `control` with `demo` and `projectriff/riff` with `riffrepo/riff` if you have an older riff install. Another option is to remove the old install using `helm delete --purge demo` and then follow the instructions link:Getting-Started.adoc#riff-repo[above] for installing the new version.
+TIP: Older instructions used `demo` for the release name and `riffrepo` as the name for riff's Helm repository. You should substitute `projectriff` with `demo` and `projectriff/riff` with `riffrepo/riff` if you have an older riff install. Another option is to remove the old install using `helm delete --purge demo` and then follow the instructions link:Getting-Started.adoc#riff-repo[above] for installing the new version.
 
 [source, bash]
 ----
 helm repo update
-helm upgrade control projectriff/riff
+helm upgrade projectriff projectriff/riff
 ----
 
 === To tear it all down
@@ -195,7 +203,6 @@ For the config file, you can create a `~/.riff.yaml` file with something like th
 riffVersion: 0.0.6-snapshot
 useraccount: myaccount
 namespace: test
-publishNamespace: riff-system
 ```
 
 === [[cli-completion]]riff CLI bash completion

--- a/helm-charts/riff/Chart.yaml
+++ b/helm-charts/riff/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: riff is for functions - a FaaS for Kubernetes
 name: riff
-version: 0.0.6-snapshot
+version: 0.0.0
 appVersion: 0.0.0
 home: https://projectriff.io/
 icon: https://raw.githubusercontent.com/projectriff/projectriff.io/master/images/riff.png

--- a/helm-charts/riff/Chart.yaml
+++ b/helm-charts/riff/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: riff is for functions - a FaaS for Kubernetes
 name: riff
-version: 0.0.0
+version: 0.0.6-snapshot
 appVersion: 0.0.0
 home: https://projectriff.io/
 icon: https://raw.githubusercontent.com/projectriff/projectriff.io/master/images/riff.png

--- a/helm-charts/riff/README.md
+++ b/helm-charts/riff/README.md
@@ -5,18 +5,19 @@
 
 ## Installing the Chart
 
-To install the chart with the release name `my-release`:
+To install the chart with the release name `projectriff` in the `riff-system` namespace:
 
 ```bash
 $ helm repo add projectriff https://riff-charts.storage.googleapis.com
 $ helm repo update
-$ helm install --name my-release projectriff/riff
+$ kubectl create namespace riff-system
+$ helm install --name projectriff --namespace riff-system projectriff/riff
 ```
 
 If you are using a cluster that does not have a load balancer (like Minikube) then you can install using a NodePort:
 
 ```bash
-$ helm install --name my-release --set httpGateway.service.type=NodePort projectriff/riff
+$ helm install --name projectriff --namespace riff-system --set httpGateway.service.type=NodePort projectriff/riff
 ```
 
 ## Configuration
@@ -25,6 +26,8 @@ The following lists the configurable parameters and their default values.
 
 | Parameter               | Description                            | Default                   |
 | ----------------------- | -------------------------------------- | ------------------------- |
+| `rbac.create`|Specifies whether RBAC resources should be created|true|
+| `kafka.create`|Specifies whether the single-node development Kafka chart should be installed|false|
 | `functionController.image.tag`|The image tag for the function-controller|latest|
 | `functionController.image.pullPolicy`|The imagePullPolicy for the function-controller|IfNotPresent|
 | `functionController.sidecar.image.tag`|The image tag for the sidecar used|latest|
@@ -38,7 +41,7 @@ The following lists the configurable parameters and their default values.
 
 ## Uninstalling the Release
 
-To remove the chart release with the name `my-release` and purge all the release info use:
+To remove the chart release with the name `projectriff` and purge all the release info use:
 
 ```bash
 $ helm delete --purge my-release

--- a/helm-charts/riff/requirements.lock
+++ b/helm-charts/riff/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kafka
+  repository: https://riff-charts.storage.googleapis.com/
+  version: 0.0.2
+digest: sha256:297fc2285ddd154c324ab7faa4f75047d5d0cd7a2e485127df1b111f59e8bc85
+generated: 2018-03-29T11:05:17.727193-04:00

--- a/helm-charts/riff/requirements.yaml
+++ b/helm-charts/riff/requirements.yaml
@@ -1,0 +1,6 @@
+dependencies:
+- name: kafka
+  version: 0.0.2
+  repository: https://riff-charts.storage.googleapis.com/
+  condition: kafka.create
+

--- a/helm-charts/riff/values.yaml
+++ b/helm-charts/riff/values.yaml
@@ -10,6 +10,10 @@ rbac:
   create: true
   apiVersion: v1beta1
 
+kafka:
+  # Specifies whether the single-node development Kafka chart should be installed
+  create: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -49,6 +53,6 @@ httpGateway:
 
 kafka:
   broker:
-    nodes: transport-kafka.riff-system:9092
+    nodes: projectriff-kafka.riff-system:9092
   zookeeper:
-    nodes: transport-zookeeper.riff-system:2181
+    nodes: projectriff-zookeeper.riff-system:2181


### PR DESCRIPTION
- set projectriff/kafka dependency to version `0.0.2`

- new flag to turn on the kafka install: `--set kafka.create=true` (default is false, so this makes it opt-in as suggested)

- this eliminates the separate transport release

- changing the release name to be projectriff instead of control

- updating Getting-Started and Development-Helm-install docs

Fixes: #477