### PR TITLE
Add v0.1.2-rc1 manifest with current versions to the latest release files

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,7 @@
 version: 0.1
 istio:
-- https://storage.googleapis.com/riff-releases/istio/istio-1.0.0-riff-crds.yaml
-- https://storage.googleapis.com/riff-releases/istio/istio-1.0.0-riff-main.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20180828-7c20145/istio.yaml
 knative:
-- https://storage.googleapis.com/knative-releases/serving/previous/v20180809-6b01d8e/release-no-mon.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release-clusterbus-stub.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20180828-7c20145/release-no-mon.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20180829-e9f182a/release.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20180829-e9f182a/release-clusterbus-stub.yaml

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -48,18 +48,6 @@ var manifests = map[string]*Manifest{
 	"stable": &Manifest{
 		Version: MANIFEST_VERSION,
 		Istio: []string{
-			"https://storage.googleapis.com/riff-releases/istio/istio-1.0.0-riff-crds.yaml",
-			"https://storage.googleapis.com/riff-releases/istio/istio-1.0.0-riff-main.yaml",
-		},
-		Knative: []string{
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20180809-6b01d8e/release-no-mon.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release-clusterbus-stub.yaml",
-		},
-	},
-	"v0.1.2-rc1": &Manifest{
-		Version: MANIFEST_VERSION,
-		Istio: []string{
 			"https://storage.googleapis.com/knative-releases/serving/previous/v20180828-7c20145/istio.yaml",
 		},
 		Knative: []string{

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -57,6 +57,17 @@ var manifests = map[string]*Manifest{
 			"https://storage.googleapis.com/knative-releases/eventing/previous/v20180809-34ab480/release-clusterbus-stub.yaml",
 		},
 	},
+	"v0.1.2-rc1": &Manifest{
+		Version: MANIFEST_VERSION,
+		Istio: []string{
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20180828-7c20145/istio.yaml",
+		},
+		Knative: []string{
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20180828-7c20145/release-no-mon.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20180829-e9f182a/release.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20180829-e9f182a/release-clusterbus-stub.yaml",
+		},
+	},
 	"v0.1.1": &Manifest{
 		Version: MANIFEST_VERSION,
 		Istio: []string{


### PR DESCRIPTION
- files as of 2018-08-29

Resolves #696 