### PR TITLE
Don't use too obvious markdown in help that could end up printed in a terminal.

### DIFF
--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -60,8 +60,7 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 		Short: "Create a new function resource, with optional input and output channels",
 		Long: `Create a new function resource from the content of the provided Git repo/revision.
 
-The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is 
-then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
+The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
 From then on you can use the sub-commands for the 'service' command to interact with the service created for the function. 
 
 ` + channelLongDesc + `

--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -58,12 +58,10 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new function resource, with optional input and output channels",
-		Long: `Create a new function resource from the content of the provided Git repo/revision.
-
-The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
-From then on you can use the sub-commands for the 'service' command to interact with the service created for the function. 
-
-` + channelLongDesc + `
+		Long: "Create a new function resource from the content of the provided Git repo/revision.\n" +
+			"\nThe INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (`service.serving.knative.dev`) instance of the name specified for the function." +
+			"\nFrom then on you can use the sub-commands for the `service` command to interact with the service created for the function.\n\n" +
+			channelLongDesc + `
 
 ` + envFromLongDesc + `
 `,

--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -63,7 +63,7 @@ func Service() *cobra.Command {
 	return &cobra.Command{
 		Use:   "service",
 		Short: "Interact with service related resources",
-		Long:  "Interact with service (as in service.serving.knative.dev) related resources.",
+		Long:  "Interact with service (as in `service.serving.knative.dev`) related resources.",
 	}
 }
 

--- a/cmd/commands/shared.go
+++ b/cmd/commands/shared.go
@@ -23,10 +23,11 @@ const (
 	envUsage        = "environment variable expressed in a 'key=value' format"
 	envFromUsage    = "environment variable created from a source reference; see command help for supported formats"
 	channelLongDesc = "If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel."
-	envFromLongDesc = `If an env-from flag is specified the source reference can be 'configMapKeyRef' to select a key from a ConfigMap
-or 'secretKeyRef' to select a key from a Secret. The following formats are supported:
-  --env-from configMapKeyRef:{config-map-name}:{key-to-select}
-  --env-from secretKeyRef:{secret-name}:{key-to-select}`
+	envFromLongDesc = "If `--env-from` is specified the source reference can be `configMapKeyRef` to select a key from a ConfigMap or `secretKeyRef` to select a key from a Secret. The following formats are supported:" +
+		`
+
+    --env-from configMapKeyRef:{config-map-name}:{key-to-select}
+    --env-from secretKeyRef:{secret-name}:{key-to-select}`
 	verboseUsage = "print details of command progress"
 	waitUsage    = "wait until the created resource reaches either a successful or an error state (automatic with --verbose)"
 )

--- a/cmd/commands/system.go
+++ b/cmd/commands/system.go
@@ -36,28 +36,23 @@ func SystemInstall(kc *core.KubectlClient) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "install",
 		Short: "Install riff and Knative system components",
-		Long: `Install riff and Knative system components
+		Long: "Install riff and Knative system components.\n" +
+			"\nIf an `istio-system` namespace isn't found, it will be created and Istio components will be installed. " +
+			"\nUse the `--node-port` flag when installing on Minikube and other clusters that don't support an external load balancer. " +
+			"\nUse the `--manifest` flag to specify the path of a manifest file which provides the URLs of the YAML definitions of the " +
+			"components to be installed. The manifest file contents should be of the following form:" +
+			`
 
-If an 'istio-system' namespace isn't found, it will be created and Istio components will be installed.
-
-Use the '--node-port' flag when installing on Minikube and other clusters that don't support an external load balancer.
-
-Use the '--manifest' flag to specify the path of a manifest file which provides the URLs of the YAML definitions of the
-components to be installed. The manifest file contents should be of the following form:
-
-` + "```yaml" + `
-manifestVersion: 0.1
-istio:
-- https://path/to/istio-release.yaml
-knative:
-- https://path/to/serving-release.yaml
-- https://path/to/eventing-release.yaml
-- https://path/to/stub-bus-release.yaml
-namespace:
-- https://path/to/riff-buildtemplate-release.yaml
-` + "```" + `
+    manifestVersion: 0.1
+    istio:
+    - https://path/to/istio-release.yaml
+    knative:
+    - https://path/to/serving-release.yaml
+    - https://path/to/eventing-release.yaml
+    - https://path/to/stub-bus-release.yaml
+    namespace:
+    - https://path/to/riff-buildtemplate-release.yaml
 `,
-		Example: `  riff system install`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: implement support for global flags - for now don't allow their use
 			if cmd.Flags().Changed("kubeconfig") {
@@ -95,12 +90,9 @@ func SystemUninstall(kc *core.KubectlClient) *cobra.Command {
 	options := core.SystemUninstallOptions{}
 
 	command := &cobra.Command{
-		Use:   "uninstall",
-		Short: "Remove riff and Knative system components",
-		Long: `Remove riff and Knative system components
-
-Use the '--istio' flag to also remove Istio components.'
-`,
+		Use:     "uninstall",
+		Short:   "Remove riff and Knative system components",
+		Long:    "Remove riff and Knative system components.\n\nUse the `--istio` flag to also remove Istio components.",
 		Example: `  riff system uninstall`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// TODO: implement support for global flags - for now don't allow their use

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -6,16 +6,15 @@ Create a new function resource, with optional input and output channels
 
 Create a new function resource from the content of the provided Git repo/revision.
 
-The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is 
-then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
+The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
 From then on you can use the sub-commands for the 'service' command to interact with the service created for the function. 
 
 If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.
 
-If an env-from flag is specified the source reference can be 'configMapKeyRef' to select a key from a ConfigMap
-or 'secretKeyRef' to select a key from a Secret. The following formats are supported:
-  --env-from configMapKeyRef:{config-map-name}:{key-to-select}
-  --env-from secretKeyRef:{secret-name}:{key-to-select}
+If `--env-from` is specified the source reference can be `configMapKeyRef` to select a key from a ConfigMap or `secretKeyRef` to select a key from a Secret. The following formats are supported:
+
+    --env-from configMapKeyRef:{config-map-name}:{key-to-select}
+    --env-from secretKeyRef:{secret-name}:{key-to-select}
 
 
 ```

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -6,8 +6,8 @@ Create a new function resource, with optional input and output channels
 
 Create a new function resource from the content of the provided Git repo/revision.
 
