### PR TITLE
Change scaler interval to 97ms

### DIFF
--- a/function-controller/pkg/controller/controller.go
+++ b/function-controller/pkg/controller/controller.go
@@ -33,7 +33,9 @@ import (
 )
 
 // DefaultScalerInterval controls how often to run the scaling strategy.
-const DefaultScalerInterval = 100 * time.Millisecond
+// 97ms is chosen to avoid accidental locksteps with other systems such
+// as OS schedulers or garbage collection.
+const DefaultScalerInterval = 97 * time.Millisecond
 
 const defaultScaleDownDelay = time.Second * 10
 


### PR DESCRIPTION
By inspiration from "Systems Performance"[0] by Brendan Gregg and by performance-sampling tools that book describes (eg lockstat[1]). A 97ms interval won't lockstep with processes running on 10/100/1000ms
boundaries, such as some OS schedulers.

[0] Page 219.
[1] https://docs.oracle.com/cd/E19253-01/816-5166/lockstat-1m/index.html