### PR TITLE
Force user and name to lowercase and remove windows computer name 

### DIFF
--- a/riff-cli/cmd/build.go
+++ b/riff-cli/cmd/build.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"path/filepath"
 
@@ -59,7 +60,7 @@ func Build(realDocker docker.Docker, dryRunDocker docker.Docker) (*cobra.Command
 		Long: `Build the function based on the code available in the path directory, using the name
 and version specified for the image that is built.`,
 		Example: `  riff build -n <name> -v <version> -f <path> [--push]`,
-		Args: utils.AliasFlagToSoleArg("filepath"),
+		Args:    utils.AliasFlagToSoleArg("filepath"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dockerClient := realDocker
 			if buildOptions.DryRun {
@@ -116,6 +117,10 @@ func pushArgs(opts BuildOptions) []string {
 
 func validateBuildOptions(options *BuildOptions) error {
 	options.FilePath = filepath.Clean(options.FilePath)
-	err := validateFunctionName(&options.FunctionName, options.FilePath)
-	return err
+
+	if options.UserAccount != strings.ToLower(options.UserAccount) {
+		return fmt.Errorf("user account name %s must be lower case", options.UserAccount)
+	}
+	return validateFunctionName(&options.FunctionName, options.FilePath)
+
 }

--- a/riff-cli/cmd/build_test.go
+++ b/riff-cli/cmd/build_test.go
@@ -117,6 +117,24 @@ var _ = Describe("The build command", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should require docker username to be lowercase", func() {
+		os.Chdir("../test_data/node/square")
+		user := "Foo"
+		buildCommand.SetArgs([]string{"-u", user})
+		err := buildCommand.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(fmt.Sprintf("user account name %s must be lower case", user)))
+	})
+
+	It("should require function name to be lowercase", func() {
+		os.Chdir("../test_data/node/square")
+		name := "squAre"
+		buildCommand.SetArgs([]string{"-n", name})
+		err := buildCommand.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(fmt.Sprintf("function name %s must be lower case", name)))
+	})
+
 	It("should work with no parameters at all", func() {
 		os.Chdir("../test_data/node/square")
 		buildCommand.SetArgs([]string{})

--- a/riff-cli/cmd/common_options.go
+++ b/riff-cli/cmd/common_options.go
@@ -30,7 +30,13 @@ func validateFunctionName(name *string, path string) error {
 	if *name == "" {
 		*name, err = functions.FunctionNameFromPath(path)
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	if *name != strings.ToLower(*name) {
+		return fmt.Errorf("function name %s must be lower case", *name)
+	}
+	return nil
 }
 
 func validateAndCleanArtifact(artifact *string, path string) error {

--- a/riff-cli/cmd/init_test.go
+++ b/riff-cli/cmd/init_test.go
@@ -143,6 +143,24 @@ var _ = Describe("The init command", func() {
 			Expect(".").NotTo(HaveUnstagedChanges())
 		})
 
+		It("should require function name to be lower case", func() {
+			os.Chdir("../test_data/riff-init/matching-invoker")
+
+			invokers, err := stubInvokers("invokers/*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			rootCommand, _, _, _, err := setupInitTest(invokers)
+			Expect(err).NotTo(HaveOccurred())
+
+			name := "Echo"
+
+			rootCommand.SetArgs(append([]string{"init", "node", "--name", name}, commonRiffArgs...))
+
+			err = rootCommand.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("function name %s must be lower case", name)))
+
+		})
+
 		It("should ignore other matching invokers when explit invoker is selected", func() {
 			os.Chdir("../test_data/riff-init/multiple-matching-invokers-with-one-selected")
 

--- a/riff-cli/pkg/osutils/osutils.go
+++ b/riff-cli/pkg/osutils/osutils.go
@@ -49,9 +49,9 @@ func GetCurrentUsername() string {
 		panic(err)
 	}
 
-	var username string
+	username := user.Username
 	if runtime.GOOS == "windows" {
-		slice := strings.Split(user.Username, "\\")
+		slice := strings.Split(username, "\\")
 		username = slice[len(slice)-1]
 	}
 

--- a/riff-cli/pkg/osutils/osutils.go
+++ b/riff-cli/pkg/osutils/osutils.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -47,7 +48,14 @@ func GetCurrentUsername() string {
 	if err != nil {
 		panic(err)
 	}
-	return user.Username
+
+	var username string
+	if runtime.GOOS == "windows" {
+		slice := strings.Split(user.Username, "\\")
+		username = slice[len(slice)-1]
+	}
+
+	return strings.ToLower(username)
 }
 
 func FileExists(path string) bool {


### PR DESCRIPTION
Fixes #568 

This requires the username and function name to be lowercase since the repository name is derived from both.  The version tag may be upper case.  I tested `osutils.GetCurrentUsername()` on Windows.  