### PR TITLE
[WIP] Containerized `riff init`

### DIFF
--- a/riff-cli/cmd/initcontainer/hack.yaml
+++ b/riff-cli/cmd/initcontainer/hack.yaml
@@ -1,0 +1,1 @@
+image: github.com/projectriff/riff/riff-cli/cmd/initcontainer

--- a/riff-cli/cmd/initcontainer/main.go
+++ b/riff-cli/cmd/initcontainer/main.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+
+	"github.com/projectriff/riff/riff-cli/pkg/initializer"
+	invoker "github.com/projectriff/riff/riff-cli/pkg/invoker"
+	"github.com/projectriff/riff/riff-cli/pkg/kubectl"
+	"github.com/projectriff/riff/riff-cli/pkg/options"
+)
+
+const (
+	riffInvokerPaths = "RIFF_INVOKER_PATHS"
+	functionArtifcat = "FUNCTION_ARTIFACT"
+	functionHandler  = "FUNCTION_HANDLER"
+	functionFilePath = "FUNCTION_FILE_PATH"
+	functionName     = "FUNCTION_NAME"
+)
+
+func main() {
+	if _, ok := os.LookupEnv(riffInvokerPaths); !ok {
+		glog.Fatalf("%q env var must be defined", riffInvokerPaths)
+	}
+
+	invokerOperations := invoker.Operations(kubectl.DryRunKubeCtl())
+	invokers, err := invokerOperations.List()
+	if err != nil {
+		glog.Fatalf("Unable to get invoker: %v", err)
+	}
+	if len(invokers) != 1 {
+		glog.Fatalf("Expected exactly one invoker, got %d", len(invokers))
+	}
+	invoker := invokers[0]
+
+	initOptions := options.InitOptions{
+		Artifact:     os.Getenv(functionArtifcat),
+		Handler:      os.Getenv(functionHandler),
+		FilePath:     os.Getenv(functionFilePath),
+		FunctionName: os.Getenv(functionName),
+	}
+	err = initializer.Initialize(invoker, &initOptions)
+	if err != nil {
+		glog.Fatalf("Unable initialize function: %v", err)
+	}
+}


### PR DESCRIPTION
As an alternative to using riff-cli to initialize a riff function, we can wrap the init functionality inside a container images. The images can operate on an attached disk with the function source.

Configuration via environment:
- *RIFF_INVOKER_PATHS*: Path to the riff invoker.yaml, may be a local path or http
- *FUNCTION_ARTIFACT*: Path to the function artifact, source code or jar file (attempts detection if not specified)
- *FUNCTION_HANDLER*: Name of method or class to invoke (see specific invoker for detail)
- *FUNCTION_FILE_PATH*: Path or directory used for the function (defaults to the current directory)
- *FUNCTION_NAME*: The name of the function
