### PR TITLE
Repair 404 performance regression by using a shared TopicInformer

### DIFF
--- a/http-gateway/cmd/http-gateway.go
+++ b/http-gateway/cmd/http-gateway.go
@@ -54,6 +54,7 @@ func main() {
 	defer consumer.Close()
 
 	done := make(chan struct{})
+	defer close(done)
 
 	var topicExistenceChecker server.TopicExistenceChecker
 	restConf, err := rest.InClusterConfig()
@@ -76,7 +77,6 @@ func main() {
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, os.Kill)
 	<-signals
 	log.Println("Shutting Down...")
-	close(done)
 }
 
 func brokers() []string {

--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -154,6 +154,6 @@ type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
-	return topicName == th.testName, nil
+func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
+	return topicName == th.testName
 }

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -41,12 +41,7 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.topicExistenceChecker.TopicExists(defaultNamespace, topicName)
-	if err != nil {
-		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return
-	}
+	topicExists:= g.topicExistenceChecker.TopicExists(defaultNamespace, topicName)
 	if !topicExists {
 		errMsg := fmt.Sprintf("could not find Riff topic '%s'", topicName)
 		http.Error(w, errMsg, http.StatusNotFound)

--- a/http-gateway/pkg/server/messages_handler_test.go
+++ b/http-gateway/pkg/server/messages_handler_test.go
@@ -231,9 +231,3 @@ type happyRiffTopicExistenceChecker struct {
 func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
 	return topicName == th.testName
 }
-
-type errorRiffTopicExistenceChecker struct{}
-
-func (th *errorRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
-	return false
-}

--- a/http-gateway/pkg/server/messages_handler_test.go
+++ b/http-gateway/pkg/server/messages_handler_test.go
@@ -81,21 +81,6 @@ var _ = Describe("MessagesHandler", func() {
 		})
 	})
 
