### PR TITLE
Add FunctionName as a file generator token

### DIFF
--- a/riff-cli/pkg/initializer/file_generator.go
+++ b/riff-cli/pkg/initializer/file_generator.go
@@ -26,6 +26,7 @@ import (
 )
 
 type fileTokens struct {
+	FunctionName   string
 	Artifact       string
 	ArtifactBase   string
 	InvokerVersion string
@@ -48,6 +49,7 @@ func generateFileContents(tmpl string, name string, opts options.InitOptions) (s
 
 func generateFileTokens(opts options.InitOptions) fileTokens {
 	tokens := fileTokens{}
+	tokens.FunctionName = opts.FunctionName
 	tokens.Artifact = opts.Artifact
 	tokens.ArtifactBase = filepath.Base(opts.Artifact)
 	tokens.InvokerVersion = opts.InvokerVersion

--- a/riff-cli/test_data/invokers/node-function-invoker.yaml
+++ b/riff-cli/test_data/invokers/node-function-invoker.yaml
@@ -15,6 +15,7 @@ spec:
   - path: Dockerfile
     template: |
       FROM projectriff/node-function-invoker:{{.InvokerVersion}}
+      ENV FUNCTION_NAME {{.FunctionName}}
       {{ if .FileExists "package.json" -}}
       ENV FUNCTION_URI /functions/
       COPY . ${FUNCTION_URI}

--- a/riff-cli/test_data/riff-init/matching-invoker-with-invoker-version/Dockerfile
+++ b/riff-cli/test_data/riff-init/matching-invoker-with-invoker-version/Dockerfile
@@ -1,3 +1,4 @@
 FROM projectriff/node-function-invoker:latest
+ENV FUNCTION_NAME matching-invoker-with-invoker-version
 ENV FUNCTION_URI /functions/echo.js
 ADD echo.js ${FUNCTION_URI}

--- a/riff-cli/test_data/riff-init/matching-invoker-with-version/Dockerfile
+++ b/riff-cli/test_data/riff-init/matching-invoker-with-version/Dockerfile
@@ -1,3 +1,4 @@
 FROM projectriff/node-function-invoker:0.0.5-snapshot
+ENV FUNCTION_NAME matching-invoker-with-version
 ENV FUNCTION_URI /functions/echo.js
 ADD echo.js ${FUNCTION_URI}

--- a/riff-cli/test_data/riff-init/matching-invoker/Dockerfile
+++ b/riff-cli/test_data/riff-init/matching-invoker/Dockerfile
@@ -1,3 +1,4 @@
 FROM projectriff/node-function-invoker:0.0.5-snapshot
+ENV FUNCTION_NAME matching-invoker
 ENV FUNCTION_URI /functions/echo.js
 ADD echo.js ${FUNCTION_URI}


### PR DESCRIPTION
Fucntion invokers can now access the function's name when scaffolding
files durring the `riff init` phase.