### PR TITLE
Set the riff chart version to a non-zero value

### DIFF
--- a/helm-charts/riff/Chart.yaml
+++ b/helm-charts/riff/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: riff is for functions - a FaaS for Kubernetes
 name: riff
-version: 0.0.0
+version: 0.0.0-snapshot
 appVersion: 0.0.0
 home: https://projectriff.io/
 icon: https://raw.githubusercontent.com/projectriff/projectriff.io/master/images/riff.png


### PR DESCRIPTION
- this will allow us to lint and install the chart from the local file system for testing