### PR TITLE
Add the option to provide env vars to services and functions

### DIFF
--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -159,5 +159,7 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 	command.Flags().StringVar(&createFunctionOptions.Handler, "handler", "", "the name of the `method or class` to invoke, depending on the invoker used")
 	command.Flags().StringVar(&createFunctionOptions.Artifact, "artifact", "", "`path` to the function source code or jar file; auto-detected if not specified")
 
+	command.Flags().StringArrayVar(&createFunctionOptions.Env, "env", []string{""}, "environment variable expressed in a 'key=value' format. The value can be a 'valueFrom' expression")
+
 	return command
 }

--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -172,6 +172,8 @@ If an input channel and bus are specified, create the channel in the bus and sub
 
 	command.Flags().StringVar(&createServiceOptions.Image, "image", "", "the `name[:tag]` reference of an image containing the application/function")
 
+	command.Flags().StringArrayVar(&createServiceOptions.Env, "env", []string{""}, "environment variable expressed in a 'key=value' format. The value can be a 'valueFrom' expression")
+
 	return command
 }
 

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -35,7 +35,10 @@ type CreateFunctionOptions struct {
 func (c *client) CreateFunction(options CreateFunctionOptions) (*v1alpha1.Service, error) {
 	ns := c.explicitOrConfigNamespace(options.Namespaced)
 
-	s := newService(options.CreateServiceOptions)
+	s, err := newService(options.CreateServiceOptions)
+	if err != nil {
+		return nil, err
+	}
 
 	s.Spec.RunLatest.Configuration.Build = &build.BuildSpec{
 		ServiceAccountName: "riff-build",

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -46,13 +47,18 @@ type CreateServiceOptions struct {
 
 	Image string
 
+	Env []string
+
 	DryRun bool
 }
 
 func (c *client) CreateService(options CreateServiceOptions) (*v1alpha1.Service, error) {
 	ns := c.explicitOrConfigNamespace(options.Namespaced)
 
-	s := newService(options)
+	s, err := newService(options)
+	if err != nil {
+		return nil, err
+	}
 
 	if !options.DryRun {
 		_, err := c.serving.ServingV1alpha1().Services(ns).Create(&s)
@@ -63,8 +69,9 @@ func (c *client) CreateService(options CreateServiceOptions) (*v1alpha1.Service,
 
 }
 
-func newService(options CreateServiceOptions) v1alpha1.Service {
-	return v1alpha1.Service{
+func newService(options CreateServiceOptions) (v1alpha1.Service, error) {
+
+	s := v1alpha1.Service{
 		TypeMeta: meta_v1.TypeMeta{
 			APIVersion: "serving.knative.dev/v1alpha1",
 			Kind:       "Service",
@@ -86,6 +93,105 @@ func newService(options CreateServiceOptions) v1alpha1.Service {
 			},
 		},
 	}
+
+	if len(options.Env) > 0 {
+		var envVars []core_v1.EnvVar
+		for _, env := range options.Env {
+			envEntry := strings.SplitN(env, "=", 2)
+			if len(envEntry) != 2 {
+				return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse '%v', environment variables must provided as 'name=value'", env))
+			}
+			envKey := strings.TrimSpace(envEntry[0])
+			envValue := strings.TrimSpace(envEntry[1])
+			if strings.HasPrefix(envValue, "valueFrom:") {
+				source := strings.Split(envValue, ":")
+				if len(source) < 3 {
+					return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse 'valueFrom' entry '%v', it should be provided as a secretKeyRef, configMapKeyRef, fieldRef or resourceFieldRef", env))
+				}
+				sourceType := strings.TrimSpace(source[1])
+				switch sourceType {
+				case "secretKeyRef":
+					{
+						if len(source) != 4 {
+							return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse 'valueFrom' entry '%v', it should be provided as valueFrom:secretKeyRef:{name}:{key}", env))
+						}
+						envVars = append(envVars, core_v1.EnvVar{
+							Name: envKey,
+							ValueFrom: &core_v1.EnvVarSource{
+								SecretKeyRef: &core_v1.SecretKeySelector{
+									LocalObjectReference: core_v1.LocalObjectReference{
+										Name: strings.TrimSpace(source[2]),
+									},
+									Key: strings.TrimSpace(source[3]),
+								},
+							},
+						})
+					}
+				case "configMapKeyRef":
+					{
+						if len(source) != 4 {
+							return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse 'valueFrom' entry '%v', it should be provided as valueFrom:configMapKeyRef:{name}:{key}", env))
+						}
+						envVars = append(envVars, core_v1.EnvVar{
+							Name: envKey,
+							ValueFrom: &core_v1.EnvVarSource{
+								ConfigMapKeyRef: &core_v1.ConfigMapKeySelector{
+									LocalObjectReference: core_v1.LocalObjectReference{
+										Name: strings.TrimSpace(source[2]),
+									},
+									Key: strings.TrimSpace(source[3]),
+								},
+							},
+						})
+					}
+				case "fieldRef":
+					{
+						if len(source) != 3 {
+							return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse 'valueFrom' entry '%v', it should be provided as valueFrom:fieldRef:{field-path}", env))
+						}
+						envVars = append(envVars, core_v1.EnvVar{
+							Name: envKey,
+							ValueFrom: &core_v1.EnvVarSource{
+								FieldRef: &core_v1.ObjectFieldSelector{
+										FieldPath: strings.TrimSpace(source[2]),
+								},
+							},
+						})
+					}
+				case "resourceFieldRef":
+					{
+						if len(source) < 4 || len(source) > 5 {
+							return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse 'valueFrom' entry '%v', it should be provided as valueFrom:resourceFieldRef:{containerName}:{resource}:[{divisor}]", env))
+						}
+						divisor := resource.Quantity{}
+						if len(source) == 5 {
+							err := divisor.UnmarshalJSON([]byte(source[4]))
+							if err != nil {
+								return v1alpha1.Service{}, errors.New(fmt.Sprintf("failed parsing the divisor in 'valueFrom' entry '%v'\n  %s", env, err.Error()))
+							}
+						}
+						envVars = append(envVars, core_v1.EnvVar{
+							Name: envKey,
+							ValueFrom: &core_v1.EnvVarSource{
+								ResourceFieldRef: &core_v1.ResourceFieldSelector{
+										ContainerName: strings.TrimSpace(source[2]),
+										Resource: strings.TrimSpace(source[3]),
+										Divisor: divisor,
+								},
+							},
+						})
+					}
+				default:
+					return v1alpha1.Service{}, errors.New(fmt.Sprintf("unable to parse 'valueFrom' entry '%v', the only accepted source types are secretKeyRef, configMapKeyRef, fieldRef and resourceFieldRef", env))
+				}
+			} else {
+				envVars = append(envVars, core_v1.EnvVar{Name: envEntry[0], Value: envEntry[1]})
+			}
+		}
+		s.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env = envVars
+	}
+
+	return s, nil
 }
 
 type ServiceStatusOptions struct {


### PR DESCRIPTION
- the env vars are provided in a `key=value` format

- the value part can be a valueFrom expression based of k8s valueFrom field in EnvVar
  https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#envvarsource-v1-core

  example for secretKeyRef:

    --env MYSQL_PASSWORD=valueFrom:secretKeyRef:petclinic-db-mysql:mysql-root-password