### PR TITLE
Add the option to provide env vars to services and functions

### DIFF
--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -52,7 +52,16 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new function resource, with optional input binding",
-		// TODO: add Long help text to mention invoker, git repo. etc. and explain that a function is a subtype of service.serving.knative.dev and so that riff service list/status/invoke/delete may be used with it.
+		Long: `Create a new function resource from the content of the provided Git repo/revision.
+
+The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is 
+then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
+From then on you can use the sub-commands for the 'service' command to interact with the service created for the function. 
+
+` + channelLongDesc + `
+
+` + envFromLongDesc + `
+`,
 		Example: `  riff function create node square --git-repo https://github.com/acme/square --image acme/square --namespace joseph-ns
   riff function create java tweets-logger --git-repo https://github.com/acme/tweets --image acme/tweets-logger:1.0.0 --input tweets --bus kafka`,
 		Args: ArgValidationConjunction(
@@ -159,6 +168,9 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 	command.Flags().StringVar(&createFunctionOptions.GitRevision, "git-revision", "master", "the git `ref-spec` of the function code to use")
 	command.Flags().StringVar(&createFunctionOptions.Handler, "handler", "", "the name of the `method or class` to invoke, depending on the invoker used")
 	command.Flags().StringVar(&createFunctionOptions.Artifact, "artifact", "", "`path` to the function source code or jar file; auto-detected if not specified")
+
+	command.Flags().StringArrayVar(&createFunctionOptions.Env, "env", []string{}, envUsage)
+	command.Flags().StringArrayVar(&createFunctionOptions.EnvFrom, "env-from", []string{}, envFromUsage)
 
 	return command
 }

