### PR TITLE
Improve 404 topic code

### DIFF
--- a/http-gateway/cmd/http-gateway.go
+++ b/http-gateway/cmd/http-gateway.go
@@ -24,12 +24,13 @@ import (
 	"syscall"
 	"time"
 
+	"io"
+
 	"github.com/bsm/sarama-cluster"
 	"github.com/projectriff/riff/http-gateway/pkg/server"
 	"github.com/projectriff/riff/message-transport/pkg/transport/kafka"
 	"github.com/projectriff/riff/message-transport/pkg/transport/metrics/kafka_over_kafka"
 	"github.com/satori/go.uuid"
-	"io"
 )
 
 func main() {
@@ -40,12 +41,11 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer func(){
+	defer func() {
 		if producer, ok := producer.(io.Closer); ok {
 			producer.Close()
 		}
 	}()
-
 
 	consumer, err := kafka.NewConsumer(brokers, "gateway", []string{"replies"}, cluster.NewConfig())
 	if err != nil {
@@ -53,12 +53,12 @@ func main() {
 	}
 	defer consumer.Close()
 
-	topicHelper, err := server.NewTopicHelper()
+	riffTopicExistenceChecker, err := server.NewRiffTopicExistenceChecker()
 	if err != nil {
 		panic(err)
 	}
 
-	gw := server.New(8080, producer, consumer, 60*time.Second, topicHelper)
+	gw := server.New(8080, producer, consumer, 60*time.Second, riffTopicExistenceChecker)
 
 	done := make(chan struct{})
 	gw.Run(done)

--- a/http-gateway/pkg/server/gateway.go
+++ b/http-gateway/pkg/server/gateway.go
@@ -33,13 +33,13 @@ type Gateway interface {
 }
 
 type gateway struct {
-	httpServer       *http.Server
-	consumer         transport.Consumer
-	consumerMessages chan message.Message
-	producer         transport.Producer
-	replies          *repliesMap
-	timeout          time.Duration
-	topicHelper      TopicHelper
+	httpServer                *http.Server
+	consumer                  transport.Consumer
+	consumerMessages          chan message.Message
+	producer                  transport.Producer
+	replies                   *repliesMap
+	timeout                   time.Duration
+	riffTopicExistenceChecker RiffTopicExistenceChecker
 }
 
 func (g *gateway) Run(stop <-chan struct{}) {
@@ -103,19 +103,19 @@ func (g *gateway) repliesLoop(stop <-chan struct{}) {
 	}
 }
 
-func New(port int, producer transport.Producer, consumer transport.Consumer, timeout time.Duration, topicHelper TopicHelper) *gateway {
+func New(port int, producer transport.Producer, consumer transport.Consumer, timeout time.Duration, riffTopicExistenceChecker RiffTopicExistenceChecker) *gateway {
 	mux := http.NewServeMux()
 	httpServer := &http.Server{Addr: fmt.Sprintf(":%v", port),
 		Handler: mux,
 	}
 	consumerMessages := make(chan message.Message)
 	g := gateway{httpServer: httpServer,
-		producer:         producer,
-		consumer:         consumer,
-		consumerMessages: consumerMessages,
-		replies:          newRepliesMap(),
-		timeout:          timeout,
-		topicHelper:      topicHelper,
+		producer:                  producer,
+		consumer:                  consumer,
+		consumerMessages:          consumerMessages,
+		replies:                   newRepliesMap(),
+		timeout:                   timeout,
+		riffTopicExistenceChecker: riffTopicExistenceChecker,
 	}
 	mux.HandleFunc(messagePath, g.messagesHandler)
 	mux.HandleFunc(requestPath, g.requestsHandler)

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -62,7 +62,7 @@ var _ = Describe("HTTP Gateway", func() {
 	JustBeforeEach(func() {
 		port = 1024 + rand.Intn(32768-1024)
 
-		gw = server.New(port, mockProducer, stubConsumer, timeout, &happyTopicHelper{testName: "testtopic"})
+		gw = server.New(port, mockProducer, stubConsumer, timeout, &happyRiffTopicExistenceChecker{testName: "testtopic"})
 
 		gw.Run(done)
 
@@ -150,10 +150,10 @@ func waitForHttpGatewayToBeReady(port int) {
 	}, timeoutDuration, pollingInterval).Should(Succeed())
 }
 
-type happyTopicHelper struct {
+type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyTopicHelper) TopicExists(topicName string) (bool, error) {
+func (th *happyRiffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
 	return topicName == th.testName, nil
 }

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -154,6 +154,6 @@ type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyRiffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
+func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
 	return topicName == th.testName, nil
 }

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -62,7 +62,7 @@ var _ = Describe("HTTP Gateway", func() {
 	JustBeforeEach(func() {
 		port = 1024 + rand.Intn(32768-1024)
 
-		gw = server.New(port, mockProducer, stubConsumer, timeout, &stubTopicHelper{testName: "testtopic"})
+		gw = server.New(port, mockProducer, stubConsumer, timeout, &happyTopicHelper{testName: "testtopic"})
 
 		gw.Run(done)
 
@@ -150,10 +150,10 @@ func waitForHttpGatewayToBeReady(port int) {
 	}, timeoutDuration, pollingInterval).Should(Succeed())
 }
 
-type stubTopicHelper struct {
+type happyTopicHelper struct {
 	testName string
 }
 
-func (sth *stubTopicHelper) TopicExists(topicName string) bool {
-	return topicName == sth.testName
+func (th *happyTopicHelper) TopicExists(topicName string) (bool, error) {
+	return topicName == th.testName, nil
 }

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -42,9 +41,14 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !g.topicHelper.TopicExists(topicName) {
-		errMsg := fmt.Sprintf("could not find topic '%s'", topicName)
-		log.Printf(errMsg)
+	topicExists, err := g.topicHelper.TopicExists(topicName)
+	if err != nil {
+		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	if !topicExists {
+		errMsg := fmt.Sprintf("could not find Riff topic '%s'", topicName)
 		http.Error(w, errMsg, http.StatusNotFound)
 		return
 	}

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -41,7 +41,7 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.riffTopicExistenceChecker.TopicExists("default", topicName)
+	topicExists, err := g.riffTopicExistenceChecker.TopicExists(defaultNamespace, topicName)
 	if err != nil {
 		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -41,7 +41,7 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.topicHelper.TopicExists(topicName)
+	topicExists, err := g.riffTopicExistenceChecker.TopicExists(topicName)
 	if err != nil {
 		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -41,7 +41,7 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.riffTopicExistenceChecker.TopicExists(topicName)
+	topicExists, err := g.riffTopicExistenceChecker.TopicExists("default", topicName)
 	if err != nil {
 		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/http-gateway/pkg/server/messages_handler_test.go
+++ b/http-gateway/pkg/server/messages_handler_test.go
@@ -243,12 +243,12 @@ type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyRiffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
+func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
 	return topicName == th.testName, nil
 }
 
 type errorRiffTopicExistenceChecker struct{}
 
-func (th *errorRiffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
+func (th *errorRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
 	return false, errors.New("test error")
 }

--- a/http-gateway/pkg/server/messages_handler_test.go
+++ b/http-gateway/pkg/server/messages_handler_test.go
@@ -52,7 +52,7 @@ var _ = Describe("MessagesHandler", func() {
 		mockResponseWriter = httptest.NewRecorder()
 		testError = errors.New(errorMessage)
 
-		gateway = New(8080, mockProducer, mockConsumer, 60*time.Second, &stubTopicHelper{testName: "testtopic"})
+		gateway = New(8080, mockProducer, mockConsumer, 60*time.Second, &happyTopicHelper{testName: "testtopic"})
 	})
 
 	JustBeforeEach(func() {
@@ -78,6 +78,21 @@ var _ = Describe("MessagesHandler", func() {
 		It("should return a 404", func() {
 			resp := mockResponseWriter.Result()
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Context("When an unexpected error occurs while looking up a Riff topic", func() {
+		BeforeEach(func() {
+			gateway.topicHelper = &errorTopicHelper{}
+		})
+
+		AfterEach(func() {
+			gateway.topicHelper = &happyTopicHelper{}
+		})
+
+		It("should return a 500", func() {
+			resp := mockResponseWriter.Result()
+			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 		})
 	})
 
@@ -224,10 +239,16 @@ func (*badReader) Close() error {
 	return nil
 }
 
-type stubTopicHelper struct {
+type happyTopicHelper struct {
 	testName string
 }
 
-func (sth *stubTopicHelper) TopicExists(topicName string) bool {
-	return topicName == sth.testName
+func (th *happyTopicHelper) TopicExists(topicName string) (bool, error) {
+	return topicName == th.testName, nil
+}
+
+type errorTopicHelper struct{}
+
+func (th *errorTopicHelper) TopicExists(topicName string) (bool, error) {
+	return false, errors.New("test error")
 }

--- a/http-gateway/pkg/server/messages_handler_test.go
+++ b/http-gateway/pkg/server/messages_handler_test.go
@@ -52,7 +52,7 @@ var _ = Describe("MessagesHandler", func() {
 		mockResponseWriter = httptest.NewRecorder()
 		testError = errors.New(errorMessage)
 
-		gateway = New(8080, mockProducer, mockConsumer, 60*time.Second, &happyTopicHelper{testName: "testtopic"})
+		gateway = New(8080, mockProducer, mockConsumer, 60*time.Second, &happyRiffTopicExistenceChecker{testName: "testtopic"})
 	})
 
 	JustBeforeEach(func() {
@@ -83,11 +83,11 @@ var _ = Describe("MessagesHandler", func() {
 
 	Context("When an unexpected error occurs while looking up a Riff topic", func() {
 		BeforeEach(func() {
-			gateway.topicHelper = &errorTopicHelper{}
+			gateway.riffTopicExistenceChecker = &errorRiffTopicExistenceChecker{}
 		})
 
 		AfterEach(func() {
-			gateway.topicHelper = &happyTopicHelper{}
+			gateway.riffTopicExistenceChecker = &happyRiffTopicExistenceChecker{}
 		})
 
 		It("should return a 500", func() {
@@ -239,16 +239,16 @@ func (*badReader) Close() error {
 	return nil
 }
 
-type happyTopicHelper struct {
+type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyTopicHelper) TopicExists(topicName string) (bool, error) {
+func (th *happyRiffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
 	return topicName == th.testName, nil
 }
 
-type errorTopicHelper struct{}
+type errorRiffTopicExistenceChecker struct{}
 
-func (th *errorTopicHelper) TopicExists(topicName string) (bool, error) {
+func (th *errorRiffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
 	return false, errors.New("test error")
 }

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -44,7 +44,7 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.topicHelper.TopicExists(topicName)
+	topicExists, err := g.riffTopicExistenceChecker.TopicExists(topicName)
 	if err != nil {
 		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -44,7 +44,7 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.riffTopicExistenceChecker.TopicExists("default", topicName)
+	topicExists, err := g.riffTopicExistenceChecker.TopicExists(defaultNamespace, topicName)
 	if err != nil {
 		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -44,7 +44,7 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.riffTopicExistenceChecker.TopicExists(topicName)
+	topicExists, err := g.riffTopicExistenceChecker.TopicExists("default", topicName)
 	if err != nil {
 		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"time"
 
@@ -45,9 +44,14 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !g.topicHelper.TopicExists(topicName) {
-		errMsg := fmt.Sprintf("could not find topic '%s'", topicName)
-		log.Printf(errMsg)
+	topicExists, err := g.topicHelper.TopicExists(topicName)
+	if err != nil {
+		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return
+	}
+	if !topicExists {
+		errMsg := fmt.Sprintf("could not find Riff topic '%s'", topicName)
 		http.Error(w, errMsg, http.StatusNotFound)
 		return
 	}

--- a/http-gateway/pkg/server/requests_handler_test.go
+++ b/http-gateway/pkg/server/requests_handler_test.go
@@ -71,7 +71,7 @@ var _ = Describe("RequestsHandler", func() {
 	Context("when Riff Topic lookup is working", func() {
 
 		JustBeforeEach(func() {
-			gateway = New(8080, mockProducer, stubConsumer, timeout, &happyTopicHelper{testName: "testtopic"})
+			gateway = New(8080, mockProducer, stubConsumer, timeout, &happyRiffTopicExistenceChecker{testName: "testtopic"})
 
 			go gateway.repliesLoop(done)
 			gateway.requestsHandler(mockResponseWriter, req)
@@ -252,7 +252,7 @@ var _ = Describe("RequestsHandler", func() {
 	// so we need another Describe() block to create separate cases.
 	Context("when Riff Topic lookup fails unexpectedly", func() {
 		JustBeforeEach(func() {
-			gateway = New(8080, mockProducer, stubConsumer, timeout, &errorTopicHelper{})
+			gateway = New(8080, mockProducer, stubConsumer, timeout, &errorRiffTopicExistenceChecker{})
 
 			go gateway.repliesLoop(done)
 			gateway.requestsHandler(mockResponseWriter, req)

--- a/http-gateway/pkg/server/requests_handler_test.go
+++ b/http-gateway/pkg/server/requests_handler_test.go
@@ -68,108 +68,44 @@ var _ = Describe("RequestsHandler", func() {
 		done = make(chan struct{})
 	})
 
-	JustBeforeEach(func() {
-		gateway = New(8080, mockProducer, stubConsumer, timeout, &stubTopicHelper{testName: "testtopic"})
+	Context("when Riff Topic lookup is working", func() {
 
-		go gateway.repliesLoop(done)
-		gateway.requestsHandler(mockResponseWriter, req)
-	})
+		JustBeforeEach(func() {
+			gateway = New(8080, mockProducer, stubConsumer, timeout, &happyTopicHelper{testName: "testtopic"})
 
-	AfterEach(func() {
-		done <- struct{}{}
-	})
-
-	Context("when the request URL is unexpected", func() {
-		BeforeEach(func() {
-			req.URL.Path = "/short"
+			go gateway.repliesLoop(done)
+			gateway.requestsHandler(mockResponseWriter, req)
 		})
 
-		It("should return a 404", func() {
-			resp := mockResponseWriter.Result()
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-		})
-	})
-
-	Context("when the request refers to a non-existent Riff Topic", func() {
-		BeforeEach(func() {
-			req.URL.Path = "/requests/nosuchtopicexists"
+		AfterEach(func() {
+			done <- struct{}{}
 		})
 
-		It("should return a 404", func() {
-			resp := mockResponseWriter.Result()
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-		})
-	})
-
-	Context("when the request body cannot be read", func() {
-		BeforeEach(func() {
-			req.Body = &badReader{testError}
-		})
-
-		It("should reply with a suitable error response", func() {
-			resp := mockResponseWriter.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
-
-			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
-			Expect(string(body)).To(HavePrefix(errorMessage))
-		})
-	})
-
-	Context("when the request body can be read", func() {
-		BeforeEach(func() {
-			req.Body = ioutil.NopCloser(strings.NewReader("body"))
-		})
-
-		Context("when sending succeeds", func() {
+		Context("when the request URL is unexpected", func() {
 			BeforeEach(func() {
-				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-					msg, ok := args[1].(message.Message)
-					Expect(ok).To(BeTrue())
-					stubConsumer.Send(msg, "topic")
-				}).Return(nil)
+				req.URL.Path = "/short"
 			})
 
-			It("should send one message to the producer", func() {
-				Expect(sendIndex(mockProducer)).To(BeNumerically(">", -1))
-			})
-
-			It("should send to the correct topic", func() {
-				Expect(mockProducer.Calls[sendIndex(mockProducer)].Arguments[0]).To(Equal("testtopic"))
-			})
-
-			It("should send a message containing the correct body", func() {
-				Expect(string(sentMessage(mockProducer).Payload())).To(Equal("body"))
-			})
-
-			It("should send a message with a correlation id header", func() {
-				Expect(sentMessage(mockProducer).Headers()).To(HaveKey("correlationId"))
-			})
-
-			Context("when the request contains some headers that should be propagated and some that should not", func() {
-				BeforeEach(func() {
-					req.Header.Add("Content-Type", "text/plain")
-					req.Header.Add("Accept", "application/json")
-					req.Header.Add("Accept", "text/plain")
-					req.Header.Add("Accept-Charset", "utf-8")
-				})
-
-				It("should send a message containing the correct headers", func() {
-					headers := sentMessage(mockProducer).Headers()
-					Expect(headers).To(HaveKeyWithValue("Content-Type", ConsistOf("text/plain")))
-					Expect(headers).To(HaveKeyWithValue("Accept", ConsistOf("application/json", "text/plain")))
-					Expect(headers).NotTo(HaveKey("Accept-Charset"))
-				})
-			})
-
-			It("should reply with an OK response", func() {
+			It("should return a 404", func() {
 				resp := mockResponseWriter.Result()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 			})
 		})
 
-		Context("when sending fails", func() {
+		Context("when the request refers to a non-existent Riff Topic", func() {
 			BeforeEach(func() {
-				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(testError)
+				req.URL.Path = "/requests/nosuchtopicexists"
+			})
+
+			It("should return a 404", func() {
+				resp := mockResponseWriter.Result()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			})
+		})
+
+		Context("when the request body cannot be read", func() {
+			BeforeEach(func() {
+				req.Body = &badReader{testError}
 			})
 
 			It("should reply with a suitable error response", func() {
@@ -181,64 +117,153 @@ var _ = Describe("RequestsHandler", func() {
 			})
 		})
 
-		Context("when sending succeeds but the reply takes too long", func() {
+		Context("when the request body can be read", func() {
 			BeforeEach(func() {
-				timeout = time.Nanosecond
-				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+				req.Body = ioutil.NopCloser(strings.NewReader("body"))
 			})
 
-			It("should time out with a 404", func() {
-				resp := mockResponseWriter.Result()
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			Context("when sending succeeds", func() {
+				BeforeEach(func() {
+					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+						msg, ok := args[1].(message.Message)
+						Expect(ok).To(BeTrue())
+						stubConsumer.Send(msg, "topic")
+					}).Return(nil)
+				})
+
+				It("should send one message to the producer", func() {
+					Expect(sendIndex(mockProducer)).To(BeNumerically(">", -1))
+				})
+
+				It("should send to the correct topic", func() {
+					Expect(mockProducer.Calls[sendIndex(mockProducer)].Arguments[0]).To(Equal("testtopic"))
+				})
+
+				It("should send a message containing the correct body", func() {
+					Expect(string(sentMessage(mockProducer).Payload())).To(Equal("body"))
+				})
+
+				It("should send a message with a correlation id header", func() {
+					Expect(sentMessage(mockProducer).Headers()).To(HaveKey("correlationId"))
+				})
+
+				Context("when the request contains some headers that should be propagated and some that should not", func() {
+					BeforeEach(func() {
+						req.Header.Add("Content-Type", "text/plain")
+						req.Header.Add("Accept", "application/json")
+						req.Header.Add("Accept", "text/plain")
+						req.Header.Add("Accept-Charset", "utf-8")
+					})
+
+					It("should send a message containing the correct headers", func() {
+						headers := sentMessage(mockProducer).Headers()
+						Expect(headers).To(HaveKeyWithValue("Content-Type", ConsistOf("text/plain")))
+						Expect(headers).To(HaveKeyWithValue("Accept", ConsistOf("application/json", "text/plain")))
+						Expect(headers).NotTo(HaveKey("Accept-Charset"))
+					})
+				})
+
+				It("should reply with an OK response", func() {
+					resp := mockResponseWriter.Result()
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				})
+			})
+
+			Context("when sending fails", func() {
+				BeforeEach(func() {
+					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(testError)
+				})
+
+				It("should reply with a suitable error response", func() {
+					resp := mockResponseWriter.Result()
+					body, _ := ioutil.ReadAll(resp.Body)
+
+					Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+					Expect(string(body)).To(HavePrefix(errorMessage))
+				})
+			})
+
+			Context("when sending succeeds but the reply takes too long", func() {
+				BeforeEach(func() {
+					timeout = time.Nanosecond
+					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(nil)
+				})
+
+				It("should time out with a 404", func() {
+					resp := mockResponseWriter.Result()
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+
+			Context("when sending succeeds but the producer reports an error before the reply comes back", func() {
+				BeforeEach(func() {
+					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+						msg, ok := args[1].(message.Message)
+						Expect(ok).To(BeTrue())
+
+						producerErrors <- testError
+
+						stubConsumer.Send(msg, "topic")
+					}).Return(nil)
+				})
+
+				It("should reply with OK", func() {
+					resp := mockResponseWriter.Result()
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				})
+			})
+
+			Context("when sending succeeds but a reply comes back with the wrong correlation id", func() {
+				BeforeEach(func() {
+					timeout = 10 * time.Millisecond
+					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+						headers := make(message.Headers)
+						headers["correlationId"] = []string{""}
+						stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
+					}).Return(nil)
+				})
+
+				It("should time out with a 404", func() {
+					resp := mockResponseWriter.Result()
+					Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				})
+			})
+
+			Context("when sending succeeds but the reply is an error", func() {
+				BeforeEach(func() {
+					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+						msg, ok := args[1].(message.Message)
+						Expect(ok).To(BeTrue())
+						headers := msg.Headers()
+						headers["error"] = []string{"error-server-function-invocation"}
+						stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
+					}).Return(nil)
+				})
+
+				It("should reply with a 500", func() {
+					resp := mockResponseWriter.Result()
+					Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+				})
 			})
 		})
+	})
 
-		Context("when sending succeeds but the producer reports an error before the reply comes back", func() {
-			BeforeEach(func() {
-				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-					msg, ok := args[1].(message.Message)
-					Expect(ok).To(BeTrue())
+	// the way the tests are set up for this mess with the 500-status/Riff topic lookup test
+	// so we need another Describe() block to create separate cases.
+	Context("when Riff Topic lookup fails unexpectedly", func() {
+		JustBeforeEach(func() {
+			gateway = New(8080, mockProducer, stubConsumer, timeout, &errorTopicHelper{})
 
-					producerErrors <- testError
-
-					stubConsumer.Send(msg, "topic")
-				}).Return(nil)
-			})
-
-			It("should reply with OK", func() {
-				resp := mockResponseWriter.Result()
-				Expect(resp.StatusCode).To(Equal(http.StatusOK))
-			})
+			go gateway.repliesLoop(done)
+			gateway.requestsHandler(mockResponseWriter, req)
 		})
 
-		Context("when sending succeeds but a reply comes back with the wrong correlation id", func() {
-			BeforeEach(func() {
-				timeout = 10 * time.Millisecond
-				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-					headers := make(message.Headers)
-					headers["correlationId"] = []string{""}
-					stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
-				}).Return(nil)
-			})
-
-			It("should time out with a 404", func() {
-				resp := mockResponseWriter.Result()
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-			})
+		AfterEach(func() {
+			done <- struct{}{}
 		})
 
-		Context("when sending succeeds but the reply is an error", func() {
-			BeforeEach(func() {
-				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-					msg, ok := args[1].(message.Message)
-					Expect(ok).To(BeTrue())
-					headers := msg.Headers()
-					headers["error"] = []string{"error-server-function-invocation"}
-					stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
-				}).Return(nil)
-			})
-
-			It("should reply with a 500", func() {
+		Context("When an unexpected error occurs while looking up a Riff topic", func() {
+			It("should return a 500", func() {
 				resp := mockResponseWriter.Result()
 				Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 			})

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -13,7 +13,7 @@ import (
 // RiffTopicExistenceChecker allows the http-gateway to check for the existence of
 // a Riff Topic before attempting to send a message to that topic.
 type RiffTopicExistenceChecker interface {
-	TopicExists(topicName string) (bool, error)
+	TopicExists(namespace string, topicName string) (bool, error)
 }
 
 type riffTopicExistenceChecker struct {
@@ -34,13 +34,13 @@ func NewRiffTopicExistenceChecker() (*riffTopicExistenceChecker, error) {
 	return &riffTopicExistenceChecker{client: riffClient}, nil
 }
 
-// TopicExists checks to see if Kubernetes is aware of a Riff Topic.
+// TopicExists checks to see if Kubernetes is aware of a Riff Topic in a namespace.
 // If the topic exists, it returns (true, nil)
 // If the topic does not exist, it returns (false, nil)
 // If there is an unexpected error, it returns (false, err), where 'err' is the unexpected
 // error that was encountered.
-func (tec *riffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
-	_, err := tec.client.ProjectriffV1alpha1().Topics("default").Get(topicName, v1.GetOptions{})
+func (tec *riffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
+	_, err := tec.client.ProjectriffV1alpha1().Topics(namespace).Get(topicName, v1.GetOptions{})
 
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -10,15 +10,15 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type TopicHelper interface {
+type RiffTopicExistenceChecker interface {
 	TopicExists(topicName string) (bool, error)
 }
 
-type topicHelper struct {
+type riffTopicExistenceChecker struct {
 	client *riffcs.Clientset
 }
 
-func NewTopicHelper() (*topicHelper, error) {
+func NewRiffTopicExistenceChecker() (*riffTopicExistenceChecker, error) {
 	restConf, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
@@ -29,11 +29,11 @@ func NewTopicHelper() (*topicHelper, error) {
 		return nil, err
 	}
 
-	return &topicHelper{client: riffClient}, nil
+	return &riffTopicExistenceChecker{client: riffClient}, nil
 }
 
-func (tw *topicHelper) TopicExists(topicName string) (bool, error) {
-	_, err := tw.client.ProjectriffV1alpha1().Topics("default").Get(topicName, v1.GetOptions{})
+func (tec *riffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
+	_, err := tec.client.ProjectriffV1alpha1().Topics("default").Get(topicName, v1.GetOptions{})
 
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// RiffTopicExistenceChecker allows the http-gateway to check for the existence of
+// a Riff Topic before attempting to send a message to that topic.
 type RiffTopicExistenceChecker interface {
 	TopicExists(topicName string) (bool, error)
 }
@@ -32,6 +34,11 @@ func NewRiffTopicExistenceChecker() (*riffTopicExistenceChecker, error) {
 	return &riffTopicExistenceChecker{client: riffClient}, nil
 }
 
+// TopicExists checks to see if Kubernetes is aware of a Riff Topic.
+// If the topic exists, it returns (true, nil)
+// If the topic does not exist, it returns (false, nil)
+// If there is an unexpected error, it returns (false, err), where 'err' is the unexpected
+// error that was encountered.
 func (tec *riffTopicExistenceChecker) TopicExists(topicName string) (bool, error) {
 	_, err := tec.client.ProjectriffV1alpha1().Topics("default").Get(topicName, v1.GetOptions{})
 

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -22,6 +22,8 @@ type riffTopicExistenceChecker struct {
 	client *versioned.Clientset
 }
 
+// NewRiffTopicExistenceChecker configures a RiffTopicExistenceChecker using the
+// provided Clientset.
 func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) *riffTopicExistenceChecker {
 	return &riffTopicExistenceChecker{client: clientSet}
 }

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -10,6 +10,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	defaultNamespace = "default" // expected to be used by consumers of TopicExists
+)
+
 // RiffTopicExistenceChecker allows the http-gateway to check for the existence of
 // a Riff Topic before attempting to send a message to that topic.
 type RiffTopicExistenceChecker interface {

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -3,11 +3,9 @@ package server
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	riffcs "github.com/projectriff/riff/kubernetes-crds/pkg/client/clientset/versioned"
+	"github.com/projectriff/riff/kubernetes-crds/pkg/client/clientset/versioned"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
-	"k8s.io/client-go/rest"
 )
 
 const (
@@ -21,21 +19,11 @@ type RiffTopicExistenceChecker interface {
 }
 
 type riffTopicExistenceChecker struct {
-	client *riffcs.Clientset
+	client *versioned.Clientset
 }
 
-func NewRiffTopicExistenceChecker() (*riffTopicExistenceChecker, error) {
-	restConf, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	riffClient, err := riffcs.NewForConfig(restConf)
-	if err != nil {
-		return nil, err
-	}
-
-	return &riffTopicExistenceChecker{client: riffClient}, nil
+func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) *riffTopicExistenceChecker {
+	return &riffTopicExistenceChecker{client: clientSet}
 }
 
 // TopicExists checks to see if Kubernetes is aware of a Riff Topic in a namespace.

--- a/http-gateway/pkg/server/topic_helper.go
+++ b/http-gateway/pkg/server/topic_helper.go
@@ -5,7 +5,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/golang/glog"
 	riffcs "github.com/projectriff/riff/kubernetes-crds/pkg/client/clientset/versioned"
 
 	"k8s.io/client-go/rest"
@@ -27,7 +26,7 @@ func NewTopicHelper() (*topicHelper, error) {
 
 	riffClient, err := riffcs.NewForConfig(restConf)
 	if err != nil {
-		glog.Fatalf("Error building riff clientset: %s", err.Error())
+		return nil, err
 	}
 
 	return &topicHelper{client: riffClient}, nil


### PR DESCRIPTION
Based on feedback @glyn gave for PR #513.

Summarising the key changes:

* `TopicHelper` became `RiffTopicExistenceChecker`
* `TopicHelper` distinguishes between 404s and other errors arising from Kubernetes; consumers were updated to take advantage of the distinction
* `TopicHelper` became aware of namespaces; consumer code became responsible for providing a namespace param
* `NewRiffTopicExistenceChecker` is no longer responsible for building and wiring a `Clientset`, this is now the responsibility of consumer code
* Documentation was added for the interface and methods

Not addressed in this PR is the [open question of performance impact](https://github.com/projectriff/riff/pull/513#discussion_r179396335).
