### PR TITLE
Check for topic in all namespaces

### DIFF
--- a/http-gateway/pkg/server/gateway_integration_test.go
+++ b/http-gateway/pkg/server/gateway_integration_test.go
@@ -154,6 +154,6 @@ type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
+func (th *happyRiffTopicExistenceChecker) TopicExists(topicName string) bool {
 	return topicName == th.testName
 }

--- a/http-gateway/pkg/server/messages_handler.go
+++ b/http-gateway/pkg/server/messages_handler.go
@@ -41,7 +41,7 @@ func (g *gateway) messagesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists:= g.topicExistenceChecker.TopicExists(defaultNamespace, topicName)
+	topicExists := g.topicExistenceChecker.TopicExists(topicName)
 	if !topicExists {
 		errMsg := fmt.Sprintf("could not find Riff topic '%s'", topicName)
 		http.Error(w, errMsg, http.StatusNotFound)

--- a/http-gateway/pkg/server/messages_handler_test.go
+++ b/http-gateway/pkg/server/messages_handler_test.go
@@ -228,6 +228,6 @@ type happyRiffTopicExistenceChecker struct {
 	testName string
 }
 
-func (th *happyRiffTopicExistenceChecker) TopicExists(namespace string, topicName string) bool {
+func (th *happyRiffTopicExistenceChecker) TopicExists(topicName string) bool {
 	return topicName == th.testName
 }

--- a/http-gateway/pkg/server/requests_handler.go
+++ b/http-gateway/pkg/server/requests_handler.go
@@ -44,7 +44,7 @@ func (g *gateway) requestsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topicExists := g.topicExistenceChecker.TopicExists(defaultNamespace, topicName)
+	topicExists := g.topicExistenceChecker.TopicExists(topicName)
 
 	if !topicExists {
 		errMsg := fmt.Sprintf("could not find Riff topic '%s'", topicName)

--- a/http-gateway/pkg/server/topic_existence_checker.go
+++ b/http-gateway/pkg/server/topic_existence_checker.go
@@ -76,7 +76,7 @@ func NewRiffTopicExistenceChecker(clientSet *versioned.Clientset, stop <-chan st
 			defer mutex.Unlock()
 
 			//TODO: implement riff-specific KeyFunc https://github.com/projectriff/riff/pull/558#discussion_r184437224
-			key, err := cache.MetaNamespaceKeyFunc(obj)
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err != nil {
 				// It is likely that the key is faulty, but we cannot signal an error.
 				// To prevent errors for processing a bad key, we return after logging.

--- a/topic-controller/README.adoc
+++ b/topic-controller/README.adoc
@@ -7,9 +7,9 @@ Currently the topic resource is namespaced while the messaging broker is per clu
 functions with topics created in different namespaces using the same input topic name. Both functions will process messages
 for this shared topic.
 
-The behavior for duplicate input topics is undefined when it comes to request/reply invocations. It seems that the last created
-function is the one that responds to the request using the correlationId. You will see error message from the other function's
-reply where the communication channel for the correlationId isn't found.
+The behavior for duplicate input topics is undefined when it comes to request/reply invocations. One of the functions will 
+respond to the request using the correlationId. You will see error message from the other function's reply where the 
+communication channel for the correlationId isn't found.
 
 == Development
 === Prerequisites

--- a/topic-controller/README.adoc
+++ b/topic-controller/README.adoc
@@ -7,8 +7,8 @@ Currently the topic resource is namespaced while the messaging broker is per clu
 functions with topics created in different namespaces using the same input topic name. Both functions will process messages
 for this shared topic.
 
-The behavior for duplicate input topics is undefined when it comes to request/reply invocations. One of the functions will 
-respond to the request using the correlationId. You will see error message from the other function's reply where the 
+The behavior for duplicate input topics is non-deterministic when it comes to request/reply invocations. One of the functions
+will respond to the request using the correlationId. You will see error message from the other function's reply where the 
 communication channel for the correlationId isn't found.
 
 == Development

--- a/topic-controller/README.adoc
+++ b/topic-controller/README.adoc
@@ -3,6 +3,14 @@ The *topic controller* runs inside kubernetes and continuously monitors the *top
 definitions for changes. It reacts by creating new topics (with given characteristics such as number of partitions)
 in the messaging broker.
 
+Currently the topic resource is namespaced while the messaging broker is per cluster. This creates a conflict if there are
+functions with topics created in different namespaces using the same input topic name. Both functions will process messages
+for this shared topic.
+
+The behavior for duplicate input topics is undefined when it comes to request/reply invocations. It seems that the last created
+function is the one that responds to the request using the correlationId. You will see error message from the other function's
+reply where the communication channel for the correlationId isn't found.
+
 == Development
 === Prerequisites
 The following tools are required to build this project:


### PR DESCRIPTION
- this change ignores the namespace and just checks for topic name

- riff currently only works for deploying a function or topic with a specific name into a single namespace, deploying the same resource with the same name to two different namespaces is not supported.

- the same function and topic can be created in two namespaces but which one will be used is unknown

- if a topic that exists in two namespaces is removed from one of the namespaces used the gateway will not be able to find the one from the other namespace

- this is more similar to the behavior that was in place before we started checking for the existence of the topic

See #485 and #459 

Fixes #529