--- a/cmd/commands/function_test.go
+++ b/cmd/commands/function_test.go
@@ -99,6 +99,8 @@ var _ = Describe("The riff function command", func() {
 			}
 			o.Name = "square"
 			o.Image = "foo/bar"
+			o.Env = []string{}
+			o.EnvFrom = []string{}
 
 			asMock.On("CreateFunction", o).Return(nil, nil)
 			err := fc.Execute()
@@ -112,6 +114,24 @@ var _ = Describe("The riff function command", func() {
 			err := fc.Execute()
 			Expect(err).To(MatchError(e))
 		})
+		It("should add env vars when asked to", func() {
+			fc.SetArgs([]string{"node", "square", "--image", "foo/bar", "--git-repo", "https://github.com/repo",
+				"--env", "FOO=bar", "--env", "BAZ=qux", "--env-from", "secretKeyRef:foo:bar"})
+
+			o := core.CreateFunctionOptions{
+				GitRepo:     "https://github.com/repo",
+				GitRevision: "master",
+				InvokerURL:  "https://github.com/projectriff/node-function-invoker/raw/v0.0.8/node-invoker.yaml",
+			}
+			o.Name = "square"
+			o.Image = "foo/bar"
+			o.Env = []string{"FOO=bar", "BAZ=qux"}
+			o.EnvFrom = []string{"secretKeyRef:foo:bar"}
+
+			asMock.On("CreateFunction", o).Return(nil, nil)
+			err := fc.Execute()
+			Expect(err).NotTo(HaveOccurred())
+		})
 		It("should create channel/subscription when asked to", func() {
 			fc.SetArgs([]string{"node", "square", "--image", "foo/bar", "--git-repo", "https://github.com/repo",
 				"--input", "my-channel", "--bus", "kafka"})
@@ -123,6 +143,8 @@ var _ = Describe("The riff function command", func() {
 			}
 			functionOptions.Name = "square"
 			functionOptions.Image = "foo/bar"
+			functionOptions.Env = []string{}
+			functionOptions.EnvFrom = []string{}
 
 			channelOptions := core.CreateChannelOptions{
 				Name: "my-channel",
@@ -151,6 +173,8 @@ var _ = Describe("The riff function command", func() {
 			}
 			functionOptions.Name = "square"
 			functionOptions.Image = "foo/bar"
+			functionOptions.Env = []string{}
+			functionOptions.EnvFrom = []string{}
 			functionOptions.DryRun = true
 
 			channelOptions := core.CreateChannelOptions{

--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -79,8 +79,13 @@ func ServiceCreate(fcTool *core.Client) *cobra.Command {
 		Use:   "create",
 		Short: "Create a new service resource, with optional input binding",
 		Long: `Create a new service resource from a given image.
-If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.`,
+
+` + channelLongDesc + `
+
+` + envFromLongDesc + `
+`,
 		Example: `  riff service create square --image acme/square:1.0 --namespace joseph-ns
+  riff service create greeter --image acme/greeter:1.0 --env FOO=bar --env MESSAGE=Hello
   riff service create tweets-logger --image acme/tweets-logger:1.0.0 --input tweets --bus kafka`,
 		Args: ArgValidationConjunction(
 			cobra.ExactArgs(serviceCreateNumberOfArgs),
@@ -173,6 +178,10 @@ If an input channel and bus are specified, create the channel in the bus and sub
 
 	command.Flags().StringVar(&createServiceOptions.Image, "image", "", "the `name[:tag]` reference of an image containing the application/function")
 	command.MarkFlagRequired("image")
+
+	command.Flags().StringArrayVar(&createServiceOptions.Env, "env", []string{}, envUsage)
+	command.Flags().StringArrayVar(&createServiceOptions.EnvFrom, "env-from", []string{}, envFromUsage)
+
 	return command
 }
 

--- a/cmd/commands/service_test.go
+++ b/cmd/commands/service_test.go
@@ -95,6 +95,8 @@ var _ = Describe("The riff service create command", func() {
 			o := core.CreateServiceOptions{
 				Name:  "my-service",
 				Image: "foo/bar",
+				Env: []string{},
+				EnvFrom: []string{},
 			}
 			o.Namespace = "ns"
 
@@ -110,6 +112,22 @@ var _ = Describe("The riff service create command", func() {
 			err := sc.Execute()
 			Expect(err).To(MatchError(e))
 		})
+		It("should add env vars when asked to", func() {
+			sc.SetArgs([]string{"my-service", "--image", "foo/bar", "--namespace", "ns", "--env", "FOO=bar",
+				"--env", "BAZ=qux", "--env-from", "secretKeyRef:foo:bar"})
+
+			o := core.CreateServiceOptions{
+				Name:  "my-service",
+				Image: "foo/bar",
+				Env: []string{"FOO=bar", "BAZ=qux"},
+				EnvFrom: []string{"secretKeyRef:foo:bar"},
+			}
+			o.Namespace = "ns"
+
+			asMock.On("CreateService", o).Return(nil, nil)
+			err := sc.Execute()
+			Expect(err).NotTo(HaveOccurred())
+		})
 		It("should print when --dry-run is set", func() {
 			sc.SetArgs([]string{"square", "--image", "foo/bar",
 				"--input", "my-channel", "--bus", "kafka", "--dry-run"})
@@ -117,6 +135,8 @@ var _ = Describe("The riff service create command", func() {
 			serviceOptions := core.CreateServiceOptions{
 				Name:   "square",
 				Image:  "foo/bar",
+				Env: []string{},
+				EnvFrom: []string{},
 				DryRun: true,
 			}
 			channelOptions := core.CreateChannelOptions{

--- a/cmd/commands/shared.go
+++ b/cmd/commands/shared.go
@@ -20,4 +20,11 @@ const (
 	clusterBusUsage = "the `name` of the cluster bus to create the channel in."
 	busUsage        = "the `name` of the bus to create the channel in."
 	dryRunUsage     = "don't create resources but print yaml representation on stdout"
+	envUsage        = "environment variable expressed in a 'key=value' format"
+	envFromUsage    = "environment variable created from a source reference; see command help for supported formats"
+	channelLongDesc = "If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel."
+	envFromLongDesc = `If an env-from flag is specified the source reference can be 'configMapKeyRef' to select a key from a ConfigMap
+or 'secretKeyRef' to select a key from a Secret. The following formats are supported:
+  --env-from configMapKeyRef:{config-map-name}:{key-to-select}
+  --env-from secretKeyRef:{secret-name}:{key-to-select}`
 )

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -4,7 +4,19 @@ Create a new function resource, with optional input binding
 
 ### Synopsis
 
-Create a new function resource, with optional input binding
+Create a new function resource from the content of the provided Git repo/revision.
+
+The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is 
+then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
+From then on you can use the sub-commands for the 'service' command to interact with the service created for the function. 
+
+If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.
+
+If an env-from flag is specified the source reference can be 'configMapKeyRef' to select a key from a ConfigMap
+or 'secretKeyRef' to select a key from a Secret. The following formats are supported:
+  --env-from configMapKeyRef:{config-map-name}:{key-to-select}
+  --env-from secretKeyRef:{secret-name}:{key-to-select}
+
 
 ```
 riff function create [flags]
@@ -24,6 +36,8 @@ riff function create [flags]
       --bus name                       the name of the bus to create the channel in.
       --cluster-bus name               the name of the cluster bus to create the channel in.
       --dry-run                        don't create resources but print yaml representation on stdout
+      --env stringArray                environment variable expressed in a 'key=value' format
+      --env-from stringArray           environment variable created from a source reference; see command help for supported formats
       --git-repo URL                   the URL for a git repository hosting the function code
       --git-revision ref-spec          the git ref-spec of the function code to use (default "master")
       --handler method or class        the name of the method or class to invoke, depending on the invoker used

--- a/docs/riff_service_create.md
+++ b/docs/riff_service_create.md
@@ -5,7 +5,14 @@ Create a new service resource, with optional input binding
 ### Synopsis
 
 Create a new service resource from a given image.
+
 If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.
+
+If an env-from flag is specified the source reference can be 'configMapKeyRef' to select a key from a ConfigMap
+or 'secretKeyRef' to select a key from a Secret. The following formats are supported:
+  --env-from configMapKeyRef:{config-map-name}:{key-to-select}
+  --env-from secretKeyRef:{secret-name}:{key-to-select}
+
 
 ```
 riff service create [flags]
@@ -15,19 +22,22 @@ riff service create [flags]
 
 ```
   riff service create square --image acme/square:1.0 --namespace joseph-ns
+  riff service create greeter --image acme/greeter:1.0 --env FOO=bar --env MESSAGE=Hello
   riff service create tweets-logger --image acme/tweets-logger:1.0.0 --input tweets --bus kafka
 ```
 
 ### Options
 
 ```
-      --bus name              the name of the bus to create the channel in.
-      --cluster-bus name      the name of the cluster bus to create the channel in.
-      --dry-run               don't create resources but print yaml representation on stdout
-  -h, --help                  help for create
-      --image name[:tag]      the name[:tag] reference of an image containing the application/function
-  -i, --input channel         name of the service's input channel, if any
-  -n, --namespace namespace   the namespace of the service and any namespaced resources specified
+      --bus name               the name of the bus to create the channel in.
+      --cluster-bus name       the name of the cluster bus to create the channel in.
+      --dry-run                don't create resources but print yaml representation on stdout
+      --env stringArray        environment variable expressed in a 'key=value' format
+      --env-from stringArray   environment variable created from a source reference; see command help for supported formats
+  -h, --help                   help for create
+      --image name[:tag]       the name[:tag] reference of an image containing the application/function
+  -i, --input channel          name of the service's input channel, if any
+  -n, --namespace namespace    the namespace of the service and any namespaced resources specified
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/env_var.go
+++ b/pkg/core/env_var.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"k8s.io/api/core/v1"
+	"errors"
+	"fmt"
+	"strings"
+		)
+
+func ParseEnvVar(envVars []string) ([]v1.EnvVar, error) {
+	var results []v1.EnvVar
+	for _, env := range envVars {
+		envEntry, err := splitEnvVarEntry(env)
+		if err != nil {
+			return []v1.EnvVar{}, err
+		}
+		results = append(results, v1.EnvVar{Name: envEntry[0], Value: envEntry[1]})
+	}
+	return results, nil
+}
+
+func ParseEnvVarSource(envVarsFrom []string) ([]v1.EnvVar, error) {
+	var results []v1.EnvVar
+	for _, env := range envVarsFrom {
+		envEntry, err := splitEnvVarEntry(env)
+		if err != nil {
+			return []v1.EnvVar{}, err
+		}
+		source := strings.Split(envEntry[1], ":")
+		sourceType := strings.TrimSpace(source[0])
+		switch sourceType {
+		case "secretKeyRef":
+			if len(source) != 3 {
+				return []v1.EnvVar{}, errors.New(fmt.Sprintf("unable to parse 'env-from' entry '%s', it should be provided as secretKeyRef:{secret-name}:{key-to-select}", env))
+			}
+			results = append(results, v1.EnvVar{
+				Name: envEntry[0],
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: source[1],
+						},
+						Key: source[2],
+					},
+				},
+			})
+		case "configMapKeyRef":
+			if len(source) != 3 {
+				return []v1.EnvVar{}, errors.New(fmt.Sprintf("unable to parse 'env-from' entry '%s', it should be provided as configMapKeyRef:{config-map-name}:{key-to-select}", env))
+			}
+			results = append(results, v1.EnvVar{
+				Name: envEntry[0],
+				ValueFrom: &v1.EnvVarSource{
+					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: source[1],
+						},
+						Key: source[2],
+					},
+				},
+			})
+		default:
+			return []v1.EnvVar{}, errors.New(fmt.Sprintf("unable to parse 'env-from' entry '%s', the only accepted source types are secretKeyRef and configMapKeyRef", env))
+		}
+	}
+	return results, nil
+}
+
+func splitEnvVarEntry(env string) ([]string, error) {
+	envEntry := strings.SplitN(env, "=", 2)
+	if len(envEntry) != 2 {
+		return nil, errors.New(fmt.Sprintf("unable to parse '%s', environment variables must be provided as 'key=value'", env))
+	}
+	if len(envEntry[0]) < 1 {
+		return nil, errors.New(fmt.Sprintf("unable to parse '%s', the key part is missing", env))
+	}
+	return envEntry, nil
+}

--- a/pkg/core/env_var_test.go
+++ b/pkg/core/env_var_test.go
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core_test
+
+import (
+	"github.com/projectriff/riff/pkg/core"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	"k8s.io/api/core/v1"
+)
+
+var _ = Describe("Environment variable parsing", func() {
+
+	var (
+		input  []string
+		output []v1.EnvVar
+		err    error
+	)
+
+	Describe("ParseEnvVar", func() {
+		JustBeforeEach(func() {
+			output, err = core.ParseEnvVar(input)
+		})
+
+		Context("when key not specified", func() {
+			BeforeEach(func() {
+				input = []string{"="}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse '=', the key part is missing"))
+			})
+		})
+
+		Context("when equal sign not specified", func() {
+			BeforeEach(func() {
+				input = []string{"FOO:BAR"}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse 'FOO:BAR', environment variables must be provided as 'key=value'"))
+			})
+		})
+
+		Context("when given empty input", func() {
+			BeforeEach(func() {
+				input = []string{}
+			})
+
+			It("should not fail and produce empty output", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(BeEmpty())
+			})
+		})
+
+		Context("when given a single env var", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=bar"}
+			})
+
+			It("should not fail and produce expected output", func() {
+				expected := []v1.EnvVar{
+					{
+						Name: "FOO",
+						Value: "bar",
+					},
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(Equal(expected))
+			})
+		})
+
+		Context("when given multiple env vars", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=bar", "BAZ=foo"}
+			})
+
+			It("should not fail and produce expected output", func() {
+				expected := []v1.EnvVar{
+					{
+						Name: "FOO",
+						Value: "bar",
+					},
+					{
+						Name: "BAZ",
+						Value: "foo",
+					},
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(Equal(expected))
+			})
+		})
+	})
+
+	Describe("ParseEnvVarSource", func() {
+		JustBeforeEach(func() {
+			output, err = core.ParseEnvVarSource(input)
+		})
+
+		Context("when key not specified", func() {
+			BeforeEach(func() {
+				input = []string{"="}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse '=', the key part is missing"))
+			})
+		})
+
+		Context("when equal sign not specified", func() {
+			BeforeEach(func() {
+				input = []string{"FOO:BAR"}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse 'FOO:BAR', environment variables must be provided as 'key=value'"))
+			})
+		})
+
+		Context("when bad source type specified", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=secretRef:bar:baz"}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse 'env-from' entry 'FOO=secretRef:bar:baz', the only accepted source types are secretKeyRef and configMapKeyRef"))
+			})
+		})
+
+		Context("when not enough parameters specified for secretKeyRef", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=secretKeyRef:bar"}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse 'env-from' entry 'FOO=secretKeyRef:bar', it should be provided as secretKeyRef:{secret-name}:{key-to-select}"))
+			})
+		})
+
+		Context("when not enough parameters specified for configMapKeyRef", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=configMapKeyRef:bar"}
+			})
+
+			It("should fail with a suitable error", func() {
+				Expect(err).To(MatchError("unable to parse 'env-from' entry 'FOO=configMapKeyRef:bar', it should be provided as configMapKeyRef:{config-map-name}:{key-to-select}"))
+			})
+		})
+
+		Context("when given empty input", func() {
+			BeforeEach(func() {
+				input = []string{}
+			})
+
+			It("should not fail and produce empty output", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(BeEmpty())
+			})
+		})
+
+		Context("when given env var source from a secret", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=secretKeyRef:bar:baz"}
+			})
+
+			It("should not fail and produce expected output", func() {
+				expected := []v1.EnvVar{
+					{
+						Name: "FOO",
+						ValueFrom: &v1.EnvVarSource{
+							SecretKeyRef: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "bar",
+								},
+								Key: "baz",
+							},
+						},
+					},
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(Equal(expected))
+			})
+		})
+
+		Context("when given env var source from a configMap", func() {
+			BeforeEach(func() {
+				input = []string{"FOO=configMapKeyRef:bar:baz"}
+			})
+
+			It("should not fail and produce expected output", func() {
+				expected := []v1.EnvVar{
+					{
+						Name: "FOO",
+						ValueFrom: &v1.EnvVarSource{
+							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "bar",
+								},
+								Key: "baz",
+							},
+						},
+					},
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(Equal(expected))
+			})
+		})
+
+		Context("when given a combination of env var sources", func() {
+			BeforeEach(func() {
+				input = []string{
+					"MAP=configMapKeyRef:bar:baz",
+					"SEC=secretKeyRef:bar:baz"}
+			})
+
+			It("should not fail and produce expected output", func() {
+				expected := []v1.EnvVar{
+					{
+						Name: "MAP",
+						ValueFrom: &v1.EnvVarSource{
+							ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "bar",
+								},
+								Key: "baz",
+							},
+						},
+					},
+					{
+						Name: "SEC",
+						ValueFrom: &v1.EnvVarSource{
+							SecretKeyRef: &v1.SecretKeySelector{
+								LocalObjectReference: v1.LocalObjectReference{
+									Name: "bar",
+								},
+								Key: "baz",
+							},
+						},
+					},
+				}
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).To(Equal(expected))
+			})
+		})
+	})
+})

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -35,7 +35,10 @@ type CreateFunctionOptions struct {
 func (c *client) CreateFunction(options CreateFunctionOptions) (*v1alpha1.Service, error) {
 	ns := c.explicitOrConfigNamespace(options.Namespaced)
 
-	s := newService(options.CreateServiceOptions)
+	s, err := newService(options.CreateServiceOptions)
+	if err != nil {
+		return nil, err
+	}
 
 	s.Spec.RunLatest.Configuration.Build = &build.BuildSpec{
 		ServiceAccountName: "riff-build",
@@ -58,10 +61,10 @@ func (c *client) CreateFunction(options CreateFunctionOptions) (*v1alpha1.Servic
 	}
 
 	if !options.DryRun {
-		_, err := c.serving.ServingV1alpha1().Services(ns).Create(&s)
-		return &s, err
+		_, err := c.serving.ServingV1alpha1().Services(ns).Create(s)
+		return s, err
 	} else {
-		return &s, nil
+		return s, nil
 	}
 
 }

--- a/pkg/core/ginkgo_suite_test.go
+++ b/pkg/core/ginkgo_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Core Suite")
+}


### PR DESCRIPTION
- the env vars are provided in a `key=value` format for `--env` flag

- also supports valueFrom expressions using `--env-source` flag

- supported sources for now are configMapKeyRef and secretKeyRef

  example for configMapKeyRef:
    --env-source MYSQL_USER=configMapKeyRef:petclinic-config:mysql-user

  example for secretKeyRef:
    --env-source MYSQL_PASSWORD=secretKeyRef:petclinic-db-mysql:mysql-root-password

FIXES #649 