### PR TITLE
README warnings about links and CLI dependency

### DIFF
--- a/Development-Helm-install.adoc
+++ b/Development-Helm-install.adoc
@@ -7,6 +7,8 @@
 * Kubernetes CLI `kubectl` installed and on the local system PATH.
 We recommend using the same version or later as the Kubernetes cluster you are using.
 
+NOTE: Since link:https://github.com/projectriff/riff/pull/578[PR #578] was merged, you must run a development (snapshot) build of the CLI to target a development build of riff.
+
 * Helm, you need helm installed, see instructions link:https://github.com/kubernetes/helm/blob/master/README.md#install[here]. 
 
 * Docker, you only need Docker when building custom versions of riff components or the samples.

--- a/README.adoc
+++ b/README.adoc
@@ -5,13 +5,15 @@ A FaaS for Kubernetes
 
 == Installation of the latest release
 
-See link:https://projectriff.io/docs/getting-started-on-minikube/[Getting started on Minikube] or 
+See link:https://projectriff.io/docs/getting-started-on-minikube/[Getting started on Minikube] or
 link:https://projectriff.io/docs/getting-started-on-gke/[Getting started on GKE] for how to install riff with a Helm Chart,
 and how to install the riff CLI.
 
 == Developer installation
 
 See link:Development-Helm-install.adoc[Installing the riff development version using Helm] to install the latest unreleased builds (git master branch) of riff.
+
+NOTE: Since link:https://github.com/projectriff/riff/pull/578[PR #578] was merged, riff functions will be deployed only when linked to a topic with a link resource. To generate yaml files for links, you must run a development (snapshot) build of the CLI.
 
 == [[manual]] Manual build
 


### PR DESCRIPTION
This PR adds a couple of README notes about the new `Link` resources.
The intent is to avoid surprises when community users try running a snapshot build.