### PR TITLE
Add "system uninstall" command and update Knative/Istio

### DIFF
--- a/cmd/commands/system.go
+++ b/cmd/commands/system.go
@@ -34,8 +34,13 @@ func SystemInstall(kc *core.KubectlClient) *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "install",
-		Short: "Install the riff and Knative system components",
-		// TODO: add Long help text to explain when to use NodePort instead of LoadBalancer
+		Short: "Install riff and Knative system components",
+		Long:  `Install riff and Knative system components
+
+If an 'istio-system' namespace isn't found then the it will be created and Istio components will be installed.
+
+Use the '--node-port' flag when installing on Minikube and other clusters that don't support an external load balancer.'
+`,
 		Example: `  riff system install`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: implement support for global flags - for now don't allow their use
@@ -60,7 +65,7 @@ func SystemInstall(kc *core.KubectlClient) *cobra.Command {
 	}
 
 	command.Flags().BoolVarP(&options.NodePort, "node-port", "", false, "whether to use NodePort instead of LoadBalancer for ingress gateways")
-	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the install of Knative system components for riff")
+	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the install of components without getting any prompts")
 
 	return command
 }
@@ -70,7 +75,11 @@ func SystemUninstall(kc *core.KubectlClient) *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Remove all riff and Knative system components",
+		Short: "Remove riff and Knative system components",
+		Long:  `Remove riff and Knative system components
+
+Use the '--istio' flag to also remove Istio components.'
+`,
 		Example: `  riff system uninstall`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: implement support for global flags - for now don't allow their use
@@ -84,19 +93,17 @@ func SystemUninstall(kc *core.KubectlClient) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err, completed := (*kc).SystemUninstall(options)
+			err := (*kc).SystemUninstall(options)
 			if err != nil {
 				return err
 			}
-			if completed {
-				printSuccessfulCompletion(cmd)
-			}
+			printSuccessfulCompletion(cmd)
 			return nil
 		},
 	}
 
 	command.Flags().BoolVarP(&options.Istio, "istio", "", false, "include Istio and the istio-system namespace in the removal")
-	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the removal of system components")
+	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the removal of components without getting any prompts")
 
 	return command
 }

--- a/cmd/commands/system.go
+++ b/cmd/commands/system.go
@@ -60,6 +60,43 @@ func SystemInstall(kc *core.KubectlClient) *cobra.Command {
 	}
 
 	command.Flags().BoolVarP(&options.NodePort, "node-port", "", false, "whether to use NodePort instead of LoadBalancer for ingress gateways")
+	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the install of Knative system components for riff")
+
+	return command
+}
+
+func SystemUninstall(kc *core.KubectlClient) *cobra.Command {
+	options := core.SystemUninstallOptions{}
+
+	command := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove all riff and Knative system components",
+		Example: `  riff system uninstall`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: implement support for global flags - for now don't allow their use
+			if cmd.Flags().Changed("kubeconfig") {
+				return errors.New("The 'kubeconfig' flag is not yet supported by the 'system install' command")
+			}
+			m, _ := cmd.Flags().GetString("master")
+			if len(m) > 0 {
+				return errors.New("The 'master' flag is not yet supported by the 'system install' command")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err, completed := (*kc).SystemUninstall(options)
+			if err != nil {
+				return err
+			}
+			if completed {
+				printSuccessfulCompletion(cmd)
+			}
+			return nil
+		},
+	}
+
+	command.Flags().BoolVarP(&options.Istio, "istio", "", false, "include Istio and the istio-system namespace in the removal")
+	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the removal of system components")
 
 	return command
 }

