### PR TITLE
Restore a Knative provided Istio

### DIFF
--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -22,18 +22,18 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	istioNamespace  = "istio-system"
-	istioCrds       = "https://storage.googleapis.com/riff-releases/istio/istio-1.0.0-riff-crds.yaml"
-	istioRelease    = "https://storage.googleapis.com/riff-releases/istio/istio-1.0.0-riff-main.yaml"
+	istioRelease    = "https://github.com/knative/serving/raw/master/third_party/istio-1.0.1/istio-lean.yaml"
 	servingRelease  = "https://storage.googleapis.com/knative-releases/serving/previous/v20180809-6b01d8e/release-no-mon.yaml"
 	eventingRelease = "https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release.yaml"
 	stubBusRelease  = "https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release-clusterbus-stub.yaml"
@@ -64,8 +64,6 @@ func (kc *kubectlClient) SystemInstall(options SystemInstallOptions) (bool, erro
 	istioStatus, err := getNamespaceStatus(kc, istioNamespace)
 	if istioStatus == "'NotFound'" {
 		fmt.Print("Installing Istio components\n")
-		applyResources(kc, istioCrds)
-		time.Sleep(5 * time.Second) // wait for them to get created
 		istioYaml, err := loadRelease(istioRelease)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This is a pre-release 1.0.1 version of Istio. We'll want to switch the url to a knative nightly before merging.