### PR TITLE
Add kubectl current-context to `riff version`

### DIFF
--- a/riff-cli/cmd/version.go
+++ b/riff-cli/cmd/version.go
@@ -39,6 +39,11 @@ func Version(w io.Writer, kubeCtl kubectl.KubeCtl) *cobra.Command {
 
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(w, "riff CLI version: %v\n", global.CLI_VERSION)
+			context, err := kubeCtl.Exec([]string{"config", "current-context"})
+			if err != nil {
+				context = "<unknown>"
+			}
+			fmt.Fprintf(w, "kubectl context: %v\n", strings.Trim(context, "\n"))
 			fmt.Fprintln(w)
 			components, err := kubeCtl.Exec([]string{
 				"get", "deployments",

--- a/riff-cli/cmd/version.go
+++ b/riff-cli/cmd/version.go
@@ -43,7 +43,7 @@ func Version(w io.Writer, kubeCtl kubectl.KubeCtl) *cobra.Command {
 			if err != nil {
 				context = "<unknown>"
 			}
-			fmt.Fprintf(w, "kubectl context: %v\n", strings.Trim(context, "\n"))
+			fmt.Fprintf(w, "kubeconfig current-context: %v\n", strings.Trim(context, "\n"))
 			fmt.Fprintln(w)
 			components, err := kubeCtl.Exec([]string{
 				"get", "deployments",

--- a/riff-cli/cmd/version_test.go
+++ b/riff-cli/cmd/version_test.go
@@ -60,14 +60,16 @@ var _ = Describe("The version command", func() {
 	})
 
 	It("should list the cli, component, and invoker versions", func() {
+		kubeClient.On("Exec", []string{"config", "current-context"}).Return("minikube\n", nil).Once()
 		kubeClient.On("Exec", listComponetsKubeArgs).Return("<Component Table>\n", nil).Once()
 		kubeClient.On("Exec", listInvokersKubeArgs).Return("<Invokers Table>\n", nil).Once()
 
 		err := versionCommand.Execute()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(writer.String()).To(Equal(
-			fmt.Sprintf("riff CLI version: %s\n\n%s\n\n%s\n",
+			fmt.Sprintf("riff CLI version: %s\nkubectl context: %s\n\n%s\n\n%s\n",
 				"0.0.1-testing",
+				"minikube",
 				"<Component Table>",
 				"<Invokers Table>",
 			),
@@ -75,14 +77,16 @@ var _ = Describe("The version command", func() {
 	})
 
 	It("should list the cli version even when kubectl fails", func() {
+		kubeClient.On("Exec", []string{"config", "current-context"}).Return("", fmt.Errorf("kubectl fault")).Once()
 		kubeClient.On("Exec", listComponetsKubeArgs).Return("", fmt.Errorf("kubectl fault")).Once()
 		kubeClient.On("Exec", listInvokersKubeArgs).Return("", fmt.Errorf("kubectl fault")).Once()
 
 		err := versionCommand.Execute()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(writer.String()).To(Equal(
-			fmt.Sprintf("riff CLI version: %s\n\n%s\n\n%s\n",
+			fmt.Sprintf("riff CLI version: %s\nkubectl context: %s\n\n%s\n\n%s\n",
 				"0.0.1-testing",
+				"<unknown>",
 				"Unable to list components",
 				"Unable to list invokers",
 			),

--- a/riff-cli/cmd/version_test.go
+++ b/riff-cli/cmd/version_test.go
@@ -67,7 +67,7 @@ var _ = Describe("The version command", func() {
 		err := versionCommand.Execute()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(writer.String()).To(Equal(
-			fmt.Sprintf("riff CLI version: %s\nkubectl context: %s\n\n%s\n\n%s\n",
+			fmt.Sprintf("riff CLI version: %s\nkubeconfig current-context: %s\n\n%s\n\n%s\n",
 				"0.0.1-testing",
 				"minikube",
 				"<Component Table>",
@@ -84,7 +84,7 @@ var _ = Describe("The version command", func() {
 		err := versionCommand.Execute()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(writer.String()).To(Equal(
-			fmt.Sprintf("riff CLI version: %s\nkubectl context: %s\n\n%s\n\n%s\n",
+			fmt.Sprintf("riff CLI version: %s\nkubeconfig current-context: %s\n\n%s\n\n%s\n",
 				"0.0.1-testing",
 				"<unknown>",
 				"Unable to list components",


### PR DESCRIPTION
```bash
$ riff version
riff CLI version: 0.0.7-snapshot
kubectl context: docker-for-desktop

COMPONENT             IMAGE
function-controller   projectriff/function-controller:0.0.7-snapshot
http-gateway          projectriff/http-gateway:0.0.7-snapshot
topic-controller      projectriff/topic-controller:0.0.7-snapshot

INVOKER   VERSION
java      0.0.6
node      0.0.9-snapshot
```