### PR TITLE
Extract reading of windowing config out of NewGrpcDispatcher()

### DIFF
--- a/function-sidecar/cmd/function-sidecar.go
+++ b/function-sidecar/cmd/function-sidecar.go
@@ -38,6 +38,8 @@ import (
 	"github.com/projectriff/riff/message-transport/pkg/transport"
 	"github.com/projectriff/riff/message-transport/pkg/transport/metrics/kafka_over_kafka"
 	"github.com/satori/go.uuid"
+	"encoding/json"
+	"github.com/projectriff/riff/kubernetes-crds/pkg/apis/projectriff.io/v1alpha1"
 )
 
 type stringSlice []string
@@ -184,7 +186,9 @@ func createDispatcher(protocol string) (dispatch.Dispatcher, error) {
 		} else {
 			timeout = 500 * time.Millisecond
 		}
-		return grpc.NewGrpcDispatcher("localhost", port, timeout)
+		var w v1alpha1.Windowing
+		json.Unmarshal([]byte(os.Getenv("WINDOWING_STRATEGY")), &w)
+		return grpc.NewGrpcDispatcher("localhost", port, w, timeout)
 	default:
 		panic("Unsupported Dispatcher " + protocol)
 	}

--- a/function-sidecar/pkg/dispatcher/grpc/grpc_test.go
+++ b/function-sidecar/pkg/dispatcher/grpc/grpc_test.go
@@ -31,8 +31,6 @@ import (
 	"fmt"
 	"github.com/projectriff/riff/message-transport/pkg/message"
 	"github.com/projectriff/riff/kubernetes-crds/pkg/apis/projectriff.io/v1alpha1"
-	"os"
-	"encoding/json"
 )
 
 func init() {
@@ -59,10 +57,7 @@ var _ = Describe("gRPC Test", func() {
 		Expect(err).NotTo(HaveOccurred())
 		go server.Serve(l)
 
-		s, err := json.Marshal(strategy)
-		Expect(err).NotTo(HaveOccurred())
-		os.Setenv("WINDOWING_STRATEGY", string(s))
-		d, err = grpc.NewGrpcDispatcher("localhost", port, 100*time.Millisecond)
+		d, err = grpc.NewGrpcDispatcher("localhost", port, strategy, 100*time.Millisecond)
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
Allows embedding several instances of dispatcher.