### PR TITLE
Create a 'latest' manifest

### DIFF
--- a/cmd/commands/system.go
+++ b/cmd/commands/system.go
@@ -18,6 +18,7 @@ package commands
 
 import (
 	"errors"
+
 	"github.com/projectriff/riff/pkg/core"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +80,7 @@ knative:
 		},
 	}
 
-	command.Flags().StringVarP(&options.Manifest, "manifest", "m", "", "file path of a manifest file referring to the YAML files to be applied")
+	command.Flags().StringVarP(&options.Manifest, "manifest", "m", "default", "file path of a manifest file referring to the YAML files to be applied")
 	command.Flags().BoolVarP(&options.NodePort, "node-port", "", false, "whether to use NodePort instead of LoadBalancer for ingress gateways")
 	command.Flags().BoolVarP(&options.Force, "force", "", false, "force the install of components without getting any prompts")
 

--- a/docs/riff_system_install.md
+++ b/docs/riff_system_install.md
@@ -37,7 +37,7 @@ riff system install [flags]
 ```
       --force             force the install of components without getting any prompts
   -h, --help              help for install
-  -m, --manifest string   file path of a manifest file referring to the YAML files to be applied
+  -m, --manifest string   file path of a manifest file referring to the YAML files to be applied (default "default")
       --node-port         whether to use NodePort instead of LoadBalancer for ingress gateways
 ```
 

--- a/pkg/core/sample_manifest_test.go
+++ b/pkg/core/sample_manifest_test.go
@@ -26,6 +26,6 @@ var _ = Describe("SampleManifest: manifest.yaml in root of this repository", fun
 	It("should match the default manifest defined in the code", func() {
 		manifest, err := NewManifest("../../manifest.yaml")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(manifest).To(Equal(defaultManifest()))
+		Expect(manifest).To(Equal(manifests["default"]))
 	})
 })


### PR DESCRIPTION
Allow named manifests to be defined and references via the CLI. If the
value provided by the user is not predefined, it is resolved by URL.

A new 'latest' manifest tracks the Knative nightly releases.