### PR TITLE
Create helper template functions for kafka and zookeeper nodes

### DIFF
--- a/helm-charts/riff/templates/_helpers.tpl
+++ b/helm-charts/riff/templates/_helpers.tpl
@@ -22,7 +22,7 @@ Create the list of kafka broker nodes to use
 {{- if .Values.kafka.create -}}
     {{ default ( printf "%s-%s.%s:9092" .Release.Name "kafka" .Release.Namespace ) .Values.kafka.broker.nodes }}
 {{- else -}}
-    {{ .Values.kafka.broker.nodes }}
+    {{ required "A valid .Values.kafka.broker.nodes entry required!" .Values.kafka.broker.nodes }}
 {{- end -}}
 {{- end -}}
 
@@ -33,7 +33,7 @@ Create the list of kafka zookeeper nodes to use
 {{- if .Values.kafka.create -}}
     {{ default ( printf "%s-%s.%s:2181" .Release.Name "zookeeper" .Release.Namespace ) .Values.kafka.zookeeper.nodes }}
 {{- else -}}
-    {{ .Values.kafka.zookeeper.nodes }}
+    {{ required "A valid .Values.kafka.zookeeper.nodes entry required!" .Values.kafka.zookeeper.nodes }}
 {{- end -}}
 {{- end -}}
 

--- a/helm-charts/riff/templates/_helpers.tpl
+++ b/helm-charts/riff/templates/_helpers.tpl
@@ -16,6 +16,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create the list of kafka broker nodes to use
+*/}}
+{{- define "riff.kafkaBrokers" -}}
+{{- if .Values.kafka.create -}}
+    {{ default ( printf "%s-%s.%s:9092" .Release.Name "kafka" .Release.Namespace ) .Values.kafka.broker.nodes }}
+{{- else -}}
+    {{ .Values.kafka.broker.nodes }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the list of kafka zookeeper nodes to use
+*/}}
+{{- define "riff.kafkaZkNodes" -}}
+{{- if .Values.kafka.create -}}
+    {{ default ( printf "%s-%s.%s:2181" .Release.Name "zookeeper" .Release.Namespace ) .Values.kafka.zookeeper.nodes }}
+{{- else -}}
+    {{ .Values.kafka.zookeeper.nodes }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "riff.serviceAccountName" -}}

--- a/helm-charts/riff/templates/function-controller-deployment.yaml
+++ b/helm-charts/riff/templates/function-controller-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - containerPort: 8080
           env:
           - name: KAFKA_BROKERS
-            value: {{ .Values.kafka.broker.nodes }}
+            value: {{ template "riff.kafkaBrokers" . }}
           - name: RIFF_FUNCTION_SIDECAR_REPOSITORY
             value: {{ .Values.functionController.sidecar.image.repository }}
           - name: RIFF_FUNCTION_SIDECAR_TAG

--- a/helm-charts/riff/templates/http-gateway-deployment.yaml
+++ b/helm-charts/riff/templates/http-gateway-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - containerPort: 8080
           env:
           - name: KAFKA_BROKERS
-            value: {{ .Values.kafka.broker.nodes }}
+            value: {{ template "riff.kafkaBrokers" . }}
           - name: RIFF_HTTP_HEADERS_WHITELIST
             value: {{ .Values.httpGateway.httpHeadersWhitelist }}
       serviceAccountName: {{ template "riff.serviceAccountName" . }}

--- a/helm-charts/riff/templates/topic-controller-deployment.yaml
+++ b/helm-charts/riff/templates/topic-controller-deployment.yaml
@@ -37,6 +37,6 @@ spec:
             - containerPort: 8080
           env:
           - name: KAFKA_ZK_NODES
-            value: {{ .Values.kafka.zookeeper.nodes }}
+            value: {{ template "riff.kafkaZkNodes" . }}
       serviceAccountName: {{ template "riff.serviceAccountName" . }}
 {{- end -}}

--- a/helm-charts/riff/values.yaml
+++ b/helm-charts/riff/values.yaml
@@ -51,6 +51,6 @@ kafka:
   # Specifies whether the single-node development Kafka chart should be installed
   create: false
   broker:
-    nodes: projectriff-kafka.riff-system:9092
+    nodes: null
   zookeeper:
-    nodes: projectriff-zookeeper.riff-system:2181
+    nodes: null


### PR DESCRIPTION
- will use release name as part of default

- can be overridden by `kafka.broker.nodes` and `kafka.zookeeper.nodes` values

Fixes #506