### PR TITLE
Align init and create command args

### DIFF
--- a/riff-cli/cmd/create.go
+++ b/riff-cli/cmd/create.go
@@ -31,6 +31,16 @@ func Create(initCmd *cobra.Command, buildCmd *cobra.Command, applyCmd *cobra.Com
 	createChainCmd.Long = utils.CreateCmdLong()
 	createChainCmd.SetUsageTemplate(utils.CustomInvokerUsageTemplate)
 
+	// ignore all validation
+	//
+	// This command will fail since no invoker is specified. The init command
+	// is able to provide a more meaningful error message. We still want to
+	// use a chained command to establish persistent flags
+	createChainCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error { return nil }
+	createChainCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {}
+	createChainCmd.PreRunE = func(cmd *cobra.Command, args []string) error { return nil }
+	createChainCmd.PreRun = func(cmd *cobra.Command, args []string) {}
+
 	return createChainCmd
 }
 

--- a/riff-cli/cmd/init.go
+++ b/riff-cli/cmd/init.go
@@ -82,6 +82,7 @@ func InitInvokers(invokers []projectriff_v1.Invoker, initOptions *options.InitOp
 			Use:   invokerName,
 			Short: fmt.Sprintf("Initialize a %s function", invokerName),
 			Long:  utils.InitInvokerCmdLong(invoker),
+			Args:  utils.AliasFlagToSoleArg("filepath"),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				invoker, err := invokerForName(invokerName, invokers)
 				if err != nil {


### PR DESCRIPTION
`riff create <invoker> <filepath>` is also handled as
`riff create <invoker> --filepath <filepath>`. Previously, the equivlent
with `riff init` was also not true. Now the first argument is treated
uniformly as the filepath flag for both the init and create commands.

Issue: #488