### PR TITLE
Use proper name for CRD backed resources

### DIFF
--- a/riff-cli/cmd/delete.go
+++ b/riff-cli/cmd/delete.go
@@ -86,7 +86,7 @@ func deleteFunctionByName(opts DeleteOptions, actingClient kubectl.KubeCtl, quer
 		if inputTopic, outputTopic, err := lookupTopicNames(opts, queryClient); err != nil {
 			return err
 		} else {
-			cmdArgs := []string{"delete", "topic", "<placeholder>"}
+			cmdArgs := []string{"delete", "topics.projectriff.io", "<placeholder>"}
 			if opts.Namespace != "" {
 				cmdArgs = append(cmdArgs, "--namespace", opts.Namespace)
 			}
@@ -105,7 +105,7 @@ func deleteFunctionByName(opts DeleteOptions, actingClient kubectl.KubeCtl, quer
 		}
 	}
 
-	cmdArgs := []string{"delete", "function", opts.FunctionName}
+	cmdArgs := []string{"delete", "functions.projectriff.io", opts.FunctionName}
 	if opts.Namespace != "" {
 		cmdArgs = append(cmdArgs, "--namespace", opts.Namespace)
 	}
@@ -128,7 +128,7 @@ func lookupTopicNames(opts DeleteOptions, queryClient kubectl.KubeCtl) (string, 
 	if opts.Namespace != "" {
 		getArgs = append(getArgs, "--namespace", opts.Namespace)
 	}
-	getArgs = append(getArgs, "function", opts.FunctionName, "-o", "json")
+	getArgs = append(getArgs, "functions.projectriff.io", opts.FunctionName, "-o", "json")
 	json, err := queryClient.Exec(getArgs)
 	if err != nil {
 		return "", "", err

--- a/riff-cli/cmd/delete_test.go
+++ b/riff-cli/cmd/delete_test.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
 	"github.com/spf13/cobra"
-	"fmt"
 )
 
 var _ = Describe("The delete command", func() {
@@ -58,7 +59,7 @@ var _ = Describe("The delete command", func() {
 
 		It("should delete the function based on dirname", func() {
 
-			realKubeCtl.On("Exec", []string{"delete", "function", "echo"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "echo"}).Return("", nil)
 
 			err := deleteCmd.Execute()
 			Expect(err).NotTo(HaveOccurred())
@@ -68,17 +69,16 @@ var _ = Describe("The delete command", func() {
 		It("should delete the function and topic when run with --all", func() {
 
 			deleteCmd.SetArgs([]string{"--all"})
-			realKubeCtl.On("Exec", []string{"delete", "function", "echo"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "echo"}).Return("", nil)
 
-			realKubeCtl.On("Exec", []string{"get", "function", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
-			realKubeCtl.On("Exec", []string{"delete", "topic", "myInputTopic"}).Return("", nil)
-			realKubeCtl.On("Exec", []string{"delete", "topic", "myOutputTopic"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"get", "functions.projectriff.io", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic"}).Return("", nil)
 
 			err := deleteCmd.Execute()
 			Expect(err).NotTo(HaveOccurred())
 
 		})
-
 
 		Context("when --namespace is set", func() {
 			BeforeEach(func() {
@@ -87,7 +87,7 @@ var _ = Describe("The delete command", func() {
 			It("should delete the function based on dirname", func() {
 
 				deleteCmd.SetArgs(args)
-				realKubeCtl.On("Exec", []string{"delete", "function", "echo", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "echo", "--namespace", "my-ns"}).Return("", nil)
 
 				err := deleteCmd.Execute()
 				Expect(err).NotTo(HaveOccurred())
@@ -98,11 +98,11 @@ var _ = Describe("The delete command", func() {
 
 				args = append(args, "--all")
 				deleteCmd.SetArgs(args)
-				realKubeCtl.On("Exec", []string{"delete", "function", "echo", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "echo", "--namespace", "my-ns"}).Return("", nil)
 
-				realKubeCtl.On("Exec", []string{"get", "--namespace", "my-ns", "function", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
-				realKubeCtl.On("Exec", []string{"delete", "topic", "myInputTopic", "--namespace", "my-ns"}).Return("", nil)
-				realKubeCtl.On("Exec", []string{"delete", "topic", "myOutputTopic", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"get", "--namespace", "my-ns", "functions.projectriff.io", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
+				realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic", "--namespace", "my-ns"}).Return("", nil)
 
 				err := deleteCmd.Execute()
 				Expect(err).NotTo(HaveOccurred())
@@ -120,7 +120,7 @@ var _ = Describe("The delete command", func() {
 		It("should delete the function based on name", func() {
 			deleteCmd.SetArgs(args)
 
-			realKubeCtl.On("Exec", []string{"delete", "function", "my-function"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "my-function"}).Return("", nil)
 
 			err := deleteCmd.Execute()
 			Expect(err).NotTo(HaveOccurred())
@@ -132,17 +132,16 @@ var _ = Describe("The delete command", func() {
 			args = append(args, "--all")
 			deleteCmd.SetArgs(args)
 
-			realKubeCtl.On("Exec", []string{"delete", "function", "my-function"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "my-function"}).Return("", nil)
 
-			realKubeCtl.On("Exec", []string{"get", "function", "my-function", "-o", "json"}).Return(canned_kubectl_get_response, nil)
-			realKubeCtl.On("Exec", []string{"delete", "topic", "myInputTopic"}).Return("", nil)
-			realKubeCtl.On("Exec", []string{"delete", "topic", "myOutputTopic"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"get", "functions.projectriff.io", "my-function", "-o", "json"}).Return(canned_kubectl_get_response, nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic"}).Return("", nil)
 
 			err := deleteCmd.Execute()
 			Expect(err).NotTo(HaveOccurred())
 
 		})
-
 
 		Context("when --namespace is set", func() {
 			BeforeEach(func() {
@@ -151,7 +150,7 @@ var _ = Describe("The delete command", func() {
 			It("should delete the function based on name", func() {
 
 				deleteCmd.SetArgs(args)
-				realKubeCtl.On("Exec", []string{"delete", "function", "my-function", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "my-function", "--namespace", "my-ns"}).Return("", nil)
 
 				err := deleteCmd.Execute()
 				Expect(err).NotTo(HaveOccurred())
@@ -162,11 +161,11 @@ var _ = Describe("The delete command", func() {
 
 				args = append(args, "--all")
 				deleteCmd.SetArgs(args)
-				realKubeCtl.On("Exec", []string{"delete", "function", "my-function", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "my-function", "--namespace", "my-ns"}).Return("", nil)
 
-				realKubeCtl.On("Exec", []string{"get", "--namespace", "my-ns", "function", "my-function", "-o", "json"}).Return(canned_kubectl_get_response, nil)
-				realKubeCtl.On("Exec", []string{"delete", "topic", "myInputTopic", "--namespace", "my-ns"}).Return("", nil)
-				realKubeCtl.On("Exec", []string{"delete", "topic", "myOutputTopic", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"get", "--namespace", "my-ns", "functions.projectriff.io", "my-function", "-o", "json"}).Return(canned_kubectl_get_response, nil)
+				realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic", "--namespace", "my-ns"}).Return("", nil)
+				realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic", "--namespace", "my-ns"}).Return("", nil)
 
 				err := deleteCmd.Execute()
 				Expect(err).NotTo(HaveOccurred())
@@ -179,7 +178,7 @@ var _ = Describe("The delete command", func() {
 	It("should report kubectl errors", func() {
 		deleteCmd.SetArgs([]string{"--name", "whatever"})
 
-		realKubeCtl.On("Exec", []string{"delete", "function", "whatever"}).Return("", fmt.Errorf("Whoops"))
+		realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "whatever"}).Return("", fmt.Errorf("Whoops"))
 
 		err := deleteCmd.Execute()
 		Expect(err).To(MatchError("Whoops"))
@@ -189,7 +188,7 @@ var _ = Describe("The delete command", func() {
 	It("should not use the real kubectl client when using --dry-run", func() {
 		deleteCmd.SetArgs([]string{"--name", "whatever", "--dry-run"})
 
-		dryRunKubeCtl.On("Exec", []string{"delete", "function", "whatever"}).Return("", nil)
+		dryRunKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "whatever"}).Return("", nil)
 
 		err := deleteCmd.Execute()
 		Expect(err).NotTo(HaveOccurred())

--- a/riff-cli/cmd/invokers.go
+++ b/riff-cli/cmd/invokers.go
@@ -109,7 +109,7 @@ func InvokersList(kubeCtl kubectl.KubeCtl) *cobra.Command {
 		Short: "List invokers in the cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kubeCtlArgs := append([]string{
-				"get", "invokers",
+				"get", "invokers.projectriff.io",
 				"--sort-by=metadata.name",
 				"-o=custom-columns=NAME:.metadata.name,VERSION:.spec.version",
 			}, args...)
@@ -139,7 +139,7 @@ func InvokersDelete(kubeCtl kubectl.KubeCtl) (*cobra.Command, *InvokersDeleteOpt
 		Short: "Remove an invoker from the cluster",
 		Args:  utils.AliasFlagToSoleArg("name"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var kubeCtlArgs = []string{"delete", "invokers"}
+			var kubeCtlArgs = []string{"delete", "invokers.projectriff.io"}
 			if invokersDeleteOptions.All {
 				kubeCtlArgs = append(kubeCtlArgs, "--all")
 			} else if invokersDeleteOptions.Name == "" {

--- a/riff-cli/cmd/invokers_test.go
+++ b/riff-cli/cmd/invokers_test.go
@@ -206,7 +206,7 @@ var _ = Describe("The invokers commands", func() {
 			normalKubeCtl.On(
 				"Exec",
 				[]string{
-					"get", "invokers",
+					"get", "invokers.projectriff.io",
 					"--sort-by=metadata.name",
 					"-o=custom-columns=NAME:.metadata.name,VERSION:.spec.version",
 				},
@@ -223,7 +223,7 @@ var _ = Describe("The invokers commands", func() {
 		It("removes the specified invoker", func() {
 			rootCommand.SetArgs([]string{"invokers", "delete", "command"})
 
-			normalKubeCtl.On("Exec", []string{"delete", "invokers", "command"}).Return("", nil).Once()
+			normalKubeCtl.On("Exec", []string{"delete", "invokers.projectriff.io", "command"}).Return("", nil).Once()
 
 			err := rootCommand.Execute()
 			Expect(err).NotTo(HaveOccurred())
@@ -235,7 +235,7 @@ var _ = Describe("The invokers commands", func() {
 		It("removes all invokers", func() {
 			rootCommand.SetArgs([]string{"invokers", "delete", "--all"})
 
-			normalKubeCtl.On("Exec", []string{"delete", "invokers", "--all"}).Return("", nil).Once()
+			normalKubeCtl.On("Exec", []string{"delete", "invokers.projectriff.io", "--all"}).Return("", nil).Once()
 
 			err := rootCommand.Execute()
 			Expect(err).NotTo(HaveOccurred())

--- a/riff-cli/cmd/list.go
+++ b/riff-cli/cmd/list.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,16 +19,16 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
 	"github.com/projectriff/riff/riff-cli/cmd/utils"
+	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
+	"github.com/spf13/cobra"
 )
 
 type ListOptions struct {
 	namespace string
 }
 
-func List() *cobra.Command {
+func List(kubeCtl kubectl.KubeCtl) *cobra.Command {
 
 	var listOptions ListOptions
 	// listCmd represents the list command
@@ -52,9 +52,9 @@ func List() *cobra.Command {
 			if listOptions.namespace != "" {
 				cmdArgs = append(cmdArgs, "--namespace", listOptions.namespace)
 			}
-			cmdArgs = append(cmdArgs, "functions")
+			cmdArgs = append(cmdArgs, "functions.projectriff.io")
 
-			output, err := kubectl.ExecForString(cmdArgs)
+			output, err := kubeCtl.Exec(cmdArgs)
 
 			if err != nil {
 				return err

--- a/riff-cli/cmd/logs.go
+++ b/riff-cli/cmd/logs.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,12 +17,13 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
+	"bufio"
 	"fmt"
 	"os/exec"
-	"bufio"
+
 	"github.com/projectriff/riff/riff-cli/cmd/utils"
 	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
+	"github.com/spf13/cobra"
 )
 
 type LogsOptions struct {
@@ -32,7 +33,7 @@ type LogsOptions struct {
 	tail      bool
 }
 
-func Logs() *cobra.Command {
+func Logs(kubeCtl kubectl.KubeCtl) *cobra.Command {
 
 	var logsOptions LogsOptions
 
@@ -40,8 +41,8 @@ func Logs() *cobra.Command {
 	var logsCmd = &cobra.Command{
 		Use:   "logs",
 		Short: "Display the logs for a running function",
-		Long: `Display the logs for a running function`,
-		Example:`
+		Long:  `Display the logs for a running function`,
+		Example: `
     riff logs -n myfunc -t
 
 will tail the logs from the 'sidecar' container for the function 'myfunc'
@@ -58,9 +59,9 @@ will tail the logs from the 'sidecar' container for the function 'myfunc'
 			if logsOptions.namespace != "" {
 				cmdArgs = append(cmdArgs, "--namespace", logsOptions.namespace)
 			}
-			cmdArgs = append(cmdArgs, "pod", "-l", "function=" + logsOptions.function, "-o", "jsonpath={.items[0].metadata.name}")
+			cmdArgs = append(cmdArgs, "pod", "-l", "function="+logsOptions.function, "-o", "jsonpath={.items[0].metadata.name}")
 
-			output, err := kubectl.ExecForString(cmdArgs)
+			output, err := kubeCtl.Exec(cmdArgs)
 
 			if err != nil {
 				return fmt.Errorf("Error %v - Function %v may not be currently active", err, logsOptions.function)
@@ -101,7 +102,7 @@ will tail the logs from the 'sidecar' container for the function 'myfunc'
 
 			} else {
 
-				output, err := kubectl.ExecForString(cmdArgs)
+				output, err := kubeCtl.Exec(cmdArgs)
 
 				if err != nil {
 					return err

--- a/riff-cli/cmd/wiring.go
+++ b/riff-cli/cmd/wiring.go
@@ -23,15 +23,15 @@ import (
 	"github.com/projectriff/riff/riff-cli/pkg/docker"
 	"github.com/projectriff/riff/riff-cli/pkg/initializer"
 	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
-	"github.com/spf13/cobra"
 	"github.com/projectriff/riff/riff-cli/pkg/minikube"
+	"github.com/spf13/cobra"
 )
 
 // CreateAndWireRootCommand creates all riff commands and sub commands, as well as the top-level 'root' command,
 // wires them together and returns the root command, ready to execute.
 func CreateAndWireRootCommand(realDocker docker.Docker, dryRunDocker docker.Docker,
 	realKubeCtl kubectl.KubeCtl, dryRunKubeCtl kubectl.KubeCtl,
-		minik minikube.Minikube) (*cobra.Command, error) {
+	minik minikube.Minikube) (*cobra.Command, error) {
 
 	invokers, err := initializer.LoadInvokers(realKubeCtl)
 	if err != nil {
@@ -69,8 +69,8 @@ func CreateAndWireRootCommand(realDocker docker.Docker, dryRunDocker docker.Dock
 		createCmd,
 		deleteCmd,
 		initCmd,
-		List(),
-		Logs(),
+		List(realKubeCtl),
+		Logs(realKubeCtl),
 		Publish(realKubeCtl, minik),
 		Update(buildCmd, applyCmd),
 		invokersCmd,

--- a/riff-cli/pkg/kubectl/kubectl.go
+++ b/riff-cli/pkg/kubectl/kubectl.go
@@ -24,9 +24,6 @@ import (
 	"github.com/projectriff/riff/riff-cli/pkg/osutils"
 )
 
-var EXEC_FOR_STRING = ExecForString
-var EXEC_FOR_BYTES = ExecForBytes
-
 //go:generate mockery -name=KubeCtl -inpkg
 type KubeCtl interface {
 	Exec(cmdArgs []string) (string, error)
@@ -68,13 +65,4 @@ func RealKubeCtl() KubeCtl {
 
 func DryRunKubeCtl() KubeCtl {
 	return &dryRunKubeCtl{}
-}
-
-func ExecForString(cmdArgs []string) (string, error) {
-	out, err := EXEC_FOR_BYTES(cmdArgs)
-	return string(out), err
-}
-
-func ExecForBytes(cmdArgs []string) ([]byte, error) {
-	return osutils.Exec("kubectl", cmdArgs, 20*time.Second)
 }


### PR DESCRIPTION
function -> functions.projectriff.io
topic -> topics.projectriff.io
invoker -> invokers.projectriff.io

Also cleans up linguring use of non-mocked kubectl APIs.

Fixes #486