### PR TITLE
Show 404s for missing topics

### DIFF
--- a/http-gateway/cmd/http-gateway.go
+++ b/http-gateway/cmd/http-gateway.go
@@ -53,7 +53,12 @@ func main() {
 	}
 	defer consumer.Close()
 
-	gw := server.New(8080, producer, consumer, 60*time.Second)
+	topicHelper, err := server.NewTopicHelper()
+	if err != nil {
+		panic(err)
+	}
+
+	gw := server.New(8080, producer, consumer, 60*time.Second, topicHelper)
 
 	done := make(chan struct{})
 	gw.Run(done)

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -62,7 +62,7 @@ var _ = Describe("HTTP Gateway", func() {
 	JustBeforeEach(func() {
 		port = 1024 + rand.Intn(32768-1024)
 
-		gw = server.New(port, mockProducer, stubConsumer, timeout, &stubTopicHelper{testName: "bar"})
+		gw = server.New(port, mockProducer, stubConsumer, timeout, &stubTopicHelper{testName: "testtopic"})
 
 		gw.Run(done)
 
@@ -75,7 +75,7 @@ var _ = Describe("HTTP Gateway", func() {
 
 	It("should request/reply OK", func() {
 
-		mockProducer.On("Send", "foo", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		mockProducer.On("Send", "testtopic", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			defer GinkgoRecover()
 			msg := args[1].(message.Message)
 			stubConsumer.Send(message.NewMessage([]byte("hello "+string(msg.Payload())),
@@ -86,7 +86,7 @@ var _ = Describe("HTTP Gateway", func() {
 			Expect(msg.Headers()["Not-Propagated-Header"]).To(BeNil())
 		})
 
-		resp := doRequest(port, "foo", bytes.NewBufferString("world"), "Content-Type", "text/solid", "Not-Propagated-Header", "secret")
+		resp := doRequest(port, "testtopic", bytes.NewBufferString("world"), "Content-Type", "text/solid", "Not-Propagated-Header", "secret")
 
 		b := make([]byte, 11)
 		resp.Body.Read(b)
@@ -100,7 +100,7 @@ var _ = Describe("HTTP Gateway", func() {
 
 	It("should accept messages and fire&forget", func() {
 
-		mockProducer.On("Send", "bar", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		mockProducer.On("Send", "testtopic", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			defer GinkgoRecover()
 			msg := args[1].(message.Message)
 			Expect(msg.Payload()).To(Equal([]byte("world")))
@@ -108,7 +108,7 @@ var _ = Describe("HTTP Gateway", func() {
 			Expect(msg.Headers()["Not-Propagated-Header"]).To(BeNil())
 		})
 
-		resp := doMessage(port, "bar", bytes.NewBufferString("world"), "Content-Type", "text/solid", "Not-Propagated-Header", "secret")
+		resp := doMessage(port, "testtopic", bytes.NewBufferString("world"), "Content-Type", "text/solid", "Not-Propagated-Header", "secret")
 
 		Expect(resp.StatusCode).To(Equal(200))
 

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -29,19 +29,19 @@ import (
 	"github.com/projectriff/riff/http-gateway/pkg/server"
 	"github.com/projectriff/riff/message-transport/pkg/message"
 	"github.com/projectriff/riff/message-transport/pkg/transport/mocktransport"
-	"github.com/stretchr/testify/mock"
 	"github.com/projectriff/riff/message-transport/pkg/transport/stubtransport"
+	"github.com/stretchr/testify/mock"
 )
 
 var _ = Describe("HTTP Gateway", func() {
 	var (
-		gw               server.Gateway
-		mockProducer     *mocktransport.Producer
-		stubConsumer     stubtransport.ConsumerStub
-		port             int
-		timeout          time.Duration
-		done             chan struct{}
-		producerErrors   chan error
+		gw             server.Gateway
+		mockProducer   *mocktransport.Producer
+		stubConsumer   stubtransport.ConsumerStub
+		port           int
+		timeout        time.Duration
+		done           chan struct{}
+		producerErrors chan error
 	)
 
 	BeforeEach(func() {
@@ -61,7 +61,8 @@ var _ = Describe("HTTP Gateway", func() {
 
 	JustBeforeEach(func() {
 		port = 1024 + rand.Intn(32768-1024)
-		gw = server.New(port, mockProducer, stubConsumer, timeout)
+
+		gw = server.New(port, mockProducer, stubConsumer, timeout, &stubTopicHelper{testName: "bar"})
 
 		gw.Run(done)
 
@@ -147,4 +148,12 @@ func waitForHttpGatewayToBeReady(port int) {
 		_, err := http.Get(url)
 		return err
 	}, timeoutDuration, pollingInterval).Should(Succeed())
+}
+
+type stubTopicHelper struct {
+	testName string
+}
+
+func (sth *stubTopicHelper) TopicExists(topicName string) bool {
+	return topicName == sth.testName
 }

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/projectriff/riff/message-transport/pkg/message"
+
 	"github.com/satori/go.uuid"
 )
 
@@ -36,7 +37,7 @@ var outgoingHeadersToPropagate = [...]string{ContentType}
 // Function requestHandler is an http handler that sends the http body to the producer, then waits
 // for a message on a go channel it creates for a reply and sends that as an http response.
 func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
-	topic, err := parseTopic(r, requestPath)
+	topicName, err := parseTopic(r, requestPath)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
@@ -56,7 +57,7 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 	headers := propagateIncomingHeaders(r)
 	headers[CorrelationId] = []string{correlationId}
 
-	err = g.producer.Send(topic, message.NewMessage(b, headers))
+	err = g.producer.Send(topicName, message.NewMessage(b, headers))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -17,7 +17,9 @@
 package server
 
 import (
+	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
@@ -40,6 +42,13 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 	topicName, err := parseTopic(r, requestPath)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if !g.topicHelper.TopicExists(topicName) {
+		errMsg := fmt.Sprintf("could not find topic '%s'", topicName)
+		log.Printf(errMsg)
+		http.Error(w, errMsg, http.StatusNotFound)
 		return
 	}
 

--- a/http-gateway/pkg/server/requests_handler_test.go
+++ b/http-gateway/pkg/server/requests_handler_test.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/projectriff/riff/message-transport/pkg/message"
 	"github.com/projectriff/riff/message-transport/pkg/transport/mocktransport"
-	"github.com/stretchr/testify/mock"
 	"github.com/projectriff/riff/message-transport/pkg/transport/stubtransport"
+	"github.com/stretchr/testify/mock"
 )
 
 var _ = Describe("RequestsHandler", func() {
@@ -69,7 +69,8 @@ var _ = Describe("RequestsHandler", func() {
 	})
 
 	JustBeforeEach(func() {
-		gateway = New(8080, mockProducer, stubConsumer, timeout)
+		gateway = New(8080, mockProducer, stubConsumer, timeout, &stubTopicHelper{})
+
 		go gateway.repliesLoop(done)
 		gateway.requestsHandler(mockResponseWriter, req)
 	})

--- a/http-gateway/pkg/server/requests_handler_test.go
+++ b/http-gateway/pkg/server/requests_handler_test.go
@@ -69,7 +69,7 @@ var _ = Describe("RequestsHandler", func() {
 	})
 
 	JustBeforeEach(func() {
-		gateway = New(8080, mockProducer, stubConsumer, timeout, &stubTopicHelper{})
+		gateway = New(8080, mockProducer, stubConsumer, timeout, &stubTopicHelper{testName: "testtopic"})
 
 		go gateway.repliesLoop(done)
 		gateway.requestsHandler(mockResponseWriter, req)
@@ -82,6 +82,17 @@ var _ = Describe("RequestsHandler", func() {
 	Context("when the request URL is unexpected", func() {
 		BeforeEach(func() {
 			req.URL.Path = "/short"
+		})
+
+		It("should return a 404", func() {
+			resp := mockResponseWriter.Result()
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Context("when the request refers to a non-existent Riff Topic", func() {
+		BeforeEach(func() {
+			req.URL.Path = "/requests/nosuchtopicexists"
 		})
 
 		It("should return a 404", func() {

--- a/http-gateway/pkg/server/topic_helper.go
+++ b/http-gateway/pkg/server/topic_helper.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"log"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/glog"
+	riffcs "github.com/projectriff/riff/kubernetes-crds/pkg/client/clientset/versioned"
+
+	"k8s.io/client-go/rest"
+)
+
+type TopicHelper interface {
+	TopicExists(topicName string) bool
+}
+
+type topicHelper struct {
+	client *riffcs.Clientset
+}
+
+func NewTopicHelper() (*topicHelper, error) {
+	restConf, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	riffClient, err := riffcs.NewForConfig(restConf)
+	if err != nil {
+		glog.Fatalf("Error building riff clientset: %s", err.Error())
+	}
+
+	return &topicHelper{client: riffClient}, nil
+
+}
+
+func (tw *topicHelper) TopicExists(topicName string) bool {
+	_, err := tw.client.ProjectriffV1alpha1().Topics("default").Get(topicName, v1.GetOptions{})
+
+	if err != nil {
+		log.Printf("%s\n", err)
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Intended to resolve #410.

These changes add topic-awareness to the `http-gateway`, so that it returns 404 errors for messages or requests that refer to non-existent topics.