### PR TITLE
Handle ingress hostnames in addition to IPs

### DIFF
--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -294,13 +294,13 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 		Args: ArgNamePrefix,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			serviceInvokeOptions.Name = args[serviceInvokeServiceNameIndex]
-			ingressIP, hostName, err := (*fcClient).ServiceCoordinates(serviceInvokeOptions)
+			ingress, hostName, err := (*fcClient).ServiceCoordinates(serviceInvokeOptions)
 			if err != nil {
 				return err
 			}
 
-			curlPrint := fmt.Sprintf("curl %s", ingressIP)
-			curlCmd := exec.Command("curl", ingressIP)
+			curlPrint := fmt.Sprintf("curl %s", ingress)
+			curlCmd := exec.Command("curl", ingress)
 
 			curlCmd.Stdin = os.Stdin
 			curlCmd.Stdout = cmd.OutOrStdout()


### PR DESCRIPTION
an ingress can be defined as either an IP address or a hostname. For
example, EKS uses ELB hostnames rather than IP addresses.