### PR TITLE
Componentize autoscaler simulator code

### DIFF
--- a/function-controller/Makefile
+++ b/function-controller/Makefile
@@ -45,6 +45,6 @@ kubectl-apply:
 	kubectl apply -n riff-system -f config/deployment.yaml
 
 simulation:
-	go build pkg/controller/autoscaler/simulator/simulator.go
+	go build cmd/simulator/simulator.go
 	./simulator
 	gnuplot -c pkg/controller/autoscaler/simulator/simulator.plt > simulation-results.png

--- a/function-controller/cmd/simulator/simulator.go
+++ b/function-controller/cmd/simulator/simulator.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/projectriff/riff/function-controller/pkg/controller/autoscaler"
+	"github.com/projectriff/riff/function-controller/pkg/controller/autoscaler/simulator/scenarios"
+)
+
+const (
+	simulationSteps = 10000
+	maxReplicas     = 1000000 // avoid setting this too high to avoid int overflow during scaling calculation. 1000000 is a reasonable high value.
+)
+
+func main() {
+	fmt.Println("starting to drive autoscaler with simulated workload")
+
+	dataFile, err := os.Create("scaler.dat")
+	if err != nil {
+		panic(err)
+	}
+	defer dataFile.Close()
+
+	stubFunctionID := autoscaler.FunctionId{Function: "stub function"}
+
+	scenario := scenarios.CombinedScenario{}
+	receiver, simUpdater, rm := scenario.MakeNewSimulation()
+	queueLen := int64(0)
+	inspector := newStubInspector(&queueLen)
+
+	scaler := autoscaler.NewAutoScaler(receiver, inspector)
+	defer scaler.Close()
+
+	scaler.SetMaxReplicasPolicy(func(function autoscaler.FunctionId) int {
+		return maxReplicas
+	})
+
+	scaler.Run()
+	scaler.StartMonitoring("topic", stubFunctionID)
+
+	actualReplicas := 0
+
+	writes := 0
+
+	for i := 0; i < simulationSteps; i++ {
+		simUpdater.UpdateProducerFor(i, &queueLen, &writes)
+		simUpdater.UpdatedConsumerFor(i, actualReplicas, &queueLen)
+
+		scalerOutput := scaler.Propose()
+
+		scalerOutputForStubFunction := scalerOutput[stubFunctionID]
+
+		rm.DesireReplicas(scalerOutputForStubFunction)
+		rm.Tick()
+		actualReplicas = rm.ActualReplicas()
+		// Scale number of replicas
+		step := fmt.Sprintf("%d %d %d %d\n", i, actualReplicas, queueLen, writes)
+		dataFile.WriteString(step)
+
+		scaler.InformFunctionReplicas(stubFunctionID, actualReplicas)
+	}
+
+	fmt.Println("simulation completed")
+}
+
+type stubInspector struct {
+	queueLen *int64
+}
+
+func newStubInspector(queueLen *int64) *stubInspector {
+	return &stubInspector{
+		queueLen: queueLen,
+	}
+}
+
+func (i *stubInspector) QueueLength(topic string, function string) (int64, error) {
+	return *i.queueLen, nil
+}

--- a/function-controller/pkg/controller/autoscaler/simulator/scenarios/combined_scenario.go
+++ b/function-controller/pkg/controller/autoscaler/simulator/scenarios/combined_scenario.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	replicaInitialisationDelaySteps = 2 // 1.5 s delayed initialisation (termination is immediate)
-	containerPullDelaySteps         = 0 // 50 // 5.0 s extra delay in starting the first replica
+	replicaInitialisationDelaySteps = 15 // 1.5 s delayed initialisation (termination is immediate)
+	containerPullDelaySteps         = 0  // 50 // 5.0 s extra delay in starting the first replica
 
 	maxWritesPerTick = 40
 )

