### PR TITLE
Unknown flags

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6f1b2d9f5f26e05a2a8832adbabb64249525a730d8577be87119a9e54e36f891
-updated: 2018-03-28T12:46:28.084984+02:00
+hash: bf0d50b03fa7df61385ccfd15d096d1b21e3149f71dbcad49b233b0f4a4cb152
+updated: 2018-04-24T08:50:52.736913-04:00
 imports:
 - name: github.com/bsm/sarama-cluster
   version: 24016d206c730276dfb58f802999066f2f4bfeaa
@@ -158,7 +158,7 @@ imports:
 - name: github.com/spf13/jwalterweatherman
   version: 7c0cea34c8ece3fbeb2b27ab9b59511d360fb394
 - name: github.com/spf13/pflag
-  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/spf13/viper
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/stretchr/objx

--- a/glide.yaml
+++ b/glide.yaml
@@ -68,7 +68,7 @@ import:
   subpackages:
   - doc
 - package: github.com/spf13/pflag
-  version: v1.0.0
+  version: v1.0.1
 - package: github.com/spf13/viper
   version: v1.0.0
 - package: github.com/mitchellh/go-homedir

--- a/riff-cli/cmd/create.go
+++ b/riff-cli/cmd/create.go
@@ -29,6 +29,8 @@ func Create(initCmd *cobra.Command, buildCmd *cobra.Command, applyCmd *cobra.Com
 	createChainCmd.Use = "create"
 	createChainCmd.Short = "Create a function (equivalent to init, build, apply)"
 	createChainCmd.Long = utils.CreateCmdLong()
+
+	createChainCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 	createChainCmd.SetUsageTemplate(utils.CustomInvokerUsageTemplate)
 
 	// ignore all validation

--- a/riff-cli/cmd/create_test.go
+++ b/riff-cli/cmd/create_test.go
@@ -104,6 +104,23 @@ var _ = Describe("The create command", func() {
 			Expect(".").NotTo(HaveUnstagedChanges())
 		})
 
+		It("ignores unknown flags", func() {
+			os.Chdir("../test_data/riff-init/no-invokers")
+
+			invokers, err := stubInvokers("invokers/*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rootCommand, _, _, _, err := setupCreateTest(invokers, normalDocker, dryRunDocker, normalKubeCtl, dryRunKubeCtl)
+			Expect(err).NotTo(HaveOccurred())
+
+			rootCommand.SetArgs(append([]string{"create", "java", "--handler", "functions.FooFunc"}, commonRiffArgs...))
+
+			err = rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(fmt.Errorf("Invokers must be installed, run `riff invokers apply --help` for help")))
+
+			Expect(".").NotTo(HaveUnstagedChanges())
+		})
+
 		It("creates a function with a matched invoker", func() {
 			os.Chdir("../test_data/riff-init/matching-invoker")
 

--- a/riff-cli/cmd/init.go
+++ b/riff-cli/cmd/init.go
@@ -68,6 +68,7 @@ func Init(invokers []projectriff_v1.Invoker) (*cobra.Command, *options.InitOptio
 	initCmd.PersistentFlags().StringVarP(&initOptions.Output, "output", "o", "", "the name of the output topic (optional)")
 	initCmd.PersistentFlags().BoolVar(&initOptions.Force, "force", utils.DefaultValues.Force, "overwrite existing functions artifacts")
 
+	initCmd.Flags().ParseErrorsWhitelist.UnknownFlags = true
 	initCmd.SetUsageTemplate(utils.CustomInvokerUsageTemplate)
 
 	return initCmd, &initOptions

--- a/riff-cli/cmd/init_test.go
+++ b/riff-cli/cmd/init_test.go
@@ -72,6 +72,23 @@ var _ = Describe("The init command", func() {
 			Expect(".").NotTo(HaveUnstagedChanges())
 		})
 
+		It("ignores unknown flags", func() {
+			os.Chdir("../test_data/riff-init/no-invokers")
+
+			invokers, err := stubInvokers("invokers/*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rootCommand, _, _, _, err := setupInitTest(invokers)
+			Expect(err).NotTo(HaveOccurred())
+
+			rootCommand.SetArgs(append([]string{"init", "--handler", "functions.FooFunc"}, commonRiffArgs...))
+
+			err = rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(fmt.Errorf("Invokers must be installed, run `riff invokers apply --help` for help")))
+
+			Expect(".").NotTo(HaveUnstagedChanges())
+		})
+
 	})
 
 	Context("with an explict invoker", func() {
@@ -88,6 +105,24 @@ var _ = Describe("The init command", func() {
 
 			err = rootCommand.Execute()
 			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(fmt.Errorf("The invoker must be specified. Pick one of: node")))
+
+			Expect(".").NotTo(HaveUnstagedChanges())
+		})
+
+		It("ignores unknown flags", func() {
+			os.Chdir("../test_data/riff-init/no-matching-invoker")
+
+			invokers, err := stubInvokers("invokers/*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rootCommand, _, _, _, err := setupInitTest(invokers)
+			Expect(err).NotTo(HaveOccurred())
+
+			rootCommand.SetArgs(append([]string{"init", "java", "--handler", "functions.FooFunc"}, commonRiffArgs...))
+
+			err = rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(fmt.Errorf("The invoker must be specified. Pick one of: node")))
 
 			Expect(".").NotTo(HaveUnstagedChanges())
 		})

--- a/vendor/github.com/spf13/pflag/bytes.go
+++ b/vendor/github.com/spf13/pflag/bytes.go
@@ -1,0 +1,105 @@
+package pflag
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// BytesHex adapts []byte for use as a flag. Value of flag is HEX encoded
+type bytesHexValue []byte
+
+func (bytesHex bytesHexValue) String() string {
+	return fmt.Sprintf("%X", []byte(bytesHex))
+}
+
+func (bytesHex *bytesHexValue) Set(value string) error {
+	bin, err := hex.DecodeString(strings.TrimSpace(value))
+
+	if err != nil {
+		return err
+	}
+
+	*bytesHex = bin
+
+	return nil
+}
+
+func (*bytesHexValue) Type() string {
+	return "bytesHex"
+}
+
+func newBytesHexValue(val []byte, p *[]byte) *bytesHexValue {
+	*p = val
+	return (*bytesHexValue)(p)
+}
+
+func bytesHexConv(sval string) (interface{}, error) {
+
+	bin, err := hex.DecodeString(sval)
+
+	if err == nil {
+		return bin, nil
+	}
+
+	return nil, fmt.Errorf("invalid string being converted to Bytes: %s %s", sval, err)
+}
+
+// GetBytesHex return the []byte value of a flag with the given name
+func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
+	val, err := f.getFlagType(name, "bytesHex", bytesHexConv)
+
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return val.([]byte), nil
+}
+
+// BytesHexVar defines an []byte flag with specified name, default value, and usage string.
+// The argument p points to an []byte variable in which to store the value of the flag.
+func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string) {
+	f.VarP(newBytesHexValue(value, p), name, "", usage)
+}
+
+// BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
+	f.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+}
+
+// BytesHexVar defines an []byte flag with specified name, default value, and usage string.
+// The argument p points to an []byte variable in which to store the value of the flag.
+func BytesHexVar(p *[]byte, name string, value []byte, usage string) {
+	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage)
+}
+
+// BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
+func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
+	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+}
+
+// BytesHex defines an []byte flag with specified name, default value, and usage string.
+// The return value is the address of an []byte variable that stores the value of the flag.
+func (f *FlagSet) BytesHex(name string, value []byte, usage string) *[]byte {
+	p := new([]byte)
+	f.BytesHexVarP(p, name, "", value, usage)
+	return p
+}
+
+// BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
+	p := new([]byte)
+	f.BytesHexVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// BytesHex defines an []byte flag with specified name, default value, and usage string.
+// The return value is the address of an []byte variable that stores the value of the flag.
+func BytesHex(name string, value []byte, usage string) *[]byte {
+	return CommandLine.BytesHexP(name, "", value, usage)
+}
+
+// BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
+func BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
+	return CommandLine.BytesHexP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/bytes_test.go
+++ b/vendor/github.com/spf13/pflag/bytes_test.go
@@ -1,0 +1,72 @@
+package pflag
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func setUpBytesHex(bytesHex *[]byte) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.BytesHexVar(bytesHex, "bytes", []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, "Some bytes in HEX")
+	f.BytesHexVarP(bytesHex, "bytes2", "B", []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, "Some bytes in HEX")
+	return f
+}
+
+func TestBytesHex(t *testing.T) {
+	testCases := []struct {
+		input    string
+		success  bool
+		expected string
+	}{
+		/// Positive cases
+		{"", true, ""}, // Is empty string OK ?
+		{"01", true, "01"},
+		{"0101", true, "0101"},
+		{"1234567890abcdef", true, "1234567890ABCDEF"},
+		{"1234567890ABCDEF", true, "1234567890ABCDEF"},
+
+		// Negative cases
+		{"0", false, ""},   // Short string
+		{"000", false, ""}, /// Odd-length string
+		{"qq", false, ""},  /// non-hex character
+	}
+
+	devnull, _ := os.Open(os.DevNull)
+	os.Stderr = devnull
+
+	for i := range testCases {
+		var bytesHex []byte
+		f := setUpBytesHex(&bytesHex)
+
+		tc := &testCases[i]
+
+		// --bytes
+		args := []string{
+			fmt.Sprintf("--bytes=%s", tc.input),
+			fmt.Sprintf("-B  %s", tc.input),
+			fmt.Sprintf("--bytes2=%s", tc.input),
+		}
+
+		for _, arg := range args {
+			err := f.Parse([]string{arg})
+
+			if err != nil && tc.success == true {
+				t.Errorf("expected success, got %q", err)
+				continue
+			} else if err == nil && tc.success == false {
+				// bytesHex, err := f.GetBytesHex("bytes")
+				t.Errorf("expected failure while processing %q", tc.input)
+				continue
+			} else if tc.success {
+				bytesHex, err := f.GetBytesHex("bytes")
+				if err != nil {
+					t.Errorf("Got error trying to fetch the IP flag: %v", err)
+				}
+				if fmt.Sprintf("%X", bytesHex) != tc.expected {
+					t.Errorf("expected %q, got '%X'", tc.expected, bytesHex)
+				}
+			}
+		}
+	}
+}

