### PR TITLE
Delete function if topics don't exist

### DIFF
--- a/riff-cli/cmd/delete.go
+++ b/riff-cli/cmd/delete.go
@@ -92,15 +92,11 @@ func deleteFunctionByName(opts DeleteOptions, actingClient kubectl.KubeCtl, quer
 			}
 			if inputTopic != "" {
 				cmdArgs[2] = inputTopic
-				if err := deleteResources(cmdArgs, actingClient); err != nil {
-					return nil
-				}
+				deleteResources(cmdArgs, actingClient)
 			}
 			if outputTopic != "" {
 				cmdArgs[2] = outputTopic
-				if err := deleteResources(cmdArgs, actingClient); err != nil {
-					return nil
-				}
+				deleteResources(cmdArgs, actingClient)
 			}
 		}
 	}
@@ -129,11 +125,12 @@ func lookupTopicNames(opts DeleteOptions, queryClient kubectl.KubeCtl) (string, 
 		getArgs = append(getArgs, "--namespace", opts.Namespace)
 	}
 	getArgs = append(getArgs, "functions.projectriff.io", opts.FunctionName, "-o", "json")
-	json, err := queryClient.Exec(getArgs)
+	output, err := queryClient.Exec(getArgs)
 	if err != nil {
+		fmt.Println(output)
 		return "", "", err
 	}
-	parser := jsonpath.NewParser([]byte(json))
+	parser := jsonpath.NewParser([]byte(output))
 
 	inputTopic, _ := parser.StringValue(`$.spec.input`)
 	outputTopic, _ := parser.StringValue(`$.spec.output`)

--- a/riff-cli/cmd/delete_test.go
+++ b/riff-cli/cmd/delete_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/juju/errgo/errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
@@ -73,6 +74,33 @@ var _ = Describe("The delete command", func() {
 
 			realKubeCtl.On("Exec", []string{"get", "functions.projectriff.io", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
 			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic"}).Return("", nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic"}).Return("", nil)
+
+			err := deleteCmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("should delete the function when run with --all and the topics do not exist", func() {
+
+			deleteCmd.SetArgs([]string{"--all"})
+			realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "echo"}).Return("", nil)
+
+			realKubeCtl.On("Exec", []string{"get", "functions.projectriff.io", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic"}).Return("", errors.New("Error from server (NotFound): topics.projectriff.io \"myInputTopic\" not found"))
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic"}).Return("", errors.New("Error from server (NotFound): topics.projectriff.io \"myOutputTopic\" not found"))
+
+			err := deleteCmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+		It("should delete the function when run with --all and one topic do not exist", func() {
+
+			deleteCmd.SetArgs([]string{"--all"})
+			realKubeCtl.On("Exec", []string{"delete", "functions.projectriff.io", "echo"}).Return("", nil)
+
+			realKubeCtl.On("Exec", []string{"get", "functions.projectriff.io", "echo", "-o", "json"}).Return(canned_kubectl_get_response, nil)
+			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myInputTopic"}).Return("", errors.New("Error from server (NotFound): topics.projectriff.io \"myInputTopic\" not found"))
 			realKubeCtl.On("Exec", []string{"delete", "topics.projectriff.io", "myOutputTopic"}).Return("", nil)
 
 			err := deleteCmd.Execute()


### PR DESCRIPTION
Fixes #530  -  Also fixed `delete --all -n no_exist`  did not print the error msg. (#522 works if `--all` not set.)