### PR TITLE
Make k8s resource checks in http gateway optional

### DIFF
--- a/http-gateway/cmd/http-gateway.go
+++ b/http-gateway/cmd/http-gateway.go
@@ -56,15 +56,15 @@ func main() {
 	defer consumer.Close()
 
 	restConf, err := rest.InClusterConfig()
-	if err != nil {
-		panic(err)
+	var riffClient *versioned.Clientset
+	if err == nil {
+		riffClient, err = versioned.NewForConfig(restConf)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		riffClient = nil
 	}
-
-	riffClient, err := versioned.NewForConfig(restConf)
-	if err != nil {
-		panic(err)
-	}
-
 	riffTopicExistenceChecker := server.NewRiffTopicExistenceChecker(riffClient)
 
 	gw := server.New(8080, producer, consumer, 60*time.Second, riffTopicExistenceChecker)

--- a/http-gateway/pkg/server/riff_topic_existence_checker.go
+++ b/http-gateway/pkg/server/riff_topic_existence_checker.go
@@ -34,14 +34,19 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) *riffTopicExis
 // If there is an unexpected error, it returns (false, err), where 'err' is the unexpected
 // error that was encountered.
 func (tec *riffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
-	_, err := tec.client.ProjectriffV1alpha1().Topics(namespace).Get(topicName, v1.GetOptions{})
 
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return false, nil
+	if tec.client != nil {
+
+		_, err := tec.client.ProjectriffV1alpha1().Topics(namespace).Get(topicName, v1.GetOptions{})
+
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
 		}
 
-		return false, err
 	}
 
 	return true, nil


### PR DESCRIPTION
You only need to be paranoid about topic existence if you are running
in an actual cluster. Running locally (like it says you can do in the
docs) there is no need to check for topic existence in k8s because
there is no k8s.