--- a/vendor/github.com/spf13/pflag/count.go
+++ b/vendor/github.com/spf13/pflag/count.go
@@ -11,13 +11,13 @@ func newCountValue(val int, p *int) *countValue {
 }
 
 func (i *countValue) Set(s string) error {
-	v, err := strconv.ParseInt(s, 0, 64)
-	// -1 means that no specific value was passed, so increment
-	if v == -1 {
+	// "+1" means that no specific value was passed, so increment
+	if s == "+1" {
 		*i = countValue(*i + 1)
-	} else {
-		*i = countValue(v)
+		return nil
 	}
+	v, err := strconv.ParseInt(s, 0, 0)
+	*i = countValue(v)
 	return err
 }
 
@@ -54,7 +54,7 @@ func (f *FlagSet) CountVar(p *int, name string, usage string) {
 // CountVarP is like CountVar only take a shorthand for the flag name.
 func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
 	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
-	flag.NoOptDefVal = "-1"
+	flag.NoOptDefVal = "+1"
 }
 
 // CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set

--- a/vendor/github.com/spf13/pflag/count_test.go
+++ b/vendor/github.com/spf13/pflag/count_test.go
@@ -17,10 +17,14 @@ func TestCount(t *testing.T) {
 		success  bool
 		expected int
 	}{
+		{[]string{}, true, 0},
+		{[]string{"-v"}, true, 1},
 		{[]string{"-vvv"}, true, 3},
 		{[]string{"-v", "-v", "-v"}, true, 3},
 		{[]string{"-v", "--verbose", "-v"}, true, 3},
 		{[]string{"-v=3", "-v"}, true, 4},
+		{[]string{"--verbose=0"}, true, 0},
+		{[]string{"-v=0"}, true, 0},
 		{[]string{"-v=a"}, false, 0},
 	}
 
@@ -45,7 +49,7 @@ func TestCount(t *testing.T) {
 				t.Errorf("Got error trying to fetch the counter flag")
 			}
 			if c != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, c)
+				t.Errorf("expected %d, got %d", tc.expected, c)
 			}
 		}
 	}

