### PR TITLE
Link to invoker repos for samples

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,7 +82,8 @@ make teardown
 
 == [[samples]]Try Some Samples
 
-Sample functions have moved into their respective invoker repositories.
+Sample functions are typically found in the corresponding invoker repositories.
+See the link:https://github.com/projectriff?q=-invoker[projectriff invoker repositories] for example.
 
 == Running the tests
 


### PR DESCRIPTION
@dsyer suggested that it would be helpful to link to the samples. This is a step in that direction while still acknowledging that 3rd parties can write invokers which are just as valid as those provided in the riff project.