### PR TITLE
Add advertised DNS name for kafka broker

### DIFF
--- a/config/kafka/kafka.yaml
+++ b/config/kafka/kafka.yaml
@@ -34,6 +34,23 @@ spec:
     component: zookeeper
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: projectriff-brokers
+  labels:
+    app: kafka
+    component: kafka-broker
+spec:
+  clusterIP: None
+  ports:
+  - port: 9092
+    name: broker # Port is not used
+  selector:
+    app: kafka
+    component: kafka-broker
+
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -69,13 +86,15 @@ metadata:
     component: kafka-broker
   name: projectriff-kafka
 spec:
-  replicas: 1
+  replicas: 1 # The headless service/hostname config only supports 1 replica!
   template:
     metadata:
       labels:
         app: kafka
         component: kafka-broker
     spec:
+      hostname: broker-1
+      subdomain: projectriff-brokers
       containers:
       - name: kafka
         image: wurstmeister/kafka:0.11.0.1
@@ -87,8 +106,6 @@ spec:
           - name: KAFKA_ADVERTISED_PORT
             value: "9092"
           - name: KAFKA_ADVERTISED_HOST_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
+            value: broker-1.projectriff-brokers.riff-system.svc.cluster.local
           - name: KAFKA_ZOOKEEPER_CONNECT
             value: projectriff-zookeeper:2181

--- a/helm-charts/kafka/Chart.yaml
+++ b/helm-charts/kafka/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: kafka for riff
 name: kafka
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.11.0.1
 home: https://kafka.apache.org

--- a/helm-charts/kafka/templates/_helpers.tpl
+++ b/helm-charts/kafka/templates/_helpers.tpl
@@ -16,6 +16,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name for headless brokers svc.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "kafka.brokers" -}}
+{{- $name := default "brokers" .Values.brokersNameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name for zookeeper.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/helm-charts/kafka/templates/kafka-deployment.yaml
+++ b/helm-charts/kafka/templates/kafka-deployment.yaml
@@ -17,6 +17,8 @@ spec:
         component: kafka-broker
         release: {{ .Release.Name }}
     spec:
+      hostname: broker-1
+      subdomain: {{ template "kafka.brokers" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.kafka.image.repository }}:{{ .Values.kafka.image.tag }}"
@@ -29,8 +31,6 @@ spec:
             - name: KAFKA_ADVERTISED_PORT
               value: "9092"
             - name: KAFKA_ADVERTISED_HOST_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
+              value: broker-1.{{ template "kafka.brokers" . }}.{{ .Release.Namespace }}.svc.cluster.local
             - name: KAFKA_ZOOKEEPER_CONNECT
               value: {{ template "kafka.zkname" . }}:2181

--- a/helm-charts/kafka/templates/kafka-headless.yaml
+++ b/helm-charts/kafka/templates/kafka-headless.yaml
@@ -1,20 +1,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "kafka.fullname" . }}
+  name: {{ template "kafka.brokers" . }}
   labels:
     app: {{ template "kafka.name" . }}
-    component: kafka
+    component: kafka-brokers
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.kafka.service.type }}
+  clusterIP: None
   ports:
-    - port: {{ .Values.kafka.service.externalPort }}
-      targetPort: {{ .Values.kafka.service.internalPort }}
-      protocol: TCP
-      name: {{ .Values.kafka.service.name }}
+    - port: 9092
+      name: broker # Port is not used
   selector:
     app: {{ template "kafka.name" . }}
     component: kafka-broker


### PR DESCRIPTION
- this change is required in order to seamlessly work with Istio 0.8.0

- add headless Kafka brokers service to enable DNS name for broker

- set hostname and subdomain for kafka broker pod

- switch to use the DNS name for advertised host

- since we aren't using a StatefulSet, this only works when using 1 broker replica which is all we need

- bump chart version