### PR TITLE
Adopt a common way of deferring close

### DIFF
--- a/function-sidecar/cmd/function-sidecar.go
+++ b/function-sidecar/cmd/function-sidecar.go
@@ -104,11 +104,9 @@ func main() {
 		panic(err)
 	}
 
-	defer func(){
-		if consumer, ok := consumer.(io.Closer); ok {
-			consumer.Close()
-		}
-	}()
+	if consumer, ok := consumer.(io.Closer); ok {
+		defer consumer.Close()
+	}
 
 	dispatcher, err := createDispatcher(protocol)
 	if err != nil {

--- a/http-gateway/cmd/http-gateway.go
+++ b/http-gateway/cmd/http-gateway.go
@@ -43,11 +43,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer func() {
-		if producer, ok := producer.(io.Closer); ok {
-			producer.Close()
-		}
-	}()
+	if producer, ok := producer.(io.Closer); ok {
+		defer producer.Close()
+	}
 
 	consumer, err := kafka.NewConsumer(brokers, "gateway", []string{"replies"}, cluster.NewConfig())
 	if err != nil {


### PR DESCRIPTION
For optional io.Closer implementations, it's cleaner to test for io.Closer
before deferring the close.