--- a/function-controller/pkg/controller/autoscaler/simulator/scenarios/combined_scenario.go
+++ b/function-controller/pkg/controller/autoscaler/simulator/scenarios/combined_scenario.go
@@ -1,0 +1,161 @@
+package scenarios
+
+import (
+	"github.com/projectriff/riff/message-transport/pkg/transport/metrics"
+	"github.com/projectriff/riff/function-controller/pkg/controller/autoscaler/simulator"
+	"math"
+	"time"
+)
+
+const (
+	replicaInitialisationDelaySteps = 2 // 1.5 s delayed initialisation (termination is immediate)
+	containerPullDelaySteps         = 0 // 50 // 5.0 s extra delay in starting the first replica
+
+	maxWritesPerTick = 40
+)
+
+type CombinedScenario struct {}
+
+func (scenario CombinedScenario) MakeNewSimulation() (metrics.MetricsReceiver, simulator.SimulationUpdater, simulator.ReplicaModel) {
+	stubReceiver := newStubReceiver()
+	rm := &replicaModel{initialDelay: containerPullDelaySteps}
+
+	return stubReceiver, stubReceiver, rm
+}
+
+type stubReceiver struct {
+	producerMetricsChan chan metrics.ProducerAggregateMetric
+	consumerMetricsChan chan metrics.ConsumerAggregateMetric
+
+	currentRound int
+}
+
+func (rec *stubReceiver) ProducerMetrics() <-chan metrics.ProducerAggregateMetric {
+	return rec.producerMetricsChan
+}
+
+func (rec *stubReceiver) ConsumerMetrics() <-chan metrics.ConsumerAggregateMetric {
+	return rec.consumerMetricsChan
+}
+
+func (rec *stubReceiver) UpdateProducerFor(simulationRound int, queueLen *int64, writes *int) {
+	numToWrite := 0
+	if simulationRound < 100 {
+		// initial quiet interval
+		numToWrite = 0
+	} else if simulationRound < 1000 {
+		// step up
+		numToWrite = maxWritesPerTick / 2
+	} else if simulationRound < 2000 {
+		// further step up
+		numToWrite = maxWritesPerTick
+	} else if simulationRound < 3000 {
+		// step down
+		numToWrite = maxWritesPerTick / 2
+	} else if simulationRound < 4000 {
+		// step down to quiet interval
+		numToWrite = 0
+	} else if simulationRound < 6000 {
+		// sinusoidal interval
+		numToWrite = maxWritesPerTick/2 + int(maxWritesPerTick*math.Sin(float64((simulationRound-4000)/167))/2)
+	} else if simulationRound < 7000 {
+		// step down to quiet interval
+		numToWrite = 0
+	} else if simulationRound < 8000 {
+		// ramp up
+		numToWrite = maxWritesPerTick * (simulationRound - 7000) / 1000
+	} else if simulationRound < 9000 {
+		// ramp down
+		numToWrite = maxWritesPerTick * (9000 - simulationRound) / 1000
+	}
+
+	*writes = numToWrite
+
+	for i := numToWrite; i > 0; i-- {
+		rec.producerMetricsChan <- metrics.ProducerAggregateMetric{Topic: "topic", Count: 1}
+		(*queueLen)++
+	}
+}
+
+func (rec *stubReceiver) UpdatedConsumerFor(simulationRound int, replicas int, queueLen *int64) {
+	if replicas == 0 {
+		return // nothing doing
+	}
+
+	numToRead := 10 * replicas
+	if *queueLen < int64(numToRead) {
+		numToRead = int(*queueLen)
+	}
+	for i := numToRead; i > 0; i-- {
+		rec.consumerMetricsChan <- metrics.ConsumerAggregateMetric{Topic: "topic", ConsumerGroup: "stub function", Pod: "pod" /*should vary by replica*/ , Count: 1, Interval: time.Millisecond}
+		(*queueLen)--
+	}
+}
+
+func newStubReceiver() *stubReceiver {
+	return &stubReceiver{
+		producerMetricsChan: make(chan metrics.ProducerAggregateMetric),
+		consumerMetricsChan: make(chan metrics.ConsumerAggregateMetric),
+	}
+}
+
+
+// A replicaModel models the way new replicas take a while to start.
+// An increase of N in the desired number of replicas results in N items being added to `scheduled`. Each item in
+// `scheduled` represents a time (in "ticks") at which the corresponding replica will count towards the actual number of
+// replicas. This isn't quite the same behaviour as k8s, which knows about, and will inform the function controller of,
+// replicas which are still completing their initialisation, but at least it makes the model more realistic than if
+// replicas initialise instantaneously.
+// A decrease in the desired number of replicas is acted upon immediately by removing items from `scheduled` and, if
+// that isn't sufficient, reducing the actual number of replicas.
+type replicaModel struct {
+	currentTime  int // in "ticks"
+	actual       int
+	lastDesired  int
+	scheduled    []int
+	initialDelay int
+}
+
+func (rm *replicaModel) DesireReplicas(desired int) {
+	if desired == rm.lastDesired {
+		return
+	}
+	if desired > rm.lastDesired {
+		// schedule some new replicas with a delay
+		initTime := rm.currentTime + replicaInitialisationDelaySteps + rm.initialDelay
+		rm.initialDelay = 0
+		for i := desired - rm.lastDesired; i > 0; i-- {
+			rm.scheduled = append(rm.scheduled, initTime)
+		}
+	} else {
+		rm.trim(rm.lastDesired - desired)
+	}
+	rm.lastDesired = desired
+}
+
+func (rm *replicaModel) trim(deschedule int) {
+	if deschedule >= len(rm.scheduled) {
+		trimmed := len(rm.scheduled)
+		rm.scheduled = []int{}
+		rm.actual -= deschedule - trimmed
+	} else {
+		rm.scheduled = rm.scheduled[0 : len(rm.scheduled)-deschedule]
+	}
+}
+
+func (rm *replicaModel) ActualReplicas() int {
+	return rm.actual
+}
+
+func (rm *replicaModel) Tick() {
+	rm.currentTime++
+	remaining := []int{}
+	for _, s := range rm.scheduled {
+		if s <= rm.currentTime {
+			rm.actual++
+		} else {
+			remaining = append(remaining, s)
+		}
+	}
+	rm.scheduled = remaining
+}