-The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (service.serving.knative.dev) instance of the name specified for the function. 
-From then on you can use the sub-commands for the 'service' command to interact with the service created for the function. 
+The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (`service.serving.knative.dev`) instance of the name specified for the function.
+From then on you can use the sub-commands for the `service` command to interact with the service created for the function.
 
 If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.
 

--- a/docs/riff_service.md
+++ b/docs/riff_service.md
@@ -4,7 +4,7 @@ Interact with service related resources
 
 ### Synopsis
 
-Interact with service (as in service.serving.knative.dev) related resources.
+Interact with service (as in `service.serving.knative.dev`) related resources.
 
 ### Options
 

--- a/docs/riff_service_create.md
+++ b/docs/riff_service_create.md
@@ -8,10 +8,10 @@ Create a new service resource from a given image.
 
 If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.
 
-If an env-from flag is specified the source reference can be 'configMapKeyRef' to select a key from a ConfigMap
-or 'secretKeyRef' to select a key from a Secret. The following formats are supported:
-  --env-from configMapKeyRef:{config-map-name}:{key-to-select}
-  --env-from secretKeyRef:{secret-name}:{key-to-select}
+If `--env-from` is specified the source reference can be `configMapKeyRef` to select a key from a ConfigMap or `secretKeyRef` to select a key from a Secret. The following formats are supported:
+
+    --env-from configMapKeyRef:{config-map-name}:{key-to-select}
+    --env-from secretKeyRef:{secret-name}:{key-to-select}
 
 
 ```

--- a/docs/riff_system_install.md
+++ b/docs/riff_system_install.md
@@ -4,36 +4,25 @@ Install riff and Knative system components
 
 ### Synopsis
 
-Install riff and Knative system components
+Install riff and Knative system components.
 
-If an 'istio-system' namespace isn't found, it will be created and Istio components will be installed.
+If an `istio-system` namespace isn't found, it will be created and Istio components will be installed. 
+Use the `--node-port` flag when installing on Minikube and other clusters that don't support an external load balancer. 
+Use the `--manifest` flag to specify the path of a manifest file which provides the URLs of the YAML definitions of the components to be installed. The manifest file contents should be of the following form:
 
-Use the '--node-port' flag when installing on Minikube and other clusters that don't support an external load balancer.
-
-Use the '--manifest' flag to specify the path of a manifest file which provides the URLs of the YAML definitions of the
-components to be installed. The manifest file contents should be of the following form:
-
-```yaml
-manifestVersion: 0.1
-istio:
-- https://path/to/istio-release.yaml
-knative:
-- https://path/to/serving-release.yaml
-- https://path/to/eventing-release.yaml
-- https://path/to/stub-bus-release.yaml
-namespace:
-- https://path/to/riff-buildtemplate-release.yaml
-```
+    manifestVersion: 0.1
+    istio:
+    - https://path/to/istio-release.yaml
+    knative:
+    - https://path/to/serving-release.yaml
+    - https://path/to/eventing-release.yaml
+    - https://path/to/stub-bus-release.yaml
+    namespace:
+    - https://path/to/riff-buildtemplate-release.yaml
 
 
 ```
 riff system install [flags]
-```
-
-### Examples
-
-```
-  riff system install
 ```
 
 ### Options

--- a/docs/riff_system_uninstall.md
+++ b/docs/riff_system_uninstall.md
@@ -4,10 +4,9 @@ Remove riff and Knative system components
 
 ### Synopsis
 
-Remove riff and Knative system components
+Remove riff and Knative system components.
 
-Use the '--istio' flag to also remove Istio components.'
-
+Use the `--istio` flag to also remove Istio components.
 
 ```
 riff system uninstall [flags]


### PR DESCRIPTION
Use consistent formatting. Use markers that will end up being interpreted as markdown where appropriate, but still look fine in a terminal.

Fixes #730

I've ended up changing a thing or two as well. The rationale is:
- make it legible both on terminal and html
- we don't control the width of the user terminal
- be consistent