--- a/cmd/commands/wiring.go
+++ b/cmd/commands/wiring.go
@@ -140,6 +140,7 @@ See https://projectriff.io and https://github.com/knative/docs`,
 	system := System()
 	system.AddCommand(
 		SystemInstall(&kc),
+		SystemUninstall(&kc),
 	)
 
 	rootCmd.AddCommand(

--- a/docs/riff_system.md
+++ b/docs/riff_system.md
@@ -22,6 +22,6 @@ Manage system related resources
 ### SEE ALSO
 
 * [riff](riff.md)	 - Commands for creating and managing function resources
-* [riff system install](riff_system_install.md)	 - Install the riff and Knative system components
-* [riff system uninstall](riff_system_uninstall.md)	 - Remove all riff and Knative system components
+* [riff system install](riff_system_install.md)	 - Install riff and Knative system components
+* [riff system uninstall](riff_system_uninstall.md)	 - Remove riff and Knative system components
 

--- a/docs/riff_system.md
+++ b/docs/riff_system.md
@@ -23,4 +23,5 @@ Manage system related resources
 
 * [riff](riff.md)	 - Commands for creating and managing function resources
 * [riff system install](riff_system_install.md)	 - Install the riff and Knative system components
+* [riff system uninstall](riff_system_uninstall.md)	 - Remove all riff and Knative system components
 

--- a/docs/riff_system_install.md
+++ b/docs/riff_system_install.md
@@ -1,10 +1,15 @@
 ## riff system install
 
-Install the riff and Knative system components
+Install riff and Knative system components
 
 ### Synopsis
 
-Install the riff and Knative system components
+Install riff and Knative system components
+
+If an 'istio-system' namespace isn't found then the it will be created and Istio components will be installed.
+
+Use the '--node-port' flag when installing on Minikube and other clusters that don't support an external load balancer.'
+
 
 ```
 riff system install [flags]
@@ -19,7 +24,7 @@ riff system install [flags]
 ### Options
 
 ```
-      --force       force the install of Knative system components for riff
+      --force       force the install of components without getting any prompts
   -h, --help        help for install
       --node-port   whether to use NodePort instead of LoadBalancer for ingress gateways
 ```

--- a/docs/riff_system_uninstall.md
+++ b/docs/riff_system_uninstall.md
@@ -1,10 +1,13 @@
 ## riff system uninstall
 
-Remove all riff and Knative system components
+Remove riff and Knative system components
 
 ### Synopsis
 
-Remove all riff and Knative system components
+Remove riff and Knative system components
+
+Use the '--istio' flag to also remove Istio components.'
+
 
 ```
 riff system uninstall [flags]
@@ -19,7 +22,7 @@ riff system uninstall [flags]
 ### Options
 
 ```
-      --force   force the removal of system components
+      --force   force the removal of components without getting any prompts
   -h, --help    help for uninstall
       --istio   include Istio and the istio-system namespace in the removal
 ```

--- a/docs/riff_system_uninstall.md
+++ b/docs/riff_system_uninstall.md
@@ -1,27 +1,27 @@
-## riff system install
+## riff system uninstall
 
-Install the riff and Knative system components
+Remove all riff and Knative system components
 
 ### Synopsis
 
-Install the riff and Knative system components
+Remove all riff and Knative system components
 
 ```
-riff system install [flags]
+riff system uninstall [flags]
 ```
 
 ### Examples
 
 ```
-  riff system install
+  riff system uninstall
 ```
 
 ### Options
 
 ```
-      --force       force the install of Knative system components for riff
-  -h, --help        help for install
-      --node-port   whether to use NodePort instead of LoadBalancer for ingress gateways
+      --force   force the removal of system components
+  -h, --help    help for uninstall
+      --istio   include Istio and the istio-system namespace in the removal
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/kubectl_client.go
+++ b/pkg/core/kubectl_client.go
@@ -23,7 +23,7 @@ import (
 
 type KubectlClient interface {
 	SystemInstall(options SystemInstallOptions) error
-	SystemUninstall(options SystemUninstallOptions) (error, bool)
+	SystemUninstall(options SystemUninstallOptions) error
 	NamespaceInit(options NamespaceInitOptions) error
 }
 

--- a/pkg/core/kubectl_client.go
+++ b/pkg/core/kubectl_client.go
@@ -23,6 +23,7 @@ import (
 
 type KubectlClient interface {
 	SystemInstall(options SystemInstallOptions) error
+	SystemUninstall(options SystemUninstallOptions) (error, bool)
 	NamespaceInit(options NamespaceInitOptions) error
 }
 

--- a/pkg/core/namespace.go
+++ b/pkg/core/namespace.go
@@ -39,7 +39,7 @@ func (c *client) explicitOrConfigNamespace(namespaced Namespaced) string {
 
 func (kc *kubectlClient) NamespaceInit(options NamespaceInitOptions) error {
 
-	riffBuildRelease := "https://storage.googleapis.com/riff-releases/riff-build-0.1.1.yaml"
+	riffBuildRelease := "https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml"
 
 	ns := options.NamespaceName
 

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -27,7 +27,6 @@ import (
 )
 
 const (
-	istioNamespace     = "istio-system"
 	ingressServiceName = "knative-ingressgateway"
 )
 

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -31,8 +31,7 @@ import (
 
 const (
 	istioNamespace  = "istio-system"
-	istioCrds       = "https://storage.googleapis.com/riff-releases/istio-crds-riff-0.1.1.yaml"
-	istioRelease    = "https://storage.googleapis.com/riff-releases/istio-system-riff-0.1.1.yaml"
+	istioRelease    = "https://storage.googleapis.com/riff-releases/istio-riff-0.1.1.yaml"
 	servingRelease  = "https://storage.googleapis.com/riff-releases/serving-release-no-mon-riff-0.1.1.yaml"
 	eventingRelease = "https://storage.googleapis.com/riff-releases/eventing-release-riff-0.1.1.yaml"
 	stubBusRelease  = "https://storage.googleapis.com/riff-releases/eventing-release-clusterbus-stub-riff-0.1.1.yaml"
@@ -62,9 +61,7 @@ func (kc *kubectlClient) SystemInstall(options SystemInstallOptions) error {
 
 	istioStatus, err := getNamespaceStatus(kc,istioNamespace)
 	if istioStatus == "'NotFound'" {
-		fmt.Print("Installing Istio CRDs and components\n")
-		applyResources(kc, istioCrds)
-
+		fmt.Print("Installing Istio Components\n")
 		istioYaml, err := loadRelease(istioRelease)
 		if err != nil {
 			return err

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -24,82 +24,190 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	"bufio"
+	"os"
+	"strings"
+)
+
+const (
+	istioNamespace  = "istio-system"
+	istioCrds       = "https://storage.googleapis.com/riff-releases/istio-crds-riff-0.1.1.yaml"
+	istioRelease    = "https://storage.googleapis.com/riff-releases/istio-system-riff-0.1.1.yaml"
+	servingRelease  = "https://storage.googleapis.com/riff-releases/serving-release-no-mon-riff-0.1.1.yaml"
+	eventingRelease = "https://storage.googleapis.com/riff-releases/eventing-release-riff-0.1.1.yaml"
+	stubBusRelease  = "https://storage.googleapis.com/riff-releases/eventing-release-clusterbus-stub-riff-0.1.1.yaml"
 )
 
 type SystemInstallOptions struct {
 	NodePort bool
+	Force bool
 }
+
+type SystemUninstallOptions struct {
+	Istio bool
+	Force bool
+}
+
+var (
+	knativeNameSpaces = []string{"knative-eventing", "knative-serving", "knative-build"}
+	allNameSpaces = append(knativeNameSpaces, istioNamespace)
+)
 
 func (kc *kubectlClient) SystemInstall(options SystemInstallOptions) error {
 
-	istioRelease := "https://storage.googleapis.com/riff-releases/istio-riff-0.1.0.yaml"
-	servingRelease := "https://storage.googleapis.com/riff-releases/release-no-mon-riff-0.1.0.yaml"
-	eventingRelease := "https://storage.googleapis.com/riff-releases/release-eventing-riff-0.1.0.yaml"
-	stubBusRelease := "https://storage.googleapis.com/riff-releases/release-eventing-clusterbus-stub-riff-0.1.0.yaml"
+	err := ensureNotTerminating(kc, allNameSpaces, "Please try again later.")
+	if err != nil {
+		return err
+	}
 
-	istioUrl, err := resolveReleaseURLs(istioRelease)
-	if err != nil {
-		return err
+	istioStatus, err := getNamespaceStatus(kc,istioNamespace)
+	if istioStatus == "'NotFound'" {
+		fmt.Print("Installing Istio CRDs and components\n")
+		applyResources(kc, istioCrds)
+
+		istioYaml, err := loadRelease(istioRelease)
+		if err != nil {
+			return err
+		}
+		if options.NodePort {
+			istioYaml = bytes.Replace(istioYaml, []byte("LoadBalancer"), []byte("NodePort"), -1)
+		}
+		fmt.Printf("Applying resources defined in: %s\n", istioRelease)
+		istioLog, err := kc.kubeCtl.ExecStdin([]string{"apply", "-f", "-"}, &istioYaml)
+		if err != nil {
+			fmt.Printf("%s\n", istioLog)
+			return err
+		}
+
+		fmt.Print("Istio for riff installed\n\n")
+	} else {
+		if !options.Force {
+			answer, err := confirm("Istio is already installed, do you want to install the Knative components for riff?")
+			if err != nil {
+				return err
+			}
+			if !answer {
+				return nil
+			}
+		}
 	}
-	print("Installing Istio: ", istioUrl.String(), "\n")
-	istioYaml, err := loadRelease(istioUrl)
-	if err != nil {
-		return err
-	}
-	if options.NodePort {
-		istioYaml = bytes.Replace(istioYaml, []byte("LoadBalancer"), []byte("NodePort"), -1)
-	}
-	istioLog, err := kc.kubeCtl.ExecStdin([]string{"apply", "-f", "-"}, &istioYaml)
-	if err != nil {
-		print(istioLog, "\n")
-		return err
-	}
-	print("Istio for riff installed\n", "\n")
 
 	err = waitForIstioSidecarInjector(kc)
 	if err != nil {
 		return err
 	}
 
-	servingUrl, err := resolveReleaseURLs(servingRelease)
-	if err != nil {
-		return err
-	}
-	print("Installing Knative Serving: ", servingUrl.String(), "\n")
-	servingYaml, err := loadRelease(servingUrl)
+	fmt.Print("Installing Knative Components\n")
+
+	servingYaml, err := loadRelease(servingRelease)
 	if err != nil {
 		return err
 	}
 	if options.NodePort {
 		servingYaml = bytes.Replace(servingYaml, []byte("LoadBalancer"), []byte("NodePort"), -1)
 	}
+	fmt.Printf("Applying resources defined in: %s\n", servingRelease)
 	servingLog, err := kc.kubeCtl.ExecStdin([]string{"apply", "-f", "-"}, &servingYaml)
 	if err != nil {
-		print(servingLog, "\n")
+		fmt.Printf("%s\n", servingLog)
 		return err
 	}
-	print("Knative Serving for riff installed\n", "\n")
 
-	eventingUrl, err := resolveReleaseURLs(eventingRelease)
-	if err != nil {
-		return err
-	}
-	print("Installing Knative Eventing: ", eventingUrl.String(), "\n")
-	eventingLog, err := kc.kubeCtl.Exec([]string{"apply", "-f", eventingUrl.String()})
-	if err != nil {
-		print(eventingLog, "\n")
-		return err
-	}
-	print("Knative Eventing for riff installed\n", "\n")
+	applyResources(kc, eventingRelease)
 
-	busUrl, err := resolveReleaseURLs(stubBusRelease)
+	applyResources(kc, stubBusRelease)
+
+	fmt.Print("Knative for riff installed\n\n")
+	return nil
+}
+
+func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) (error, bool) {
+
+	err := ensureNotTerminating(kc, allNameSpaces, "This would indicate that the system was already uninstalled.")
 	if err != nil {
-		return err
+		return err, false
 	}
-	print("Applying Stub ClusterBus resource: ", busUrl.String(), "\n")
-	busLog, err := kc.kubeCtl.Exec([]string{"apply", "-f", busUrl.String()})
-	print(busLog, "\n")
-	return err
+	knativeNsCount, err := checkNamespacesExists(kc, knativeNameSpaces)
+	istioNsCount, err := checkNamespacesExists(kc, []string{istioNamespace})
+	if err != nil {
+		return err, false
+	}
+	if knativeNsCount == 0 {
+		fmt.Print("No Knative components for riff found\n")
+	} else {
+		if !options.Force {
+			answer, err := confirm("Are you sure you want to uninstall the riff system?")
+			if err != nil {
+				return err, false
+			}
+			if !answer {
+				return nil, false
+			}
+		}
+		fmt.Print("Removing Knative for riff components\n")
+		err = deleteCrds(kc, "knative.dev")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrolebinding", "knative-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrolebinding", "build-controller-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrolebinding", "eventing-controller-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrolebinding", "clusterbus-controller-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrole", "knative-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteNamespaces(kc, knativeNameSpaces)
+		if err != nil {
+			return err, false
+		}
+	}
+	if istioNsCount == 0 {
+		fmt.Print("No Istio components found\n")
+	} else {
+		if !options.Istio {
+			if options.Force {
+				return nil, true
+			}
+			answer, err := confirm("Do you also want to uninstall Istio components?")
+			if err != nil {
+				return err, false
+			}
+			if !answer {
+				return nil, true
+			}
+		}
+		fmt.Print("Removing Istio components\n")
+		err = deleteCrds(kc, "istio.io")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrolebinding", "istio-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteClusterResources(kc, "clusterrole", "istio-")
+		if err != nil {
+			return err, false
+		}
+		err = deleteNamespaces(kc, []string{istioNamespace})
+		if err != nil {
+			return err, false
+		}
+	}
+	return nil, true
 }
 
 func resolveReleaseURLs(filename string) (url.URL, error) {
@@ -110,11 +218,15 @@ func resolveReleaseURLs(filename string) (url.URL, error) {
 	if u.Scheme == "http" || u.Scheme == "https" {
 		return *u, nil
 	}
-	return *u, fmt.Errorf("Filename must be file, http or https, got %s", u.Scheme)
+	return *u, fmt.Errorf("filename must be file, http or https, got %s", u.Scheme)
 }
 
-func loadRelease(url url.URL) ([]byte, error) {
-	resp, err := http.Get(url.String())
+func loadRelease(release string) ([]byte, error) {
+	releaseUrl, err := resolveReleaseURLs(release)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.Get(releaseUrl.String())
 	if err != nil {
 		return nil, err
 	}
@@ -129,10 +241,13 @@ func loadRelease(url url.URL) ([]byte, error) {
 func waitForIstioSidecarInjector(kc *kubectlClient) error {
 	print("Waiting for istio-sidecar-injector to start ")
 	for i := 0; i < 36; i++ {
-		print(".")
-		injectorStatus, err := kc.kubeCtl.Exec([]string{"get", "pod", "-n", "istio-system", "-l", "istio=sidecar-injector", "-o", "jsonpath='{.items[0].status.phase}'"})
+		fmt.Print(".")
+		injectorStatus, err := kc.kubeCtl.Exec([]string{"get", "pod", "-n", istioNamespace, "-l", "istio=sidecar-injector", "-o", "jsonpath='{.items[0].status.phase}'"})
 		if err != nil {
-			return err
+			// might take some time for the pod to show up so ignore early errors
+			if i > 3 {
+				return err
+			}
 		}
 		if injectorStatus == "'Error'" {
 			return errors.New("istio-sidecar-injector pod failed to start")
@@ -143,6 +258,128 @@ func waitForIstioSidecarInjector(kc *kubectlClient) error {
 		}
 		time.Sleep(10 * time.Second) // wait for it to start
 	}
-	print("\n\n")
+	fmt.Print("\n\n")
 	return errors.New("istio-sidecar-injector pod did not start in time")
+}
+
+func applyResources(kc *kubectlClient, release string) error {
+	releaseUrl, err := resolveReleaseURLs(release)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Applying resources defined in: %s\n", releaseUrl.String())
+	releaseLog, err := kc.kubeCtl.Exec([]string{"apply", "-f", releaseUrl.String()})
+	if err != nil {
+		fmt.Printf("%s", releaseLog)
+	}
+	return nil
+}
+
+func deleteNamespaces(kc *kubectlClient, namespaces []string) error {
+	for _, namespace := range namespaces {
+		fmt.Printf("Deleting resources defined in: %s\n", namespace)
+		deleteLog, err := kc.kubeCtl.Exec([]string{"delete", "namespace", namespace})
+		if err != nil {
+			fmt.Printf("%s", deleteLog)
+		}
+	}
+	return nil
+}
+
+func deleteClusterResources(kc *kubectlClient, resourceType string, prefix string) error {
+	fmt.Printf("Deleting %ss prefixed with %s\n", resourceType, prefix)
+	resourceList, err := kc.kubeCtl.Exec([]string{"get", resourceType, "-ocustom-columns=name:metadata.name"})
+	if err != nil {
+		return err
+	}
+	resource := strings.Split(string(resourceList), "\n")
+	var resourcesToDelete []string
+	for _, resource := range resource {
+		if strings.HasPrefix(resource, prefix) {
+			resourcesToDelete = append(resourcesToDelete, resource)
+		}
+	}
+	if len(resourcesToDelete) > 0 {
+		resourceLog, err := kc.kubeCtl.Exec(append([]string{"delete", resourceType}, resourcesToDelete...))
+		if err != nil {
+			fmt.Printf("%s", resourceLog)
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteCrds(kc *kubectlClient, suffix string) error {
+	fmt.Printf("Deleting CRDs for %s\n", suffix)
+	crdList, err := kc.kubeCtl.Exec([]string{"get", "customresourcedefinitions", "-ocustom-columns=name:metadata.name"})
+	if err != nil {
+		return err
+	}
+	crds := strings.Split(string(crdList), "\n")
+	var crdsToDelete []string
+	for _, crd := range crds {
+		if strings.HasSuffix(crd, suffix) {
+			crdsToDelete = append(crdsToDelete, crd)
+		}
+	}
+	if len(crdsToDelete) > 0 {
+		crdLog, err := kc.kubeCtl.Exec(append([]string{"delete", "customresourcedefinition"}, crdsToDelete...))
+		if err != nil {
+			fmt.Printf("%s", crdLog)
+			return err
+		}
+	}
+	return nil
+}
+
+func checkNamespacesExists (kc *kubectlClient, names []string) (int, error) {
+	count := 0
+	for _, name := range names {
+		status, err := getNamespaceStatus(kc, name)
+		if err != nil {
+			return count, err
+		}
+		if status != "'NotFound'" {
+			count =+ 1
+		}
+	}
+	return count, nil
+}
+
+func ensureNotTerminating (kc *kubectlClient, names []string, message string) error {
+	for _, name := range names {
+		status, err := getNamespaceStatus(kc, name)
+		if err != nil {
+			return err
+		}
+		if status == "'Terminating'" {
+			return errors.New(fmt.Sprintf("The %s namespace is currently 'Terminating'. %s", name, message))
+		}
+	}
+	return nil
+}
+
+func getNamespaceStatus(kc *kubectlClient, name string) (string, error) {
+	nsLog, err := kc.kubeCtl.Exec([]string{"get", "namespace", name, "-o", "jsonpath='{.status.phase}'"})
+	if err != nil {
+		if strings.Contains(nsLog, "NotFound") {
+			return "'NotFound'", nil
+		}
+		return "", err
+	}
+	return nsLog, nil
+}
+
+func confirm(s string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s [y/n]: ", s)
+	res, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	if len(res) < 2 {
+		return false, nil
+	}
+	answer := strings.ToLower(strings.TrimSpace(res))[0] == 'y'
+	return answer, nil
 }

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -31,10 +31,10 @@ import (
 
 const (
 	istioNamespace  = "istio-system"
-	istioRelease    = "https://storage.googleapis.com/riff-releases/istio-riff-0.1.1.yaml"
-	servingRelease  = "https://storage.googleapis.com/riff-releases/serving-release-no-mon-riff-0.1.1.yaml"
-	eventingRelease = "https://storage.googleapis.com/riff-releases/eventing-release-riff-0.1.1.yaml"
-	stubBusRelease  = "https://storage.googleapis.com/riff-releases/eventing-release-clusterbus-stub-riff-0.1.1.yaml"
+	istioRelease    = "https://storage.googleapis.com/knative-releases/serving/previous/v20180809-6b01d8e/istio.yaml"
+	servingRelease  = "https://storage.googleapis.com/knative-releases/serving/previous/v20180809-6b01d8e/release-no-mon.yaml"
+	eventingRelease = "https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release.yaml"
+	stubBusRelease  = "https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release-clusterbus-stub.yaml"
 )
 
 type SystemInstallOptions struct {

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -48,8 +48,8 @@ type SystemUninstallOptions struct {
 }
 
 var (
-	knativeNameSpaces = []string{"knative-eventing", "knative-serving", "knative-build"}
-	allNameSpaces = append(knativeNameSpaces, istioNamespace)
+	knativeNamespaces = []string{"knative-eventing", "knative-serving", "knative-build"}
+	allNameSpaces     = append(knativeNamespaces, istioNamespace)
 )
 
 func (kc *kubectlClient) SystemInstall(options SystemInstallOptions) error {
@@ -118,16 +118,16 @@ func (kc *kubectlClient) SystemInstall(options SystemInstallOptions) error {
 	return nil
 }
 
-func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) (error, bool) {
+func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) error {
 
 	err := ensureNotTerminating(kc, allNameSpaces, "This would indicate that the system was already uninstalled.")
 	if err != nil {
-		return err, false
+		return err
 	}
-	knativeNsCount, err := checkNamespacesExists(kc, knativeNameSpaces)
+	knativeNsCount, err := checkNamespacesExists(kc, knativeNamespaces)
 	istioNsCount, err := checkNamespacesExists(kc, []string{istioNamespace})
 	if err != nil {
-		return err, false
+		return err
 	}
 	if knativeNsCount == 0 {
 		fmt.Print("No Knative components for riff found\n")
@@ -135,40 +135,40 @@ func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) (error,
 		if !options.Force {
 			answer, err := confirm("Are you sure you want to uninstall the riff system?")
 			if err != nil {
-				return err, false
+				return err
 			}
 			if !answer {
-				return nil, false
+				return nil
 			}
 		}
 		fmt.Print("Removing Knative for riff components\n")
 		err = deleteCrds(kc, "knative.dev")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrolebinding", "knative-")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrolebinding", "build-controller-")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrolebinding", "eventing-controller-")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrolebinding", "clusterbus-controller-")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrole", "knative-")
 		if err != nil {
-			return err, false
+			return err
 		}
-		err = deleteNamespaces(kc, knativeNameSpaces)
+		err = deleteNamespaces(kc, knativeNamespaces)
 		if err != nil {
-			return err, false
+			return err
 		}
 	}
 	if istioNsCount == 0 {
@@ -176,35 +176,35 @@ func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) (error,
 	} else {
 		if !options.Istio {
 			if options.Force {
-				return nil, true
+				return nil
 			}
 			answer, err := confirm("Do you also want to uninstall Istio components?")
 			if err != nil {
-				return err, false
+				return err
 			}
 			if !answer {
-				return nil, true
+				return nil
 			}
 		}
 		fmt.Print("Removing Istio components\n")
 		err = deleteCrds(kc, "istio.io")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrolebinding", "istio-")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteClusterResources(kc, "clusterrole", "istio-")
 		if err != nil {
-			return err, false
+			return err
 		}
 		err = deleteNamespaces(kc, []string{istioNamespace})
 		if err != nil {
-			return err, false
+			return err
 		}
 	}
-	return nil, true
+	return nil
 }
 
 func resolveReleaseURLs(filename string) (url.URL, error) {


### PR DESCRIPTION
- update to use latest Istio and Knative resources for 0.1.1

- don't overwrite existing Istio installation

- add new checks for install/uninstall to make sure namespaces aren't terminating

- check that namespaces exist before uninstalling

- make Istio uninstall optional

- add --force flag to install/uninstall to avoid prompts

- labeling namespaces no longer needed

- change to use fmt.Printf instead of print

Fixes #625 
