### PR TITLE
Support LoadBalancer whose ingress is hostname

### DIFF
--- a/riff-cli/cmd/publish.go
+++ b/riff-cli/cmd/publish.go
@@ -116,7 +116,7 @@ func lookupAddress(kube kubectl.KubeCtl, minik minikube.Minikube) (string, strin
 		if ipAddress == "" {
 			hostname, err = parser.StringValue(`$.items[0].status.loadBalancer.ingress[0].hostname`)
 			if hostname == "" {
-				return "", "", errors.New("unable to determine http-gateway ip address")
+				return "", "", errors.New("unable to determine http-gateway ip address nor hostname")
 			}
 		}
 		pFloat, err = parser.Value(`$.items[0].spec.ports[?(@.name == http)].port[0]`)

--- a/riff-cli/cmd/publish.go
+++ b/riff-cli/cmd/publish.go
@@ -129,7 +129,11 @@ func lookupAddress(kube kubectl.KubeCtl, minik minikube.Minikube) (string, strin
 		return "", "", errors.New("Unable to determine gateway port: " + err.Error())
 	}
 	port := strconv.FormatFloat(pFloat.(float64), 'f', 0, 64)
-	return ipAddress, port, nil
+
+	if ipAddress != "" {
+		return ipAddress, port, nil
+	}
+	return hostname, port, nil
 }
 
 func publish(ipAddress string, port string, publishOptions publishOptions) error {

--- a/riff-cli/cmd/publish.go
+++ b/riff-cli/cmd/publish.go
@@ -113,7 +113,10 @@ func lookupAddress(kube kubectl.KubeCtl, minik minikube.Minikube) (string, strin
 	case "LoadBalancer":
 		ipAddress, err = parser.StringValue(`$.items[0].status.loadBalancer.ingress[0].ip`)
 		if ipAddress == "" {
-			return "", "", errors.New("unable to determine http-gateway ip address")
+			ipAddress, err = parser.StringValue(`$.items[0].status.loadBalancer.ingress[0].hostname`)
+			if ipAddress == "" {
+				return "", "", errors.New("unable to determine http-gateway ip address")
+			}
 		}
 		pFloat, err = parser.Value(`$.items[0].spec.ports[?(@.name == http)].port[0]`)
 

--- a/riff-cli/cmd/publish.go
+++ b/riff-cli/cmd/publish.go
@@ -101,6 +101,7 @@ func lookupAddress(kube kubectl.KubeCtl, minik minikube.Minikube) (string, strin
 	}
 
 	var ipAddress string
+	var hostname string
 	var pFloat interface{}
 
 	switch portType {
@@ -113,8 +114,8 @@ func lookupAddress(kube kubectl.KubeCtl, minik minikube.Minikube) (string, strin
 	case "LoadBalancer":
 		ipAddress, err = parser.StringValue(`$.items[0].status.loadBalancer.ingress[0].ip`)
 		if ipAddress == "" {
-			ipAddress, err = parser.StringValue(`$.items[0].status.loadBalancer.ingress[0].hostname`)
-			if ipAddress == "" {
+			hostname, err = parser.StringValue(`$.items[0].status.loadBalancer.ingress[0].hostname`)
+			if hostname == "" {
 				return "", "", errors.New("unable to determine http-gateway ip address")
 			}
 		}

--- a/riff-cli/test_data/publish/LoadBalancerWithHostnameReply.json
+++ b/riff-cli/test_data/publish/LoadBalancerWithHostnameReply.json
@@ -1,0 +1,58 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "creationTimestamp": "2018-01-09T16:40:15Z",
+                "labels": {
+                    "app": "riff",
+                    "chart": "riff-0.0.2",
+                    "component": "http-gateway",
+                    "heritage": "Tiller",
+                    "release": "demo"
+                },
+                "name": "demo-riff-http-gateway",
+                "namespace": "default",
+                "resourceVersion": "3380",
+                "selfLink": "/api/v1/namespaces/default/services/demo-riff-http-gateway",
+                "uid": "c50fdf3f-f55b-11e7-9f39-42010a8e0080"
+            },
+            "spec": {
+                "clusterIP": "10.63.251.94",
+                "externalTrafficPolicy": "Cluster",
+                "ports": [
+                    {
+                        "name": "http",
+                        "nodePort": 32627,
+                        "port": <port>,
+                        "protocol": "TCP",
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "app": "riff",
+                    "component": "http-gateway",
+                    "release": "demo"
+                },
+                "sessionAffinity": "None",
+                "type": "LoadBalancer"
+            },
+            "status": {
+                "loadBalancer": {
+                    "ingress": [
+                        {
+                            "hostname": "<hostname>"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}


### PR DESCRIPTION
In case of deploying riff on AWS where ELB is used as a loadbalancer,  `riff publish` fails with `unable to determine http-gateway ip address`.  In this case `ingress` does not have `ip` but `hostname` like following:
 
```json
{
    "apiVersion": "v1",
    "kind": "Service",
    "metadata": {
        "creationTimestamp": "2018-05-24T12:50:02Z",
        "labels": {
            "app": "riff",
            "chart": "riff-0.0.7",
            "component": "http-gateway",
            "heritage": "Tiller",
            "release": "projectriff"
        },
        "name": "projectriff-riff-http-gateway",
        "namespace": "riff-system",
        "resourceVersion": "179110",
        "selfLink": "/api/v1/namespaces/riff-system/services/projectriff-riff-http-gateway",
        "uid": "f9b4297f-5f50-11e8-8eac-06ebbf1d72be"
    },
    "spec": {
        "clusterIP": "10.100.200.36",
        "externalTrafficPolicy": "Cluster",
        "ports": [
            {
                "name": "http",
                "nodePort": 31420,
                "port": 80,
                "protocol": "TCP",
                "targetPort": 8080
            }
        ],
        "selector": {
            "app": "riff",
            "component": "http-gateway",
            "release": "projectriff"
        },
        "sessionAffinity": "None",
        "type": "LoadBalancer"
    },
    "status": {
        "loadBalancer": {
            "ingress": [
                {
                    "hostname": "xxxxx.ap-northeast-1.elb.amazonaws.com"
                }
            ]
        }
    }
}
```

This pull request support `hostname`.