--- a/vendor/github.com/spf13/pflag/duration_slice.go
+++ b/vendor/github.com/spf13/pflag/duration_slice.go
@@ -1,0 +1,128 @@
+package pflag
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// -- durationSlice Value
+type durationSliceValue struct {
+	value   *[]time.Duration
+	changed bool
+}
+
+func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSliceValue {
+	dsv := new(durationSliceValue)
+	dsv.value = p
+	*dsv.value = val
+	return dsv
+}
+
+func (s *durationSliceValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]time.Duration, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = time.ParseDuration(d)
+		if err != nil {
+			return err
+		}
+
+	}
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *durationSliceValue) Type() string {
+	return "durationSlice"
+}
+
+func (s *durationSliceValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = fmt.Sprintf("%s", d)
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func durationSliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
+	// Empty string would cause a slice with one (empty) entry
+	if len(val) == 0 {
+		return []time.Duration{}, nil
+	}
+	ss := strings.Split(val, ",")
+	out := make([]time.Duration, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = time.ParseDuration(d)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return out, nil
+}
+
+// GetDurationSlice returns the []time.Duration value of a flag with the given name
+func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
+	val, err := f.getFlagType(name, "durationSlice", durationSliceConv)
+	if err != nil {
+		return []time.Duration{}, err
+	}
+	return val.([]time.Duration), nil
+}
+
+// DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
+// The argument p points to a []time.Duration variable in which to store the value of the flag.
+func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
+	f.VarP(newDurationSliceValue(value, p), name, "", usage)
+}
+
+// DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
+	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+}
+
+// DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
+// The argument p points to a duration[] variable in which to store the value of the flag.
+func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
+	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage)
+}
+
+// DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
+	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+}
+
+// DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a []time.Duration variable that stores the value of the flag.
+func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
+	p := []time.Duration{}
+	f.DurationSliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+	p := []time.Duration{}
+	f.DurationSliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a []time.Duration variable that stores the value of the flag.
+func DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
+	return CommandLine.DurationSliceP(name, "", value, usage)
+}
+
+// DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
+func DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+	return CommandLine.DurationSliceP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/duration_slice_test.go
+++ b/vendor/github.com/spf13/pflag/duration_slice_test.go
@@ -1,0 +1,165 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code ds governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pflag
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func setUpDSFlagSet(dsp *[]time.Duration) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.DurationSliceVar(dsp, "ds", []time.Duration{}, "Command separated list!")
+	return f
+}
+
+func setUpDSFlagSetWithDefault(dsp *[]time.Duration) *FlagSet {
+	f := NewFlagSet("test", ContinueOnError)
+	f.DurationSliceVar(dsp, "ds", []time.Duration{0, 1}, "Command separated list!")
+	return f
+}
+
+func TestEmptyDS(t *testing.T) {
+	var ds []time.Duration
+	f := setUpDSFlagSet(&ds)
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	getDS, err := f.GetDurationSlice("ds")
+	if err != nil {
+		t.Fatal("got an error from GetDurationSlice():", err)
+	}
+	if len(getDS) != 0 {
+		t.Fatalf("got ds %v with len=%d but expected length=0", getDS, len(getDS))
+	}
+}
+
+func TestDS(t *testing.T) {
+	var ds []time.Duration
+	f := setUpDSFlagSet(&ds)
+
+	vals := []string{"1ns", "2ms", "3m", "4h"}
+	arg := fmt.Sprintf("--ds=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ds {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %s but got: %d", i, vals[i], v)
+		}
+	}
+	getDS, err := f.GetDurationSlice("ds")
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	for i, v := range getDS {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %s but got: %d from GetDurationSlice", i, vals[i], v)
+		}
+	}
+}
+
+func TestDSDefault(t *testing.T) {
+	var ds []time.Duration
+	f := setUpDSFlagSetWithDefault(&ds)
+
+	vals := []string{"0s", "1ns"}
+
+	err := f.Parse([]string{})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ds {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %d but got: %d", i, d, v)
+		}
+	}
+
+	getDS, err := f.GetDurationSlice("ds")
+	if err != nil {
+		t.Fatal("got an error from GetDurationSlice():", err)
+	}
+	for i, v := range getDS {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatal("got an error from GetDurationSlice():", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %d from GetDurationSlice but got: %d", i, d, v)
+		}
+	}
+}
+
+func TestDSWithDefault(t *testing.T) {
+	var ds []time.Duration
+	f := setUpDSFlagSetWithDefault(&ds)
+
+	vals := []string{"1ns", "2ns"}
+	arg := fmt.Sprintf("--ds=%s", strings.Join(vals, ","))
+	err := f.Parse([]string{arg})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ds {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %d but got: %d", i, d, v)
+		}
+	}
+
+	getDS, err := f.GetDurationSlice("ds")
+	if err != nil {
+		t.Fatal("got an error from GetDurationSlice():", err)
+	}
+	for i, v := range getDS {
+		d, err := time.ParseDuration(vals[i])
+		if err != nil {
+			t.Fatalf("got error: %v", err)
+		}
+		if d != v {
+			t.Fatalf("expected ds[%d] to be %d from GetDurationSlice but got: %d", i, d, v)
+		}
+	}
+}
+
+func TestDSCalledTwice(t *testing.T) {
+	var ds []time.Duration
+	f := setUpDSFlagSet(&ds)
+
+	in := []string{"1ns,2ns", "3ns"}
+	expected := []time.Duration{1, 2, 3}
+	argfmt := "--ds=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+	for i, v := range ds {
+		if expected[i] != v {
+			t.Fatalf("expected ds[%d] to be %d but got: %d", i, expected[i], v)
+		}
+	}
+}

