### PR TITLE
Parameterize ports between invoker and sidecar

### DIFF
--- a/function-controller/pkg/controller/deployer.go
+++ b/function-controller/pkg/controller/deployer.go
@@ -36,7 +36,11 @@ const (
 )
 
 var (
-	zero = int32(0)
+	zero  = int32(0)
+	ports = map[string]string{
+		"http": "8080",
+		"grpc": "10382",
+	}
 )
 
 // Deployer allows the realisation of a function on k8s and its subsequent scaling to accommodate more/less load.
@@ -95,6 +99,14 @@ func (d *deployer) buildMainContainer(function *v1.Function) corev1.Container {
 		Name:  "RIFF_FUNCTION_INVOKER_PROTOCOL",
 		Value: function.Spec.Protocol,
 	})
+	c.Env = append(c.Env, corev1.EnvVar{
+		Name:  "HTTP_PORT",
+		Value: ports["http"],
+	})
+	c.Env = append(c.Env, corev1.EnvVar{
+		Name:  "GRPC_PORT",
+		Value: ports["grpc"],
+	})
 	return c
 }
 
@@ -114,6 +126,7 @@ func (d *deployer) buildSidecarContainer(function *v1.Function) corev1.Container
 		"--outputs", outputDestination,
 		"--group", function.Name,
 		"--protocol", function.Spec.Protocol,
+		"--port", ports[function.Spec.Protocol],
 		"--brokers", strings.Join(d.brokers, ","),
 	}
 	return c

--- a/function-controller/pkg/controller/deployer_test.go
+++ b/function-controller/pkg/controller/deployer_test.go
@@ -54,6 +54,31 @@ var _ = Describe("Deployer", func() {
 					Value: "grpc",
 				}))
 			})
+			It("should set the sidecar --protocol and --port arg", func() {
+				deployment := d.buildDeployment(&function)
+				sidecarContainer := deployment.Spec.Template.Spec.Containers[1]
+				args := sidecarContainer.Args
+				Expect(args[indexOf(args, "--protocol")+1]).To(Equal("grpc"))
+				Expect(args[indexOf(args, "--port")+1]).To(Equal("10382"))
+			})
+
+			It("should set the HTTP_PORT var", func() {
+				deployment := d.buildDeployment(&function)
+				mainContainer := deployment.Spec.Template.Spec.Containers[0]
+				Expect(mainContainer.Env).To(ContainElement(corev1.EnvVar{
+					Name:  "HTTP_PORT",
+					Value: "8080",
+				}))
+			})
+
+			It("should set the GRPC_PORT var", func() {
+				deployment := d.buildDeployment(&function)
+				mainContainer := deployment.Spec.Template.Spec.Containers[0]
+				Expect(mainContainer.Env).To(ContainElement(corev1.EnvVar{
+					Name:  "GRPC_PORT",
+					Value: "10382",
+				}))
+			})
 		})
 
 		Context("when the protocol is http", func() {
@@ -70,7 +95,42 @@ var _ = Describe("Deployer", func() {
 					Value: "http",
 				}))
 			})
+
+			It("should set the sidecar --protocol and --port arg", func() {
+				deployment := d.buildDeployment(&function)
+				sidecarContainer := deployment.Spec.Template.Spec.Containers[1]
+				args := sidecarContainer.Args
+				Expect(args[indexOf(args, "--protocol")+1]).To(Equal("http"))
+				Expect(args[indexOf(args, "--port")+1]).To(Equal("8080"))
+			})
+
+			It("should set the HTTP_PORT var", func() {
+				deployment := d.buildDeployment(&function)
+				mainContainer := deployment.Spec.Template.Spec.Containers[0]
+				Expect(mainContainer.Env).To(ContainElement(corev1.EnvVar{
+					Name:  "HTTP_PORT",
+					Value: "8080",
+				}))
+			})
+
+			It("should set the GRPC_PORT var", func() {
+				deployment := d.buildDeployment(&function)
+				mainContainer := deployment.Spec.Template.Spec.Containers[0]
+				Expect(mainContainer.Env).To(ContainElement(corev1.EnvVar{
+					Name:  "GRPC_PORT",
+					Value: "10382",
+				}))
+			})
 		})
 	})
 
 })
+
+func indexOf(slice []string, elem string) int {
+	for index, item := range slice {
+		if item == elem {
+			return index
+		}
+	}
+	return -1
+}

--- a/function-sidecar/pkg/carrier/carrier_integration_test.go
+++ b/function-sidecar/pkg/carrier/carrier_integration_test.go
@@ -17,21 +17,22 @@
 package carrier_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"bufio"
+	"math/rand"
 	"net/http"
 	"os"
-	"bufio"
-	"github.com/bsm/sarama-cluster"
-	"math/rand"
 	"time"
+
 	"github.com/Shopify/sarama"
-	"github.com/projectriff/riff/message-transport/pkg/message"
-	"github.com/projectriff/riff/message-transport/pkg/transport/kafka"
+	"github.com/bsm/sarama-cluster"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/projectriff/riff/function-sidecar/pkg/carrier"
 	dispatch "github.com/projectriff/riff/function-sidecar/pkg/dispatcher"
 	dispatchhttp "github.com/projectriff/riff/function-sidecar/pkg/dispatcher/http"
+	"github.com/projectriff/riff/message-transport/pkg/message"
 	"github.com/projectriff/riff/message-transport/pkg/transport"
+	"github.com/projectriff/riff/message-transport/pkg/transport/kafka"
 )
 
 const sourceMsg = `World`
@@ -52,7 +53,7 @@ var _ = Describe("Carrier Integration Test", func() {
 
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			bodyScanner := bufio.NewScanner(r.Body)
-			if ! bodyScanner.Scan() {
+			if !bodyScanner.Scan() {
 				Fail("Scan of message body failed")
 			}
 			w.Write([]byte("Hello " + bodyScanner.Text()))
@@ -115,7 +116,7 @@ func startFunctionSidecar(broker string, input string, output string, group stri
 	consumer, err := kafka.NewConsumer(brokers, group, []string{input}, consumerConfig)
 	Expect(err).NotTo(HaveOccurred())
 
-	dispatcher, err := dispatch.NewWrapper(dispatchhttp.NewHttpDispatcher())
+	dispatcher, err := dispatch.NewWrapper(dispatchhttp.NewHttpDispatcher(8080))
 	Expect(err).NotTo(HaveOccurred())
 
 	go carrier.Run(consumer, producer, dispatcher, output)


### PR DESCRIPTION
The port used for the function sidecar to communicate with the function
invoker is currently shared knowledge. Each invoker needs to know to
listen on 8080 for http or 10382 for grpc. This knowledge is hard coded
into the sidecar and each function invoker.

Instead the ports should be determined by the function-controller and
set into the function's deployment. For the sidecar there is a new
`--port` argument, and for the invoker there are environment variables
`HTTP_PORT` and `GRPC_PORT`.

There are two port variables for the invoker because there are cases
where an invoker may need to support http and grpc.

These ports should no longer be hard coded in invokers. Although the
values have not changed.