--- a/function-controller/pkg/controller/autoscaler/simulator/scenarios/combined_scenario_test.go
+++ b/function-controller/pkg/controller/autoscaler/simulator/scenarios/combined_scenario_test.go
@@ -1,4 +1,4 @@
-package main
+package scenarios
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -16,37 +16,37 @@ var _ = Describe("Simulator", func() {
 		})
 
 		It("should delay increasing the actual number of replicas", func() {
-			rm.desireReplicas(9)
+			rm.DesireReplicas(9)
 			for i := 0; i < replicaInitialisationDelaySteps-1; i++ {
-				rm.tick()
+				rm.Tick()
 				Expect(rm.actual).To(Equal(0))
 			}
-			rm.tick()
+			rm.Tick()
 			Expect(rm.actual).To(Equal(9))
 		})
 
 		It("should delay new increases", func() {
-			rm.desireReplicas(9)
+			rm.DesireReplicas(9)
 			for i := 0; i < replicaInitialisationDelaySteps-1; i++ {
-				rm.tick()
+				rm.Tick()
 				Expect(rm.actual).To(Equal(0))
-				rm.desireReplicas(12)
+				rm.DesireReplicas(12)
 			}
-			rm.tick()
+			rm.Tick()
 			Expect(rm.actual).To(Equal(9))
-			rm.tick()
+			rm.Tick()
 			Expect(rm.actual).To(Equal(12))
 		})
 
 		It("should expedite decreases", func() {
-			rm.desireReplicas(9)
-			rm.desireReplicas(5)
+			rm.DesireReplicas(9)
+			rm.DesireReplicas(5)
 
 			for i := 0; i < replicaInitialisationDelaySteps-1; i++ {
-				rm.tick()
+				rm.Tick()
 				Expect(rm.actual).To(Equal(0))
 			}
-			rm.tick()
+			rm.Tick()
 			Expect(rm.actual).To(Equal(5))
 		})
 

--- a/function-controller/pkg/controller/autoscaler/simulator/scenarios/scenarios_suite_test.go
+++ b/function-controller/pkg/controller/autoscaler/simulator/scenarios/scenarios_suite_test.go
@@ -1,4 +1,4 @@
-package main
+package scenarios
 
 import (
 	"testing"

--- a/function-controller/pkg/controller/autoscaler/simulator/simulator.go
+++ b/function-controller/pkg/controller/autoscaler/simulator/simulator.go
@@ -14,233 +14,24 @@
  * limitations under the License.
  */
 
-package main
+package simulator
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/projectriff/riff/function-controller/pkg/controller/autoscaler"
 	"github.com/projectriff/riff/message-transport/pkg/transport/metrics"
-	"math"
-	"time"
 )