-	Context("When an unexpected error occurs while looking up a Riff topic", func() {
-		BeforeEach(func() {
-			gateway.topicExistenceChecker = &errorRiffTopicExistenceChecker{}
-		})
-
-		AfterEach(func() {
-			gateway.topicExistenceChecker = &happyRiffTopicExistenceChecker{}
-		})
-
-		It("should return a 500", func() {
-			resp := mockResponseWriter.Result()
-			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
-		})
-	})
-
 	Context("when the request body cannot be read", func() {
 		BeforeEach(func() {
 			req.Body = &badReader{testError}
@@ -243,12 +228,12 @@ type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
-	return topicName == th.testName, nil
+func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
+	return topicName == th.testName
 }
 
 type errorRiffTopicExistenceChecker struct{}
 
-func (th *errorRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
-	return false, errors.New("test error")
+func (th *errorRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
+	return false
 }

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -44,12 +44,8 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists, err := g.topicExistenceChecker.TopicExists(defaultNamespace, topicName)
-	if err != nil {
-		errMsg := fmt.Sprintf("while checking to see if there was a Riff topic '%s', an unexpected error occurred: %+v", topicName, err)
-		http.Error(w, errMsg, http.StatusInternalServerError)
-		return
-	}
+	topicExists := g.topicExistenceChecker.TopicExists(defaultNamespace, topicName)
+
 	if !topicExists {
 		errMsg := fmt.Sprintf("could not find Riff topic '%s'", topicName)
 		http.Error(w, errMsg, http.StatusNotFound)

--- a/http-gateway/pkg/server/requests_handler_test.go
+++ b/http-gateway/pkg/server/requests_handler_test.go
@@ -68,44 +68,109 @@ var _ = Describe("RequestsHandler", func() {
 		done = make(chan struct{})
 	})
 
-	Context("when Riff Topic lookup is working", func() {
 
-		JustBeforeEach(func() {
-			gateway = New(8080, mockProducer, stubConsumer, timeout, &happyRiffTopicExistenceChecker{testName: "testtopic"})
+	JustBeforeEach(func() {
+		gateway = New(8080, mockProducer, stubConsumer, timeout, &happyRiffTopicExistenceChecker{testName: "testtopic"})
 
-			go gateway.repliesLoop(done)
-			gateway.requestsHandler(mockResponseWriter, req)
+		go gateway.repliesLoop(done)
+		gateway.requestsHandler(mockResponseWriter, req)
+	})
+
+	AfterEach(func() {
+		done <- struct{}{}
+	})
+
+	Context("when the request URL is unexpected", func() {
+		BeforeEach(func() {
+			req.URL.Path = "/short"
 		})
 
-		AfterEach(func() {
-			done <- struct{}{}
+		It("should return a 404", func() {
+			resp := mockResponseWriter.Result()
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Context("when the request refers to a non-existent Riff Topic", func() {
+		BeforeEach(func() {
+			req.URL.Path = "/requests/nosuchtopicexists"
 		})
 
-		Context("when the request URL is unexpected", func() {
+		It("should return a 404", func() {
+			resp := mockResponseWriter.Result()
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Context("when the request body cannot be read", func() {
+		BeforeEach(func() {
+			req.Body = &badReader{testError}
+		})
+
+		It("should reply with a suitable error response", func() {
+			resp := mockResponseWriter.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+			Expect(string(body)).To(HavePrefix(errorMessage))
+		})
+	})
+
+	Context("when the request body can be read", func() {
+		BeforeEach(func() {
+			req.Body = ioutil.NopCloser(strings.NewReader("body"))
+		})
+
+		Context("when sending succeeds", func() {
 			BeforeEach(func() {
-				req.URL.Path = "/short"
+				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+					msg, ok := args[1].(message.Message)
+					Expect(ok).To(BeTrue())
+					stubConsumer.Send(msg, "topic")
+				}).Return(nil)
 			})
 
-			It("should return a 404", func() {
+			It("should send one message to the producer", func() {
+				Expect(sendIndex(mockProducer)).To(BeNumerically(">", -1))
+			})
+
+			It("should send to the correct topic", func() {
+				Expect(mockProducer.Calls[sendIndex(mockProducer)].Arguments[0]).To(Equal("testtopic"))
+			})
+
+			It("should send a message containing the correct body", func() {
+				Expect(string(sentMessage(mockProducer).Payload())).To(Equal("body"))
+			})
+
+			It("should send a message with a correlation id header", func() {
+				Expect(sentMessage(mockProducer).Headers()).To(HaveKey("correlationId"))
+			})
+
+			Context("when the request contains some headers that should be propagated and some that should not", func() {
+				BeforeEach(func() {
+					req.Header.Add("Content-Type", "text/plain")
+					req.Header.Add("Accept", "application/json")
+					req.Header.Add("Accept", "text/plain")
+					req.Header.Add("Accept-Charset", "utf-8")
+				})
+
+				It("should send a message containing the correct headers", func() {
+					headers := sentMessage(mockProducer).Headers()
+					Expect(headers).To(HaveKeyWithValue("Content-Type", ConsistOf("text/plain")))
+					Expect(headers).To(HaveKeyWithValue("Accept", ConsistOf("application/json", "text/plain")))
+					Expect(headers).NotTo(HaveKey("Accept-Charset"))
+				})
+			})
+
+			It("should reply with an OK response", func() {
 				resp := mockResponseWriter.Result()
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			})
 		})
 
-		Context("when the request refers to a non-existent Riff Topic", func() {
+		Context("when sending fails", func() {
 			BeforeEach(func() {
-				req.URL.Path = "/requests/nosuchtopicexists"
-			})
-
-			It("should return a 404", func() {
-				resp := mockResponseWriter.Result()
-				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
-			})
-		})
-
-		Context("when the request body cannot be read", func() {
-			BeforeEach(func() {
-				req.Body = &badReader{testError}
+				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(testError)
 			})
 
 			It("should reply with a suitable error response", func() {
@@ -117,153 +182,64 @@ var _ = Describe("RequestsHandler", func() {
 			})
 		})
 
-		Context("when the request body can be read", func() {
+		Context("when sending succeeds but the reply takes too long", func() {
 			BeforeEach(func() {
-				req.Body = ioutil.NopCloser(strings.NewReader("body"))
+				timeout = time.Nanosecond
+				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(nil)
 			})
 
-			Context("when sending succeeds", func() {
-				BeforeEach(func() {
-					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-						msg, ok := args[1].(message.Message)
-						Expect(ok).To(BeTrue())
-						stubConsumer.Send(msg, "topic")
-					}).Return(nil)
-				})
-
-				It("should send one message to the producer", func() {
-					Expect(sendIndex(mockProducer)).To(BeNumerically(">", -1))
-				})
-
-				It("should send to the correct topic", func() {
-					Expect(mockProducer.Calls[sendIndex(mockProducer)].Arguments[0]).To(Equal("testtopic"))
-				})
-
-				It("should send a message containing the correct body", func() {
-					Expect(string(sentMessage(mockProducer).Payload())).To(Equal("body"))
-				})
-
-				It("should send a message with a correlation id header", func() {
-					Expect(sentMessage(mockProducer).Headers()).To(HaveKey("correlationId"))
-				})
-
-				Context("when the request contains some headers that should be propagated and some that should not", func() {
-					BeforeEach(func() {
-						req.Header.Add("Content-Type", "text/plain")
-						req.Header.Add("Accept", "application/json")
-						req.Header.Add("Accept", "text/plain")
-						req.Header.Add("Accept-Charset", "utf-8")
-					})
-
-					It("should send a message containing the correct headers", func() {
-						headers := sentMessage(mockProducer).Headers()
-						Expect(headers).To(HaveKeyWithValue("Content-Type", ConsistOf("text/plain")))
-						Expect(headers).To(HaveKeyWithValue("Accept", ConsistOf("application/json", "text/plain")))
-						Expect(headers).NotTo(HaveKey("Accept-Charset"))
-					})
-				})
-
-				It("should reply with an OK response", func() {
-					resp := mockResponseWriter.Result()
-					Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				})
-			})
-
-			Context("when sending fails", func() {
-				BeforeEach(func() {
-					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(testError)
-				})
-
-				It("should reply with a suitable error response", func() {
-					resp := mockResponseWriter.Result()
-					body, _ := ioutil.ReadAll(resp.Body)
-
-					Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
-					Expect(string(body)).To(HavePrefix(errorMessage))
-				})
-			})
-
-			Context("when sending succeeds but the reply takes too long", func() {
-				BeforeEach(func() {
-					timeout = time.Nanosecond
-					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Return(nil)
-				})
-
-				It("should time out with a 504", func() {
-					resp := mockResponseWriter.Result()
-					Expect(resp.StatusCode).To(Equal(http.StatusGatewayTimeout))
-				})
-			})
-
-			Context("when sending succeeds but the producer reports an error before the reply comes back", func() {
-				BeforeEach(func() {
-					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-						msg, ok := args[1].(message.Message)
-						Expect(ok).To(BeTrue())
-
-						producerErrors <- testError
-
-						stubConsumer.Send(msg, "topic")
-					}).Return(nil)
-				})
-
-				It("should reply with OK", func() {
-					resp := mockResponseWriter.Result()
-					Expect(resp.StatusCode).To(Equal(http.StatusOK))
-				})
-			})
-
-			Context("when sending succeeds but a reply comes back with the wrong correlation id", func() {
-				BeforeEach(func() {
-					timeout = 10 * time.Millisecond
-					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-						headers := make(message.Headers)
-						headers["correlationId"] = []string{""}
-						stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
-					}).Return(nil)
-				})
-
-				It("should time out with a 504", func() {
-					resp := mockResponseWriter.Result()
-					Expect(resp.StatusCode).To(Equal(http.StatusGatewayTimeout))
-				})
-			})
-
-			Context("when sending succeeds but the reply is an error", func() {
-				BeforeEach(func() {
-					mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
-						msg, ok := args[1].(message.Message)
-						Expect(ok).To(BeTrue())
-						headers := msg.Headers()
-						headers["error"] = []string{"error-server-function-invocation"}
-						stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
-					}).Return(nil)
-				})
-
-				It("should reply with a 500", func() {
-					resp := mockResponseWriter.Result()
-					Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
-				})
+			It("should time out with a 504", func() {
+				resp := mockResponseWriter.Result()
+				Expect(resp.StatusCode).To(Equal(http.StatusGatewayTimeout))
 			})
 		})
-	})
 
-	// the way the tests are set up for this mess with the 500-status/Riff topic lookup test
-	// so we need another Describe() block to create separate cases.
-	Context("when Riff Topic lookup fails unexpectedly", func() {
-		JustBeforeEach(func() {
-			gateway = New(8080, mockProducer, stubConsumer, timeout, &errorRiffTopicExistenceChecker{})
+		Context("when sending succeeds but the producer reports an error before the reply comes back", func() {
+			BeforeEach(func() {
+				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+					msg, ok := args[1].(message.Message)
+					Expect(ok).To(BeTrue())
 
-			go gateway.repliesLoop(done)
-			gateway.requestsHandler(mockResponseWriter, req)
+					producerErrors <- testError
+
+					stubConsumer.Send(msg, "topic")
+				}).Return(nil)
+			})
+
+			It("should reply with OK", func() {
+				resp := mockResponseWriter.Result()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			})
 		})
 
-		AfterEach(func() {
-			done <- struct{}{}
+		Context("when sending succeeds but a reply comes back with the wrong correlation id", func() {
+			BeforeEach(func() {
+				timeout = 10 * time.Millisecond
+				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+					headers := make(message.Headers)
+					headers["correlationId"] = []string{""}
+					stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
+				}).Return(nil)
+			})
+
+			It("should time out with a 504", func() {
+				resp := mockResponseWriter.Result()
+				Expect(resp.StatusCode).To(Equal(http.StatusGatewayTimeout))
+			})
 		})
 
-		Context("When an unexpected error occurs while looking up a Riff topic", func() {
-			It("should return a 500", func() {
+		Context("when sending succeeds but the reply is an error", func() {
+			BeforeEach(func() {
+				mockProducer.On("Send", mock.AnythingOfType("string"), mock.Anything).Run(func(args mock.Arguments) {
+					msg, ok := args[1].(message.Message)
+					Expect(ok).To(BeTrue())
+					headers := msg.Headers()
+					headers["error"] = []string{"error-server-function-invocation"}
+					stubConsumer.Send(message.NewMessage([]byte(""), headers), "banana")
+				}).Return(nil)
+			})
+
+			It("should reply with a 500", func() {
 				resp := mockResponseWriter.Result()
 				Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 			})

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -26,9 +26,9 @@ type TopicExistenceChecker interface {
 }
 
 type riffTopicExistenceChecker struct {
+	mutex         *sync.Mutex
 	topicInformer v1alpha1.TopicInformer
 	knownTopics   map[string]ignoredValue
-	mutex *sync.Mutex
 }
 
 type ignoredValue struct{}
@@ -43,10 +43,12 @@ func NewAlwaysTrueTopicExistenceChecker() TopicExistenceChecker {
 // NewRiffTopicExistenceChecker configures a TopicExistenceChecker using the
 // provided Clientset.
 func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistenceChecker {
+	mutex := &sync.Mutex{}
+
 	riffInformerFactory := informers.NewSharedInformerFactory(clientSet, time.Second*30)
 	topicInformer := riffInformerFactory.Projectriff().V1alpha1().Topics()
+
 	knownTopics := make(map[string]ignoredValue)
-	mutex := &sync.Mutex{}
 
 	topicInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -55,6 +55,7 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 			mutex.Lock()
 			defer mutex.Unlock()
 
+			//TODO: implement riff-specific KeyFunc https://github.com/projectriff/riff/pull/558#discussion_r184437224
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err != nil {
 				// It is likely that the key is faulty, but we cannot signal an error.
@@ -71,6 +72,7 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 			mutex.Lock()
 			defer mutex.Unlock()
 
+			//TODO: implement riff-specific KeyFunc https://github.com/projectriff/riff/pull/558#discussion_r184437224
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err != nil {
 				// It is likely that the key is faulty, but we cannot signal an error.

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -31,11 +31,9 @@ type riffTopicExistenceChecker struct {
 	mutex *sync.Mutex
 }
 
-type ignoredValue struct {
-}
+type ignoredValue struct{}
 
-type alwaysTrueTopicExistenceChecker struct {
-}
+type alwaysTrueTopicExistenceChecker struct{}
 
 // NewAlwaysTrueTopicExistenceChecker configures a TopicExistenceChecker that always returns true.
 func NewAlwaysTrueTopicExistenceChecker() TopicExistenceChecker {

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -26,8 +26,9 @@ type TopicExistenceChecker interface {
 }
 
 type riffTopicExistenceChecker struct {
-	mutex         *sync.Mutex
 	topicInformer v1alpha1.TopicInformer
+
+	mutex         *sync.Mutex
 	knownTopics   map[string]ignoredValue
 }
 
@@ -43,11 +44,10 @@ func NewAlwaysTrueTopicExistenceChecker() TopicExistenceChecker {
 // NewRiffTopicExistenceChecker configures a TopicExistenceChecker using the
 // provided Clientset.
 func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistenceChecker {
-	mutex := &sync.Mutex{}
-
 	riffInformerFactory := informers.NewSharedInformerFactory(clientSet, time.Second*30)
 	topicInformer := riffInformerFactory.Projectriff().V1alpha1().Topics()
 
+	mutex := &sync.Mutex{}
 	knownTopics := make(map[string]ignoredValue)
 
 	topicInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -89,7 +89,7 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 	done := make(chan struct{}) //TODO: ideally, this would be the same channel used by the gateway itself
 	go topicInformer.Informer().Run(done)
 
-	return &riffTopicExistenceChecker{topicInformer: topicInformer, knownTopics: knownTopics, mutex: mutex}
+	return &riffTopicExistenceChecker{topicInformer: topicInformer, mutex: mutex, knownTopics: knownTopics}
 }
 
 func (tec *alwaysTrueTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -57,7 +57,10 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err != nil {
+				// It is likely that the key is faulty, but we cannot signal an error.
+				// To prevent errors for processing a bad key, we return after logging.
 				log.Printf("AddFunc had an error for key '%s': %+v", err)
+				return
 			}
 
 			knownTopics[key] = ignoredValue{}
@@ -70,7 +73,10 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err != nil {
+				// It is likely that the key is faulty, but we cannot signal an error.
+				// To prevent errors for processing a bad key, we return after logging.
 				log.Printf("DeleteFunc had an error for key '%s': %+v", err)
+				return
 			}
 
 			delete(knownTopics, key)

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -59,12 +59,12 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 			if err != nil {
 				// It is likely that the key is faulty, but we cannot signal an error.
 				// To prevent errors for processing a bad key, we return after logging.
-				log.Printf("AddFunc had an error for key '%s': %+v", err)
+				log.Printf("AddFunc failed during a topic lookup: %#v", err)
 				return
 			}
 
 			knownTopics[key] = ignoredValue{}
-			log.Printf("Added topic to internal map: %+v", key)
+			log.Printf("New topic has been added: %s", key)
 		},
 
 		DeleteFunc: func(obj interface{}) {
@@ -75,12 +75,12 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 			if err != nil {
 				// It is likely that the key is faulty, but we cannot signal an error.
 				// To prevent errors for processing a bad key, we return after logging.
-				log.Printf("DeleteFunc had an error for key '%s': %+v", err)
+				log.Printf("DeleteFunc failed during a topic lookup: %#v", err)
 				return
 			}
 
 			delete(knownTopics, key)
-			log.Printf("Removed topic from internal map: %+v", key)
+			log.Printf("A topic was removed: %s", key)
 		},
 	})
 

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -43,7 +43,7 @@ func NewAlwaysTrueTopicExistenceChecker() TopicExistenceChecker {
 
 // NewRiffTopicExistenceChecker configures a TopicExistenceChecker using the
 // provided Clientset.
-func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistenceChecker {
+func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset, stop <-chan struct{}) TopicExistenceChecker {
 	riffInformerFactory := informers.NewSharedInformerFactory(clientSet, time.Second*30)
 	topicInformer := riffInformerFactory.Projectriff().V1alpha1().Topics()
 
@@ -86,8 +86,7 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 		},
 	})
 
-	done := make(chan struct{}) //TODO: ideally, this would be the same channel used by the gateway itself
-	go topicInformer.Informer().Run(done)
+	go topicInformer.Informer().Run(stop)
 
 	return &riffTopicExistenceChecker{topicInformer: topicInformer, mutex: mutex, knownTopics: knownTopics}
 }

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -19,7 +19,7 @@ const (
 // TopicExistenceChecker allows the http-gateway to check for the existence of
 // a Topic before attempting to send a message to that topic.
 type TopicExistenceChecker interface {
-	TopicExists(namespace string, topicName string) (bool, error)
+	TopicExists(namespace string, topicName string) bool
 }
 
 type riffTopicExistenceChecker struct {
@@ -71,21 +71,15 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset) TopicExistence
 	return &riffTopicExistenceChecker{topicInformer: topicInformer, knownTopics: knownTopics}
 }
 
-func (tec *alwaysTrueTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
-	return true, nil
+func (tec *alwaysTrueTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
+	return true
 }
 
-// TopicExists checks to see if Kubernetes is aware of a Riff Topic in a namespace.
-// If the topic exists, it returns (true, nil)
-// If the topic does not exist, it returns (false, nil)
-// If there is an unexpected error, it returns (false, err), where 'err' is the unexpected
-// error that was encountered.
-func (tec *riffTopicExistenceChecker) TopicExists(namespace string, topicName string) (bool, error) {
+// TopicExists checks to see if Kubernetes is aware of a riff Topic in a namespace.
+func (tec *riffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
 	topicKey := fmt.Sprintf("%s/%s", namespace, topicName)
 
-	if _, exists := tec.knownTopics[topicKey]; exists {
-		return true, nil
-	} else {
-		return false, nil
-	}
+	 _, exists := tec.knownTopics[topicKey];
+
+	return exists
 }


### PR DESCRIPTION
## Background

The issue reported at projectriff/riff#553 showed that topic checking introduced a performance regression of 2 orders of magnitude. This renders the s1p sample unusable. The commits in this PR change the implementation to use a callback-with-cache mechanism provided by Kubernetes APIs (shared informers).

To validate performance improvement, I compared the `alwaysTrueTopicExistenceChecker` and `RiffTopicExistenceChecker` using `ab2`. Not very scientific, but a useful sanity check. My test case shows the two checking strategies now perform approximately identically, suggesting they are hitting some bottleneck unrelated to topic lookup.

## alwaysTrueTopicExistenceChecker

```
ab -H "Content-Type: text/plain" -n 100000 -c 100 -p in.txt http://192.168.39.8:30788/requests/numbers
...
Concurrency Level:      100
Time taken for tests:   19.363 seconds
Complete requests:      100000
Failed requests:        0
Total transferred:      10400000 bytes
Total body sent:        17700000
HTML transferred:       300000 bytes
Requests per second:    5164.55 [#/sec] (mean)
Time per request:       19.363 [ms] (mean)
Time per request:       0.194 [ms] (mean, across all concurrent requests)
Transfer rate:          524.53 [Kbytes/sec] received
                        892.70 kb/s sent
                        1417.23 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.2      0       5
Processing:     5   19  38.6     17    1268
Waiting:        5   19  38.6     17    1268
Total:          5   19  38.7     18    1270

Percentage of the requests served within a certain time (ms)
  50%     18
  66%     19
  75%     20
  80%     21
  90%     24
  95%     26
  98%     29
  99%     32
 100%   1270 (longest request)
```

## RiffTopicExistenceChecker using a TopicInformer

```
ab -H "Content-Type: text/plain" -n 100000 -c 100 -p in.txt http://192.168.39.8:32408/requests/numbers
...
Concurrency Level:      100
Time taken for tests:   19.131 seconds
Complete requests:      100000
Failed requests:        0
Total transferred:      10400000 bytes
Total body sent:        17700000
HTML transferred:       300000 bytes
Requests per second:    5227.05 [#/sec] (mean)
Time per request:       19.131 [ms] (mean)
Time per request:       0.191 [ms] (mean, across all concurrent requests)
Transfer rate:          530.87 [Kbytes/sec] received
                        903.50 kb/s sent
                        1434.38 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.2      0       5
Processing:     5   19  38.1     17    1247
Waiting:        5   19  38.1     17    1247
Total:          5   19  38.2     17    1250

Percentage of the requests served within a certain time (ms)
  50%     17
  66%     19
  75%     20
  80%     21
  90%     24
  95%     26
  98%     30
  99%     32
 100%   1250 (longest request)
```