### PR TITLE
[DNM] Support stream gateway in function controller

### DIFF
--- a/config/rbac/riff-clusterrole.yaml
+++ b/config/rbac/riff-clusterrole.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: projectriff-riff
 rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]

--- a/function-controller/cmd/function-controller.go
+++ b/function-controller/cmd/function-controller.go
@@ -54,7 +54,9 @@ func main() {
 	}
 
 	topicsInformer, functionsInformer, linksInformer, deploymentInformer := makeInformers(config)
-	deployer, err := controller.NewDeployer(config, brokers)
+	streamGatewayFeatureFlag := os.Getenv("stream-gateway") == "enabled"
+	log.Printf("Feature flag stream-gateway=enabled: %t", streamGatewayFeatureFlag)
+	deployer, err := controller.NewDeployer(config, brokers, streamGatewayFeatureFlag)
 	if err != nil {
 		panic(err)
 	}

--- a/function-controller/config/deployment.yaml
+++ b/function-controller/config/deployment.yaml
@@ -36,4 +36,8 @@ spec:
           value: projectriff/function-sidecar
         - name: RIFF_FUNCTION_SIDECAR_TAG
           value: 0.0.8-snapshot
+        envFrom:
+        - configMapRef:
+            name: riff-feature-flags
+            optional: true
       serviceAccountName: projectriff-riff

--- a/helm-charts/riff/templates/function-controller-deployment.yaml
+++ b/helm-charts/riff/templates/function-controller-deployment.yaml
@@ -41,4 +41,8 @@ spec:
             value: {{ .Values.functionController.sidecar.image.repository }}
           - name: RIFF_FUNCTION_SIDECAR_TAG
             value: {{ .Values.functionController.sidecar.image.tag }}
+          envFrom:
+          - configMapRef:
+              name: riff-feature-flags
+              optional: true
       serviceAccountName: {{ template "riff.serviceAccountName" . }}

--- a/helm-charts/riff/templates/rbac.yaml
+++ b/helm-charts/riff/templates/rbac.yaml
@@ -9,6 +9,9 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]


### PR DESCRIPTION
Support is provided by enabling a feature flag BEFORE the function controller is
deployed. The feature flag is enabled by setting the property
stream-gateway=enabled in the riff-feature-flags configmap in the riff-system
namespace.

For example, the feature flag may be enabled as follows:

```
kubectl create configmap riff-feature-flags --from-literal=stream-gateway=enabled --namespace=riff-system
```

When the feature flag is enabled:
* A service is created for each link which fronts the gRPC servers of the link's
  function pods
* The function pod consists of the main container only (with no function sidecar)