-
-const (
-	simulationSteps                 = 10000
-	replicaInitialisationDelaySteps = 15 // 1.5 s delayed initialisation (termination is immediate)
-	containerPullDelaySteps         = 0 // 50 // 5.0 s extra delay in starting the first replica
-	maxWritesPerTick                = 40
-	maxReplicas                     = 1000000 // avoid setting this too high to avoid int overflow during scaling calculation. 1000000 is a reasonable high value.
-)
-
-func main() {
-	fmt.Println("starting to drive autoscaler with simulated workload")
-
-	dataFile, err := os.Create("scaler.dat")
-	if err != nil {
-		panic(err)
-	}
-	defer dataFile.Close()
-
-	stubFunctionID := autoscaler.FunctionId{Function: "stub function"}
-
-	receiver := newStubReceiver()
-	queueLen := int64(0)
-	inspector := newStubInspector(&queueLen)
-
-	scaler := autoscaler.NewAutoScaler(receiver, inspector)
-	defer scaler.Close()
-
-	scaler.SetMaxReplicasPolicy(func(function autoscaler.FunctionId) int {
-		return maxReplicas
-	})
-
-	var simUpdater SimulationUpdater
-	simUpdater = receiver
-
-	scaler.Run()
-	scaler.StartMonitoring("topic", stubFunctionID)
-
-	actualReplicas := 0
-
-	rm := &replicaModel{initialDelay: containerPullDelaySteps}
-
-	writes := 0
-
-	for i := 0; i < simulationSteps; i++ {
-		simUpdater.UpdateProducerFor(i, &queueLen, &writes)
-		simUpdater.UpdatedConsumerFor(i, actualReplicas, &queueLen)
-
-		scalerOutput := scaler.Propose()
-
-		scalerOutputForStubFunction := scalerOutput[stubFunctionID]
-
-		rm.desireReplicas(scalerOutputForStubFunction)
-		rm.tick()
-		actualReplicas = rm.actualReplicas()
-		// Scale number of replicas
-		step := fmt.Sprintf("%d %d %d %d\n", i, actualReplicas, queueLen, writes)
-		dataFile.WriteString(step)
-
-		scaler.InformFunctionReplicas(stubFunctionID, actualReplicas)
-	}
-
-	fmt.Println("simulation completed")
-}
 
 type SimulationUpdater interface {
 	UpdateProducerFor(simulationRound int, queueLen *int64, writes *int)
 	UpdatedConsumerFor(simulationRound int, replicas int, queueLen *int64)
 }
 