--- a/vendor/github.com/spf13/pflag/flag.go
+++ b/vendor/github.com/spf13/pflag/flag.go
@@ -101,6 +101,7 @@ package pflag
 import (
 	"bytes"
 	"errors"
+	goflag "flag"
 	"fmt"
 	"io"
 	"os"
@@ -123,6 +124,12 @@ const (
 	PanicOnError
 )
 
+// ParseErrorsWhitelist defines the parsing errors that can be ignored
+type ParseErrorsWhitelist struct {
+	// UnknownFlags will ignore unknown flags errors and continue parsing rest of the flags
+	UnknownFlags bool
+}
+
 // NormalizedName is a flag name that has been normalized according to rules
 // for the FlagSet (e.g. making '-' and '_' equivalent).
 type NormalizedName string
@@ -137,6 +144,9 @@ type FlagSet struct {
 	// SortFlags is used to indicate, if user wants to have sorted flags in
 	// help/usage messages.
 	SortFlags bool
+
+	// ParseErrorsWhitelist is used to configure a whitelist of errors
+	ParseErrorsWhitelist ParseErrorsWhitelist
 
 	name              string
 	parsed            bool
@@ -153,6 +163,8 @@ type FlagSet struct {
 	output            io.Writer // nil means stderr; use out() accessor
 	interspersed      bool      // allow interspersed option/non-option args
 	normalizeNameFunc func(f *FlagSet, name string) NormalizedName
+
+	addedGoFlagSets []*goflag.FlagSet
 }
 
 // A Flag represents the state of a flag.
@@ -202,12 +214,18 @@ func sortFlags(flags map[NormalizedName]*Flag) []*Flag {
 func (f *FlagSet) SetNormalizeFunc(n func(f *FlagSet, name string) NormalizedName) {
 	f.normalizeNameFunc = n
 	f.sortedFormal = f.sortedFormal[:0]
-	for k, v := range f.orderedFormal {
-		delete(f.formal, NormalizedName(v.Name))
-		nname := f.normalizeFlagName(v.Name)
-		v.Name = string(nname)
-		f.formal[nname] = v
-		f.orderedFormal[k] = v
+	for fname, flag := range f.formal {
+		nname := f.normalizeFlagName(flag.Name)
+		if fname == nname {
+			continue
+		}
+		flag.Name = string(nname)
+		delete(f.formal, fname)
+		f.formal[nname] = flag
+		if _, set := f.actual[fname]; set {
+			delete(f.actual, fname)
+			f.actual[nname] = flag
+		}
 	}
 }
 
@@ -261,16 +279,16 @@ func (f *FlagSet) VisitAll(fn func(*Flag)) {
 	}
 }
 
-// HasFlags returns a bool to indicate if the FlagSet has any flags definied.
+// HasFlags returns a bool to indicate if the FlagSet has any flags defined.
 func (f *FlagSet) HasFlags() bool {
 	return len(f.formal) > 0
 }
 
 // HasAvailableFlags returns a bool to indicate if the FlagSet has any flags
-// definied that are not hidden or deprecated.
+// that are not hidden.
 func (f *FlagSet) HasAvailableFlags() bool {
 	for _, flag := range f.formal {
-		if !flag.Hidden && len(flag.Deprecated) == 0 {
+		if !flag.Hidden {
 			return true
 		}
 	}
@@ -380,6 +398,7 @@ func (f *FlagSet) MarkDeprecated(name string, usageMessage string) error {
 		return fmt.Errorf("deprecated message for flag %q must be set", name)
 	}
 	flag.Deprecated = usageMessage
+	flag.Hidden = true
 	return nil
 }
 
@@ -440,13 +459,15 @@ func (f *FlagSet) Set(name, value string) error {
 		return fmt.Errorf("invalid argument %q for %q flag: %v", value, flagName, err)
 	}
 
-	if f.actual == nil {
-		f.actual = make(map[NormalizedName]*Flag)
-	}
-	f.actual[normalName] = flag
-	f.orderedActual = append(f.orderedActual, flag)
+	if !flag.Changed {
+		if f.actual == nil {
+			f.actual = make(map[NormalizedName]*Flag)
+		}
+		f.actual[normalName] = flag
+		f.orderedActual = append(f.orderedActual, flag)
 
-	flag.Changed = true
+		flag.Changed = true
+	}
 
 	if flag.Deprecated != "" {
 		fmt.Fprintf(f.out(), "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
@@ -556,6 +577,14 @@ func UnquoteUsage(flag *Flag) (name string, usage string) {
 		name = "int"
 	case "uint64":
 		name = "uint"
+	case "stringSlice":
+		name = "strings"
+	case "intSlice":
+		name = "ints"
+	case "uintSlice":
+		name = "uints"
+	case "boolSlice":
+		name = "bools"
 	}
 
 	return
@@ -570,11 +599,14 @@ func wrapN(i, slop int, s string) (string, string) {
 		return s, ""
 	}
 
-	w := strings.LastIndexAny(s[:i], " \t")
+	w := strings.LastIndexAny(s[:i], " \t\n")
 	if w <= 0 {
 		return s, ""
 	}
-
+	nlPos := strings.LastIndex(s[:i], "\n")
+	if nlPos > 0 && nlPos < w {
+		return s[:nlPos], s[nlPos+1:]
+	}
 	return s[:w], s[w+1:]
 }
 
@@ -583,7 +615,7 @@ func wrapN(i, slop int, s string) (string, string) {
 // caller). Pass `w` == 0 to do no wrapping
 func wrap(i, w int, s string) string {
 	if w == 0 {
-		return s
+		return strings.Replace(s, "\n", "\n"+strings.Repeat(" ", i), -1)
 	}
 
 	// space between indent i and end of line width w into which
@@ -601,7 +633,7 @@ func wrap(i, w int, s string) string {
 	}
 	// If still not enough space then don't even try to wrap.
 	if wrap < 24 {
-		return s
+		return strings.Replace(s, "\n", r, -1)
 	}
 
 	// Try to avoid short orphan words on the final line, by
@@ -613,14 +645,14 @@ func wrap(i, w int, s string) string {
 	// Handle first line, which is indented by the caller (or the
 	// special case above)
 	l, s = wrapN(wrap, slop, s)
-	r = r + l
+	r = r + strings.Replace(l, "\n", "\n"+strings.Repeat(" ", i), -1)
 
 	// Now wrap the rest
 	for s != "" {
 		var t string
 
 		t, s = wrapN(wrap, slop, s)
-		r = r + "\n" + strings.Repeat(" ", i) + t
+		r = r + "\n" + strings.Repeat(" ", i) + strings.Replace(t, "\n", "\n"+strings.Repeat(" ", i), -1)
 	}
 
 	return r
@@ -637,7 +669,7 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 
 	maxlen := 0
 	f.VisitAll(func(flag *Flag) {
-		if flag.Deprecated != "" || flag.Hidden {
+		if flag.Hidden {
 			return
 		}
 
@@ -660,6 +692,10 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 				if flag.NoOptDefVal != "true" {
 					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 				}
+			case "count":
+				if flag.NoOptDefVal != "+1" {
+					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				}
 			default:
 				line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 			}
@@ -679,6 +715,9 @@ func (f *FlagSet) FlagUsagesWrapped(cols int) string {
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}
+		}
+		if len(flag.Deprecated) != 0 {
+			line += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
 		}
 
 		lines = append(lines, line)
@@ -857,8 +896,10 @@ func VarP(value Value, name, shorthand, usage string) {
 // returns the error.
 func (f *FlagSet) failf(format string, a ...interface{}) error {
 	err := fmt.Errorf(format, a...)
-	fmt.Fprintln(f.out(), err)
-	f.usage()
+	if f.errorHandling != ContinueOnError {
+		fmt.Fprintln(f.out(), err)
+		f.usage()
+	}
 	return err
 }
 
@@ -874,6 +915,25 @@ func (f *FlagSet) usage() {
 	}
 }
 
+//--unknown (args will be empty)
+//--unknown --next-flag ... (args will be --next-flag ...)
+//--unknown arg ... (args will be arg ...)
+func stripUnknownFlagValue(args []string) []string {
+	if len(args) == 0 {
+		//--unknown
+		return args
+	}
+
+	first := args[0]
+	if first[0] == '-' {
+		//--unknown --next-flag ...
+		return args
+	}
+
+	//--unknown arg ... (args will be arg ...)
+	return args[1:]
+}
+
 func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []string, err error) {
 	a = args
 	name := s[2:]
@@ -885,13 +945,24 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 	split := strings.SplitN(name, "=", 2)
 	name = split[0]
 	flag, exists := f.formal[f.normalizeFlagName(name)]
+
 	if !exists {
-		if name == "help" { // special case for nice help message.
+		switch {
+		case name == "help":
 			f.usage()
 			return a, ErrHelp
+		case f.ParseErrorsWhitelist.UnknownFlags:
+			// --unknown=unknownval arg ...
+			// we do not want to lose arg in this case
+			if len(split) >= 2 {
+				return a, nil
+			}
+
+			return stripUnknownFlagValue(a), nil
+		default:
+			err = f.failf("unknown flag: --%s", name)
+			return
 		}
-		err = f.failf("unknown flag: --%s", name)
-		return
 	}
 
 	var value string
@@ -912,6 +983,9 @@ func (f *FlagSet) parseLongArg(s string, args []string, fn parseFunc) (a []strin
 	}
 
 	err = fn(flag, value)
+	if err != nil {
+		f.failf(err.Error())
+	}
 	return
 }
 
@@ -926,13 +1000,25 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 
 	flag, exists := f.shorthands[c]
 	if !exists {
-		if c == 'h' { // special case for nice help message.
+		switch {
+		case c == 'h':
 			f.usage()
 			err = ErrHelp
 			return
+		case f.ParseErrorsWhitelist.UnknownFlags:
+			// '-f=arg arg ...'
+			// we do not want to lose arg in this case
+			if len(shorthands) > 2 && shorthands[1] == '=' {
+				outShorts = ""
+				return
+			}
+
+			outArgs = stripUnknownFlagValue(outArgs)
+			return
+		default:
+			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+			return
 		}
-		err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
-		return
 	}
 
 	var value string
@@ -962,6 +1048,9 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string, fn parse
 	}
 
 	err = fn(flag, value)
+	if err != nil {
+		f.failf(err.Error())
+	}
 	return
 }
 
@@ -1016,6 +1105,11 @@ func (f *FlagSet) parseArgs(args []string, fn parseFunc) (err error) {
 // are defined and before flags are accessed by the program.
 // The return value will be ErrHelp if -help was set but not defined.
 func (f *FlagSet) Parse(arguments []string) error {
+	if f.addedGoFlagSets != nil {
+		for _, goFlagSet := range f.addedGoFlagSets {
+			goFlagSet.Parse(nil)
+		}
+	}
 	f.parsed = true
 
 	if len(arguments) < 0 {
@@ -1034,6 +1128,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 		case ContinueOnError:
 			return err
 		case ExitOnError:
+			fmt.Println(err)
 			os.Exit(2)
 		case PanicOnError:
 			panic(err)

--- a/vendor/github.com/spf13/pflag/flag_test.go
+++ b/vendor/github.com/spf13/pflag/flag_test.go
@@ -106,8 +106,8 @@ func TestUsage(t *testing.T) {
 	if GetCommandLine().Parse([]string{"--x"}) == nil {
 		t.Error("parse did not fail for unknown flag")
 	}
-	if !called {
-		t.Error("did not call Usage for unknown flag")
+	if called {
+		t.Error("did call Usage while using ContinueOnError")
 	}
 }
 
@@ -168,6 +168,7 @@ func testParse(f *FlagSet, t *testing.T) {
 	bool3Flag := f.Bool("bool3", false, "bool3 value")
 	intFlag := f.Int("int", 0, "int value")
 	int8Flag := f.Int8("int8", 0, "int value")
+	int16Flag := f.Int16("int16", 0, "int value")
 	int32Flag := f.Int32("int32", 0, "int value")
 	int64Flag := f.Int64("int64", 0, "int64 value")
 	uintFlag := f.Uint("uint", 0, "uint value")
@@ -192,6 +193,7 @@ func testParse(f *FlagSet, t *testing.T) {
 		"--bool3=false",
 		"--int=22",
 		"--int8=-8",
+		"--int16=-16",
 		"--int32=-32",
 		"--int64=0x23",
 		"--uint", "24",
@@ -236,8 +238,14 @@ func testParse(f *FlagSet, t *testing.T) {
 	if *int8Flag != -8 {
 		t.Error("int8 flag should be 0x23, is ", *int8Flag)
 	}
+	if *int16Flag != -16 {
+		t.Error("int16 flag should be -16, is ", *int16Flag)
+	}
 	if v, err := f.GetInt8("int8"); err != nil || v != *int8Flag {
 		t.Error("GetInt8 does not work.")
+	}
+	if v, err := f.GetInt16("int16"); err != nil || v != *int16Flag {
+		t.Error("GetInt16 does not work.")
 	}
 	if *int32Flag != -32 {
 		t.Error("int32 flag should be 0x23, is ", *int32Flag)
@@ -381,7 +389,78 @@ func testParseAll(f *FlagSet, t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("f.ParseAll() fail to restore the args")
-		t.Errorf("Got: %v", got)
+		t.Errorf("Got:  %v", got)
+		t.Errorf("Want: %v", want)
+	}
+}
+
+func testParseWithUnknownFlags(f *FlagSet, t *testing.T) {
+	if f.Parsed() {
+		t.Error("f.Parse() = true before Parse")
+	}
+	f.ParseErrorsWhitelist.UnknownFlags = true
+
+	f.BoolP("boola", "a", false, "bool value")
+	f.BoolP("boolb", "b", false, "bool2 value")
+	f.BoolP("boolc", "c", false, "bool3 value")
+	f.BoolP("boold", "d", false, "bool4 value")
+	f.BoolP("boole", "e", false, "bool4 value")
+	f.StringP("stringa", "s", "0", "string value")
+	f.StringP("stringz", "z", "0", "string value")
+	f.StringP("stringx", "x", "0", "string value")
+	f.StringP("stringy", "y", "0", "string value")
+	f.StringP("stringo", "o", "0", "string value")
+	f.Lookup("stringx").NoOptDefVal = "1"
+	args := []string{
+		"-ab",
+		"-cs=xx",
+		"--stringz=something",
+		"--unknown1",
+		"unknown1Value",
+		"-d=true",
+		"-x",
+		"--unknown2=unknown2Value",
+		"-u=unknown3Value",
+		"-p",
+		"unknown4Value",
+		"-q", //another unknown with bool value
+		"-y",
+		"ee",
+		"--unknown7=unknown7value",
+		"--stringo=ovalue",
+		"--unknown8=unknown8value",
+		"--boole",
+		"--unknown6",
+	}
+	want := []string{
+		"boola", "true",
+		"boolb", "true",
+		"boolc", "true",
+		"stringa", "xx",
+		"stringz", "something",
+		"boold", "true",
+		"stringx", "1",
+		"stringy", "ee",
+		"stringo", "ovalue",
+		"boole", "true",
+	}
+	got := []string{}
+	store := func(flag *Flag, value string) error {
+		got = append(got, flag.Name)
+		if len(value) > 0 {
+			got = append(got, value)
+		}
+		return nil
+	}
+	if err := f.ParseAll(args, store); err != nil {
+		t.Errorf("expected no error, got %s", err)
+	}
+	if !f.Parsed() {
+		t.Errorf("f.Parse() = false after Parse")
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("f.ParseAll() fail to restore the args")
+		t.Errorf("Got:  %v", got)
 		t.Errorf("Want: %v", want)
 	}
 }
@@ -490,6 +569,11 @@ func TestParse(t *testing.T) {
 func TestParseAll(t *testing.T) {
 	ResetForTesting(func() { t.Error("bad parse") })
 	testParseAll(GetCommandLine(), t)
+}
+
+func TestIgnoreUnknownFlags(t *testing.T) {
+	ResetForTesting(func() { t.Error("bad parse") })
+	testParseWithUnknownFlags(GetCommandLine(), t)
 }
 
 func TestFlagSetParse(t *testing.T) {
@@ -604,7 +688,6 @@ func aliasAndWordSepFlagNames(f *FlagSet, name string) NormalizedName {
 	switch name {
 	case oldName:
 		name = newName
-		break
 	}
 
 	return NormalizedName(name)
@@ -655,6 +738,70 @@ func TestNormalizationFuncShouldChangeFlagName(t *testing.T) {
 	f.Bool("valid_flag", false, "bool value")
 	if f.Lookup("valid_flag").Name != "valid.flag" {
 		t.Error("The new flag should have the name 'valid.flag' instead of ", f.Lookup("valid_flag").Name)
+	}
+}
+
+// Related to https://github.com/spf13/cobra/issues/521.
+func TestNormalizationSharedFlags(t *testing.T) {
+	f := NewFlagSet("set f", ContinueOnError)
+	g := NewFlagSet("set g", ContinueOnError)
+	nfunc := wordSepNormalizeFunc
+	testName := "valid_flag"
+	normName := nfunc(nil, testName)
+	if testName == string(normName) {
+		t.Error("TestNormalizationSharedFlags meaningless: the original and normalized flag names are identical:", testName)
+	}
+
+	f.Bool(testName, false, "bool value")
+	g.AddFlagSet(f)
+
+	f.SetNormalizeFunc(nfunc)
+	g.SetNormalizeFunc(nfunc)
+
+	if len(f.formal) != 1 {
+		t.Error("Normalizing flags should not result in duplications in the flag set:", f.formal)
+	}
+	if f.orderedFormal[0].Name != string(normName) {
+		t.Error("Flag name not normalized")
+	}
+	for k := range f.formal {
+		if k != "valid.flag" {
+			t.Errorf("The key in the flag map should have been normalized: wanted \"%s\", got \"%s\" instead", normName, k)
+		}
+	}
+
+	if !reflect.DeepEqual(f.formal, g.formal) || !reflect.DeepEqual(f.orderedFormal, g.orderedFormal) {
+		t.Error("Two flag sets sharing the same flags should stay consistent after being normalized. Original set:", f.formal, "Duplicate set:", g.formal)
+	}
+}
+
+func TestNormalizationSetFlags(t *testing.T) {
+	f := NewFlagSet("normalized", ContinueOnError)
+	nfunc := wordSepNormalizeFunc
+	testName := "valid_flag"
+	normName := nfunc(nil, testName)
+	if testName == string(normName) {
+		t.Error("TestNormalizationSetFlags meaningless: the original and normalized flag names are identical:", testName)
+	}
+
+	f.Bool(testName, false, "bool value")
+	f.Set(testName, "true")
+	f.SetNormalizeFunc(nfunc)
+
+	if len(f.formal) != 1 {
+		t.Error("Normalizing flags should not result in duplications in the flag set:", f.formal)
+	}
+	if f.orderedFormal[0].Name != string(normName) {
+		t.Error("Flag name not normalized")
+	}
+	for k := range f.formal {
+		if k != "valid.flag" {
+			t.Errorf("The key in the flag map should have been normalized: wanted \"%s\", got \"%s\" instead", normName, k)
+		}
+	}
+
+	if !reflect.DeepEqual(f.formal, f.actual) {
+		t.Error("The map of set flags should get normalized. Formal:", f.formal, "Actual:", f.actual)
 	}
 }
 
@@ -819,10 +966,14 @@ func TestTermination(t *testing.T) {
 	}
 }
 
-func TestDeprecatedFlagInDocs(t *testing.T) {
+func getDeprecatedFlagSet() *FlagSet {
 	f := NewFlagSet("bob", ContinueOnError)
 	f.Bool("badflag", true, "always true")
 	f.MarkDeprecated("badflag", "use --good-flag instead")
+	return f
+}
+func TestDeprecatedFlagInDocs(t *testing.T) {
+	f := getDeprecatedFlagSet()
 
 	out := new(bytes.Buffer)
 	f.SetOutput(out)
@@ -830,6 +981,27 @@ func TestDeprecatedFlagInDocs(t *testing.T) {
 
 	if strings.Contains(out.String(), "badflag") {
 		t.Errorf("found deprecated flag in usage!")
+	}
+}
+
+func TestUnHiddenDeprecatedFlagInDocs(t *testing.T) {
+	f := getDeprecatedFlagSet()
+	flg := f.Lookup("badflag")
+	if flg == nil {
+		t.Fatalf("Unable to lookup 'bob' in TestUnHiddenDeprecatedFlagInDocs")
+	}
+	flg.Hidden = false
+
+	out := new(bytes.Buffer)
+	f.SetOutput(out)
+	f.PrintDefaults()
+
+	defaults := out.String()
+	if !strings.Contains(defaults, "badflag") {
+		t.Errorf("Did not find deprecated flag in usage!")
+	}
+	if !strings.Contains(defaults, "use --good-flag instead") {
+		t.Errorf("Did not find 'use --good-flag instead' in defaults")
 	}
 }
 
@@ -978,16 +1150,17 @@ const defaultOutput = `      --A                         for bootstrapping, allo
       --IP ip                     IP address with no default
       --IPMask ipMask             Netmask address with no default
       --IPNet ipNet               IP network with no default
-      --Ints intSlice             int slice with zero default
+      --Ints ints                 int slice with zero default
       --N int                     a non-zero int (default 27)
       --ND1 string[="bar"]        a string with NoOptDefVal (default "foo")
       --ND2 num[=4321]            a num with NoOptDefVal (default 1234)
       --StringArray stringArray   string array with zero default
-      --StringSlice stringSlice   string slice with zero default
+      --StringSlice strings       string slice with zero default
       --Z int                     an int that defaults to zero
       --custom custom             custom Value implementation
       --customP custom            a VarP with default (default 10)
       --maxT timeout              set timeout for dial
+  -v, --verbose count             verbosity
 `
 
 // Custom value that satisfies the Value interface.
@@ -1028,6 +1201,7 @@ func TestPrintDefaults(t *testing.T) {
 	fs.ShorthandLookup("E").NoOptDefVal = "1234"
 	fs.StringSlice("StringSlice", []string{}, "string slice with zero default")
 	fs.StringArray("StringArray", []string{}, "string array with zero default")
+	fs.CountP("verbose", "v", "verbosity")
 
 	var cv customValue
 	fs.Var(&cv, "custom", "custom Value implementation")

--- a/vendor/github.com/spf13/pflag/golangflag.go
+++ b/vendor/github.com/spf13/pflag/golangflag.go
@@ -98,4 +98,8 @@ func (f *FlagSet) AddGoFlagSet(newSet *goflag.FlagSet) {
 	newSet.VisitAll(func(goflag *goflag.Flag) {
 		f.AddGoFlag(goflag)
 	})
+	if f.addedGoFlagSets == nil {
+		f.addedGoFlagSets = make([]*goflag.FlagSet, 0)
+	}
+	f.addedGoFlagSets = append(f.addedGoFlagSets, newSet)
 }

--- a/vendor/github.com/spf13/pflag/golangflag_test.go
+++ b/vendor/github.com/spf13/pflag/golangflag_test.go
@@ -36,4 +36,12 @@ func TestGoflags(t *testing.T) {
 	if getBool != true {
 		t.Fatalf("expected getBool=true but got getBool=%v", getBool)
 	}
+	if !f.Parsed() {
+		t.Fatal("f.Parsed() return false after f.Parse() called")
+	}
+
+	// in fact it is useless. because `go test` called flag.Parse()
+	if !goflag.CommandLine.Parsed() {
+		t.Fatal("goflag.CommandLine.Parsed() return false after f.Parse() called")
+	}
 }

--- a/vendor/github.com/spf13/pflag/int16.go
+++ b/vendor/github.com/spf13/pflag/int16.go
@@ -1,0 +1,88 @@
+package pflag
+
+import "strconv"
+
+// -- int16 Value
+type int16Value int16
+
+func newInt16Value(val int16, p *int16) *int16Value {
+	*p = val
+	return (*int16Value)(p)
+}
+
+func (i *int16Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 16)
+	*i = int16Value(v)
+	return err
+}
+
+func (i *int16Value) Type() string {
+	return "int16"
+}
+
+func (i *int16Value) String() string { return strconv.FormatInt(int64(*i), 10) }
+
+func int16Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseInt(sval, 0, 16)
+	if err != nil {
+		return 0, err
+	}
+	return int16(v), nil
+}
+
+// GetInt16 returns the int16 value of a flag with the given name
+func (f *FlagSet) GetInt16(name string) (int16, error) {
+	val, err := f.getFlagType(name, "int16", int16Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(int16), nil
+}
+
+// Int16Var defines an int16 flag with specified name, default value, and usage string.
+// The argument p points to an int16 variable in which to store the value of the flag.
+func (f *FlagSet) Int16Var(p *int16, name string, value int16, usage string) {
+	f.VarP(newInt16Value(value, p), name, "", usage)
+}
+
+// Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
+	f.VarP(newInt16Value(value, p), name, shorthand, usage)
+}
+
+// Int16Var defines an int16 flag with specified name, default value, and usage string.
+// The argument p points to an int16 variable in which to store the value of the flag.
+func Int16Var(p *int16, name string, value int16, usage string) {
+	CommandLine.VarP(newInt16Value(value, p), name, "", usage)
+}
+
+// Int16VarP is like Int16Var, but accepts a shorthand letter that can be used after a single dash.
+func Int16VarP(p *int16, name, shorthand string, value int16, usage string) {
+	CommandLine.VarP(newInt16Value(value, p), name, shorthand, usage)
+}
+
+// Int16 defines an int16 flag with specified name, default value, and usage string.
+// The return value is the address of an int16 variable that stores the value of the flag.
+func (f *FlagSet) Int16(name string, value int16, usage string) *int16 {
+	p := new(int16)
+	f.Int16VarP(p, name, "", value, usage)
+	return p
+}
+
+// Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int16P(name, shorthand string, value int16, usage string) *int16 {
+	p := new(int16)
+	f.Int16VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int16 defines an int16 flag with specified name, default value, and usage string.
+// The return value is the address of an int16 variable that stores the value of the flag.
+func Int16(name string, value int16, usage string) *int16 {
+	return CommandLine.Int16P(name, "", value, usage)
+}
+
+// Int16P is like Int16, but accepts a shorthand letter that can be used after a single dash.
+func Int16P(name, shorthand string, value int16, usage string) *int16 {
+	return CommandLine.Int16P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/printusage_test.go
+++ b/vendor/github.com/spf13/pflag/printusage_test.go
@@ -1,0 +1,74 @@
+package pflag
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+const expectedOutput = `      --long-form    Some description
+      --long-form2   Some description
+                       with multiline
+  -s, --long-name    Some description
+  -t, --long-name2   Some description with
+                       multiline
+`
+
+func setUpPFlagSet(buf io.Writer) *FlagSet {
+	f := NewFlagSet("test", ExitOnError)
+	f.Bool("long-form", false, "Some description")
+	f.Bool("long-form2", false, "Some description\n  with multiline")
+	f.BoolP("long-name", "s", false, "Some description")
+	f.BoolP("long-name2", "t", false, "Some description with\n  multiline")
+	f.SetOutput(buf)
+	return f
+}
+
+func TestPrintUsage(t *testing.T) {
+	buf := bytes.Buffer{}
+	f := setUpPFlagSet(&buf)
+	f.PrintDefaults()
+	res := buf.String()
+	if res != expectedOutput {
+		t.Errorf("Expected \n%s \nActual \n%s", expectedOutput, res)
+	}
+}
+
+func setUpPFlagSet2(buf io.Writer) *FlagSet {
+	f := NewFlagSet("test", ExitOnError)
+	f.Bool("long-form", false, "Some description")
+	f.Bool("long-form2", false, "Some description\n  with multiline")
+	f.BoolP("long-name", "s", false, "Some description")
+	f.BoolP("long-name2", "t", false, "Some description with\n  multiline")
+	f.StringP("some-very-long-arg", "l", "test", "Some very long description having break the limit")
+	f.StringP("other-very-long-arg", "o", "long-default-value", "Some very long description having break the limit")
+	f.String("some-very-long-arg2", "very long default value", "Some very long description\nwith line break\nmultiple")
+	f.SetOutput(buf)
+	return f
+}
+
+const expectedOutput2 = `      --long-form                    Some description
+      --long-form2                   Some description
+                                       with multiline
+  -s, --long-name                    Some description
+  -t, --long-name2                   Some description with
+                                       multiline
+  -o, --other-very-long-arg string   Some very long description having
+                                     break the limit (default
+                                     "long-default-value")
+  -l, --some-very-long-arg string    Some very long description having
+                                     break the limit (default "test")
+      --some-very-long-arg2 string   Some very long description
+                                     with line break
+                                     multiple (default "very long default
+                                     value")
+`
+
+func TestPrintUsage_2(t *testing.T) {
+	buf := bytes.Buffer{}
+	f := setUpPFlagSet2(&buf)
+	res := f.FlagUsagesWrapped(80)
+	if res != expectedOutput2 {
+		t.Errorf("Expected \n%q \nActual \n%q", expectedOutput2, res)
+	}
+}

--- a/vendor/github.com/spf13/pflag/string_array.go
+++ b/vendor/github.com/spf13/pflag/string_array.go
@@ -52,7 +52,7 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the values of the multiple flags.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string) {
 	f.VarP(newStringArrayValue(value, p), name, "", usage)
 }
@@ -64,7 +64,7 @@ func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []s
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func StringArrayVar(p *[]string, name string, value []string, usage string) {
 	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage)
 }
@@ -76,7 +76,7 @@ func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage 
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func (f *FlagSet) StringArray(name string, value []string, usage string) *[]string {
 	p := []string{}
 	f.StringArrayVarP(&p, name, "", value, usage)
@@ -92,7 +92,7 @@ func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage str
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func StringArray(name string, value []string, usage string) *[]string {
 	return CommandLine.StringArrayP(name, "", value, usage)
 }

--- a/vendor/github.com/spf13/pflag/string_slice.go
+++ b/vendor/github.com/spf13/pflag/string_slice.go
@@ -82,6 +82,11 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string) {
 	f.VarP(newStringSliceValue(value, p), name, "", usage)
 }
@@ -93,6 +98,11 @@ func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []s
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func StringSliceVar(p *[]string, name string, value []string, usage string) {
 	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
 }
@@ -104,6 +114,11 @@ func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage 
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSlice(name string, value []string, usage string) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, "", value, usage)
@@ -119,6 +134,11 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func StringSlice(name string, value []string, usage string) *[]string {
 	return CommandLine.StringSliceP(name, "", value, usage)
 }


### PR DESCRIPTION
Ignore unknown falgs for init and create commands  …
If the user attempts to run a command like:

    riff create java --handler functions.Uppercase

...but they do not have the java invoker installed, they currently
recieve an unhelpful error saying the `--handler` flag is unknown. Since
the init and create root comamnds require an invoker, and some invokers
require the handler flag while others do no, we can relax the
enforcement of unknown flags for these commands. Subcommands continue to
enforce unknown flags.

The ability to supress unknown flag warnings is new in pflags v1.0.1.

Fixes #555