### PR TITLE
Install mockery as part of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 go:
 - '1.11'
-install: "go get -u github.com/golang/dep/cmd/dep"
+install:
+  - "go get -u github.com/golang/dep/cmd/dep"
+  - "go get -u github.com/vektra/mockery/.../"
 matrix:
   include:
   - stage: test


### PR DESCRIPTION
Fixes the current build condition (not sure how it did not fail before)
and also prevent the makefile from messing with a user's installation
without her consent