-type stubReceiver struct {
-	producerMetricsChan chan metrics.ProducerAggregateMetric
-	consumerMetricsChan chan metrics.ConsumerAggregateMetric
-
-	currentRound int
+type ReplicaModel interface {
+	DesireReplicas(int)
+	ActualReplicas() int
+	Tick()
 }
 
-func (rec *stubReceiver) ProducerMetrics() <-chan metrics.ProducerAggregateMetric {
-	return rec.producerMetricsChan
+type SimulationConfiguration interface {
+	MakeNewSimulation() (metrics.MetricsReceiver, SimulationUpdater, ReplicaModel)
 }
 
-func (rec *stubReceiver) ConsumerMetrics() <-chan metrics.ConsumerAggregateMetric {
-	return rec.consumerMetricsChan
-}
-
-func (rec *stubReceiver) UpdateProducerFor(simulationRound int, queueLen *int64, writes *int) {
-	numToWrite := 0
-	if simulationRound < 100 {
-		// initial quiet interval
-		numToWrite = 0
-	} else if simulationRound < 1000 {
-		// step up
-		numToWrite = maxWritesPerTick / 2
-	} else if simulationRound < 2000 {
-		// further step up
-		numToWrite = maxWritesPerTick
-	} else if simulationRound < 3000 {
-		// step down
-		numToWrite = maxWritesPerTick / 2
-	} else if simulationRound < 4000 {
-		// step down to quiet interval
-		numToWrite = 0
-	} else if simulationRound < 6000 {
-		// sinusoidal interval
-		numToWrite = maxWritesPerTick/2 + int(maxWritesPerTick*math.Sin(float64((simulationRound-4000)/167))/2)
-	} else if simulationRound < 7000 {
-		// step down to quiet interval
-		numToWrite = 0
-	} else if simulationRound < 8000 {
-		// ramp up
-		numToWrite = maxWritesPerTick * (simulationRound - 7000) / 1000
-	} else if simulationRound < 9000 {
-		// ramp down
-		numToWrite = maxWritesPerTick * (9000 - simulationRound) / 1000
-	}
-
-	*writes = numToWrite
-
-	for i := numToWrite; i > 0; i-- {
-		rec.producerMetricsChan <- metrics.ProducerAggregateMetric{Topic: "topic", Count: 1}
-		(*queueLen)++
-	}
-}
-
-func (rec *stubReceiver) UpdatedConsumerFor(simulationRound int, replicas int, queueLen *int64) {
-	if replicas == 0 {
-		return // nothing doing
-	}
-
-	numToRead := 10 * replicas
-	if *queueLen < int64(numToRead) {
-		numToRead = int(*queueLen)
-	}
-	for i := numToRead; i > 0; i-- {
-		rec.consumerMetricsChan <- metrics.ConsumerAggregateMetric{Topic: "topic", ConsumerGroup: "stub function", Pod: "pod" /*should vary by replica*/ , Count: 1, Interval: time.Millisecond}
-		(*queueLen)--
-	}
-}
-
-func
-newStubReceiver() *stubReceiver {
-	return &stubReceiver{
-		producerMetricsChan: make(chan metrics.ProducerAggregateMetric),
-		consumerMetricsChan: make(chan metrics.ConsumerAggregateMetric),
-	}
-}
-
-type stubInspector struct {
-	queueLen *int64
-}
-
-func newStubInspector(queueLen *int64) *stubInspector {
-	return &stubInspector{
-		queueLen: queueLen,
-	}
-}
-
-func (i *stubInspector) QueueLength(topic string, function string) (int64, error) {
-	return *i.queueLen, nil
-}
-
-// A replicaModel models the way new replicas take a while to start.
-// An increase of N in the desired number of replicas results in N items being added to `scheduled`. Each item in
-// `scheduled` represents a time (in "ticks") at which the corresponding replica will count towards the actual number of
-// replicas. This isn't quite the same behaviour as k8s, which knows about, and will inform the function controller of,
-// replicas which are still completing their initialisation, but at least it makes the model more realistic than if
-// replicas initialise instantaneously.
-// A decrease in the desired number of replicas is acted upon immediately by removing items from `scheduled` and, if
-// that isn't sufficient, reducing the actual number of replicas.
-type replicaModel struct {
-	currentTime  int // in "ticks"
-	actual       int
-	lastDesired  int
-	scheduled    []int
-	initialDelay int
-}
-
-func (rm *replicaModel) desireReplicas(desired int) {
-	if desired == rm.lastDesired {
-		return
-	}
-	if desired > rm.lastDesired {
-		// schedule some new replicas with a delay
-		initTime := rm.currentTime + replicaInitialisationDelaySteps + rm.initialDelay
-		rm.initialDelay = 0
-		for i := desired - rm.lastDesired; i > 0; i-- {
-			rm.scheduled = append(rm.scheduled, initTime)
-		}
-	} else {
-		rm.trim(rm.lastDesired - desired)
-	}
-	rm.lastDesired = desired
-}
-
-func (rm *replicaModel) trim(deschedule int) {
-	if deschedule >= len(rm.scheduled) {
-		trimmed := len(rm.scheduled)
-		rm.scheduled = []int{}
-		rm.actual -= deschedule - trimmed
-	} else {
-		rm.scheduled = rm.scheduled[0 : len(rm.scheduled)-deschedule]
-	}
-}
-
-func (rm *replicaModel) actualReplicas() int {
-	return rm.actual
-}
-
-func (rm *replicaModel) tick() {
-	rm.currentTime++
-	remaining := []int{}
-	for _, s := range rm.scheduled {
-		if s <= rm.currentTime {
-			rm.actual++
-		} else {
-			remaining = append(remaining, s)
-		}
-	}
-	rm.scheduled = remaining
-}


### PR DESCRIPTION
Previously the autoscaler simulator lived entirely in a single file.
This commit decomposes the simulator into distinct components in order
to allow further enhancements of the simulator's flexibility and
features.

- Extract cmd/simulator
- Extract scenarios
  * Introduce SimulationConfiguration interface
  * Introduce ReplicaModel interface
  * Extract CombinedScenario