### PR TITLE
Avoid defaulting the invoker version

### DIFF
--- a/riff-cli/cmd/init.go
+++ b/riff-cli/cmd/init.go
@@ -19,12 +19,13 @@ package cmd
 import (
 	"fmt"
 
+	"path/filepath"
+
 	projectriff_v1 "github.com/projectriff/riff/kubernetes-crds/pkg/apis/projectriff.io/v1alpha1"
 	"github.com/projectriff/riff/riff-cli/cmd/utils"
 	"github.com/projectriff/riff/riff-cli/pkg/initializer"
 	"github.com/projectriff/riff/riff-cli/pkg/options"
 	"github.com/spf13/cobra"
-	"path/filepath"
 )
 
 func Init(invokers []projectriff_v1.Invoker) (*cobra.Command, *options.InitOptions) {
@@ -59,7 +60,7 @@ func Init(invokers []projectriff_v1.Invoker) (*cobra.Command, *options.InitOptio
 	initCmd.PersistentFlags().StringVarP(&initOptions.FilePath, "filepath", "f", "", "path or directory used for the function resources (defaults to the current directory)")
 	initCmd.PersistentFlags().StringVarP(&initOptions.FunctionName, "name", "n", "", "the name of the function (defaults to the name of the current directory)")
 	initCmd.PersistentFlags().StringVarP(&initOptions.Version, "version", "v", utils.DefaultValues.Version, "the version of the function image")
-	initCmd.Flags().StringVar(&initOptions.InvokerVersion, "invoker-version", "", "the version of the invoker to use when building containers")
+	initCmd.PersistentFlags().StringVar(&initOptions.InvokerVersion, "invoker-version", "", "the version of the invoker to use when building containers")
 	initCmd.PersistentFlags().StringVarP(&initOptions.UserAccount, "useraccount", "u", utils.DefaultValues.UserAccount, "the Docker user account to be used for the image repository")
 	initCmd.PersistentFlags().StringVarP(&initOptions.Artifact, "artifact", "a", "", "path to the function artifact, source code or jar file")
 	initCmd.PersistentFlags().StringVarP(&initOptions.Input, "input", "i", "", "the name of the input topic (defaults to function name)")
@@ -83,8 +84,6 @@ func InitInvokers(invokers []projectriff_v1.Invoker, initOptions *options.InitOp
 				return initializer.Initialize(invokers, initOptions)
 			},
 		}
-
-		initInvokerCmd.Flags().StringVar(&initOptions.InvokerVersion, "invoker-version", invoker.Spec.Version, "the version of invoker to use when building containers")
 
 		handler := invoker.Spec.Handler
 		if handler.Default != "" || handler.Description != "" {

--- a/riff-cli/cmd/utils/command_utils.go
+++ b/riff-cli/cmd/utils/command_utils.go
@@ -25,12 +25,11 @@ import (
 )
 
 type Defaults struct {
-	InvokerVersion string
-	UserAccount    string
-	Force          bool
-	DryRun         bool
-	Push           bool
-	Version        string
+	UserAccount string
+	Force       bool
+	DryRun      bool
+	Push        bool
+	Version     string
 }
 
 var DefaultValues = Defaults{

--- a/riff-cli/test_data/docs/riff_create_command.md
+++ b/riff-cli/test_data/docs/riff_create_command.md
@@ -25,25 +25,25 @@ riff create command [flags]
 ### Options
 
 ```
-  -h, --help                     help for command
-      --invoker-version string   the version of invoker to use when building containers (default "0.0.5-snapshot")
-      --namespace string         the namespace used for the deployed resources (defaults to kubectl's default)
-      --push                     push the image to Docker registry
+  -h, --help               help for command
+      --namespace string   the namespace used for the deployed resources (defaults to kubectl's default)
+      --push               push the image to Docker registry
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --artifact string      path to the function artifact, source code or jar file
-      --config string        config file (default is $HOME/.riff.yaml)
-      --dry-run              print generated function artifacts content to stdout only
-  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
-      --force                overwrite existing functions artifacts
-  -i, --input string         the name of the input topic (defaults to function name)
-  -n, --name string          the name of the function (defaults to the name of the current directory)
-  -o, --output string        the name of the output topic (optional)
-  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
-  -v, --version string       the version of the function image (default "0.0.1")
+  -a, --artifact string          path to the function artifact, source code or jar file
+      --config string            config file (default is $HOME/.riff.yaml)
+      --dry-run                  print generated function artifacts content to stdout only
+  -f, --filepath string          path or directory used for the function resources (defaults to the current directory)
+      --force                    overwrite existing functions artifacts
+  -i, --input string             the name of the input topic (defaults to function name)
+      --invoker-version string   the version of the invoker to use when building containers
+  -n, --name string              the name of the function (defaults to the name of the current directory)
+  -o, --output string            the name of the output topic (optional)
+  -u, --useraccount string       the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string           the version of the function image (default "0.0.1")
 ```
 
 ### SEE ALSO

--- a/riff-cli/test_data/docs/riff_init_command.md
+++ b/riff-cli/test_data/docs/riff_init_command.md
@@ -25,23 +25,23 @@ riff init command [flags]
 ### Options
 
 ```
-  -h, --help                     help for command
-      --invoker-version string   the version of invoker to use when building containers (default "0.0.5-snapshot")
+  -h, --help   help for command
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -a, --artifact string      path to the function artifact, source code or jar file
-      --config string        config file (default is $HOME/.riff.yaml)
-      --dry-run              print generated function artifacts content to stdout only
-  -f, --filepath string      path or directory used for the function resources (defaults to the current directory)
-      --force                overwrite existing functions artifacts
-  -i, --input string         the name of the input topic (defaults to function name)
-  -n, --name string          the name of the function (defaults to the name of the current directory)
-  -o, --output string        the name of the output topic (optional)
-  -u, --useraccount string   the Docker user account to be used for the image repository (default "current OS user")
-  -v, --version string       the version of the function image (default "0.0.1")
+  -a, --artifact string          path to the function artifact, source code or jar file
+      --config string            config file (default is $HOME/.riff.yaml)
+      --dry-run                  print generated function artifacts content to stdout only
+  -f, --filepath string          path or directory used for the function resources (defaults to the current directory)
+      --force                    overwrite existing functions artifacts
+  -i, --input string             the name of the input topic (defaults to function name)
+      --invoker-version string   the version of the invoker to use when building containers
+  -n, --name string              the name of the function (defaults to the name of the current directory)
+  -o, --output string            the name of the output topic (optional)
+  -u, --useraccount string       the Docker user account to be used for the image repository (default "current OS user")
+  -v, --version string           the version of the function image (default "0.0.1")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
When using cobra to set the default value for the --invoker-version flag
for `riff init <invoker>` and `riff create <invoker>` the wrong default
version can be selected at runtime.

Previously, we used the list of invokers to dynamically install sub
commands for `init` and `create`. The default for the invoker version
was set based on the invoker version. With a set of invokers installed
like:

```
NAME      VERSION
command   0.0.6-snapshot
go        0.0.2-snapshot
java      0.0.6-snapshot
node      0.0.6-snapshot
python2   0.0.6-snapshot
python3   0.0.6-snapshot
```

When creating a function with the go invoker, cobra is defaulting the
.InvokerVersion to `0.0.6-snapshot`, instead of the `0.0.2-snapshot`.
When the go invoker is the only invoker install, it defaults correctly
to `0.0.2-snapshot`.

We can work arround this issue by not defaulting the .InvokerVersion in
cobra, but by manually defaulting the value.