### PR TITLE
Allow manifest on namespace init and other commands to be URL

### DIFF
--- a/cmd/commands/image.go
+++ b/cmd/commands/image.go
@@ -43,7 +43,7 @@ func ImageRelocate(c *core.Client) *cobra.Command {
 			"the `--output` flag to specify the path for the relocated file. If `--output` is an existing directory, the relocated " +
 			"file will be placed in that directory. Otherwise the relocated file will be written to the path specified in `--output`.\n" +
 
-			"\nTo relocate a manifest, use the `--manifest` flag to specify the path of a manifest file which provides the paths or " +
+			"\nTo relocate a manifest, use the `--manifest` flag to specify the path or URL of a manifest file which provides the paths or " +
 			"URLs of the kubernetes configuration files for riff components. Use the `--output` flag to specify the path of a " +
 			"directory to contain the relocated manifest, kubernetes configuration files, and image manifest. Any associated images "+
 			"are copied to the output directory.\n" +
@@ -61,8 +61,8 @@ func ImageRelocate(c *core.Client) *cobra.Command {
     ... 
 
 `,
-		Example: `  riff image relocate --manifest=/path/to/manifest.yaml --registry=hostname --user=username --images=/path/to/image-manifest.yaml --output=/path/to/output/dir
-  riff image relocate --file=/path/to/file --registry=hostname --user=username --images=/path/to/image-manifest.yaml --output=/path/to/output`,
+		Example: `  riff image relocate --manifest=path/to/manifest.yaml --registry=hostname --user=username --images=path/to/image-manifest.yaml --output=path/to/output/dir
+  riff image relocate --file=path/to/file --registry=hostname --user=username --images=path/to/image-manifest.yaml --output=path/to/output`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return errors.New("the `image relocate` command does not support positional arguments")

--- a/cmd/commands/namespace.go
+++ b/cmd/commands/namespace.go
@@ -65,7 +65,7 @@ func NamespaceInit(kc *core.KubectlClient) *cobra.Command {
 
 	LabelArgs(command, "NAME")
 
-	command.Flags().StringVarP(&options.Manifest, "manifest", "m", "stable", "manifest of YAML files to be applied; can be a named manifest (stable or latest) or a file path of a manifest file")
+	command.Flags().StringVarP(&options.Manifest, "manifest", "m", "stable", "manifest of YAML files to be applied; can be a named manifest (stable or latest) or a path or URL of a manifest file")
 
 	command.Flags().StringVarP(&options.SecretName, "secret", "s", "push-credentials", "the name of a `secret` containing credentials for the image registry")
 	command.Flags().StringVar(&options.GcrTokenPath, "gcr", "", "path to a file containing Google Container Registry credentials")

--- a/cmd/commands/system.go
+++ b/cmd/commands/system.go
@@ -39,7 +39,7 @@ func SystemInstall(kc *core.KubectlClient) *cobra.Command {
 		Long: "Install riff and Knative system components.\n" +
 			"\nIf an `istio-system` namespace isn't found, it will be created and Istio components will be installed. " +
 			"\nUse the `--node-port` flag when installing on Minikube and other clusters that don't support an external load balancer. " +
-			"\nUse the `--manifest` flag to specify the path of a manifest file which provides the URLs of the YAML definitions of the " +
+			"\nUse the `--manifest` flag to specify the path or URL of a manifest file which provides the URLs of the YAML definitions of the " +
 			"components to be installed. The manifest file contents should be of the following form:" +
 			`
 

--- a/docs/riff_image_relocate.md
+++ b/docs/riff_image_relocate.md
@@ -8,7 +8,7 @@ Relocate either a single kubernetes configuration file or a riff manifest, its k
 
 To relocate a single kubernetes configuration file, use the `--file` flag to specify the path or URL of the file. Use the `--output` flag to specify the path for the relocated file. If `--output` is an existing directory, the relocated file will be placed in that directory. Otherwise the relocated file will be written to the path specified in `--output`.
 
-To relocate a manifest, use the `--manifest` flag to specify the path of a manifest file which provides the paths or URLs of the kubernetes configuration files for riff components. Use the `--output` flag to specify the path of a directory to contain the relocated manifest, kubernetes configuration files, and image manifest. Any associated images are copied to the output directory.
+To relocate a manifest, use the `--manifest` flag to specify the path or URL of a manifest file which provides the paths or URLs of the kubernetes configuration files for riff components. Use the `--output` flag to specify the path of a directory to contain the relocated manifest, kubernetes configuration files, and image manifest. Any associated images are copied to the output directory.
 
 Specify the registry hostname using the `--registry` flag, the user owning the images using the `--registry-user` flag, and the images to be mapped using the `--images` flag. The `--images` flag contains the path of an image manifest file with contents of the following form:
 
@@ -29,8 +29,8 @@ riff image relocate [flags]
 ### Examples
 
 ```
-  riff image relocate --manifest=/path/to/manifest.yaml --registry=hostname --user=username --images=/path/to/image-manifest.yaml --output=/path/to/output/dir
-  riff image relocate --file=/path/to/file --registry=hostname --user=username --images=/path/to/image-manifest.yaml --output=/path/to/output
+  riff image relocate --manifest=path/to/manifest.yaml --registry=hostname --user=username --images=path/to/image-manifest.yaml --output=path/to/output/dir
+  riff image relocate --file=path/to/file --registry=hostname --user=username --images=path/to/image-manifest.yaml --output=path/to/output
 ```
 
 ### Options

--- a/docs/riff_namespace_init.md
+++ b/docs/riff_namespace_init.md
@@ -22,7 +22,7 @@ riff namespace init [flags]
       --dockerhub string   dockerhub username for authentication; password will be read from stdin
       --gcr string         path to a file containing Google Container Registry credentials
   -h, --help               help for init
-  -m, --manifest string    manifest of YAML files to be applied; can be a named manifest (stable or latest) or a file path of a manifest file (default "stable")
+  -m, --manifest string    manifest of YAML files to be applied; can be a named manifest (stable or latest) or a path or URL of a manifest file (default "stable")
   -s, --secret secret      the name of a secret containing credentials for the image registry (default "push-credentials")
 ```
 

--- a/docs/riff_system_install.md
+++ b/docs/riff_system_install.md
@@ -8,7 +8,7 @@ Install riff and Knative system components.
 
 If an `istio-system` namespace isn't found, it will be created and Istio components will be installed. 
 Use the `--node-port` flag when installing on Minikube and other clusters that don't support an external load balancer. 
-Use the `--manifest` flag to specify the path of a manifest file which provides the URLs of the YAML definitions of the components to be installed. The manifest file contents should be of the following form:
+Use the `--manifest` flag to specify the path or URL of a manifest file which provides the URLs of the YAML definitions of the components to be installed. The manifest file contents should be of the following form:
 
     manifestVersion: 0.1
     istio:

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -19,7 +19,7 @@ package core
 
 import (
 	"fmt"
-	"io/ioutil"
+	"github.com/projectriff/riff/pkg/fileutils"
 	"net/url"
 	"path/filepath"
 
@@ -116,7 +116,7 @@ func NewManifest(path string) (*Manifest, error) {
 	}
 
 	var m Manifest
-	yamlFile, err := ioutil.ReadFile(path)
+	yamlFile, err := fileutils.Read(path, "")
 	if err != nil {
 		return nil, fmt.Errorf("Error reading manifest file: %v", err)
 	}

--- a/pkg/fileutils/dir.go
+++ b/pkg/fileutils/dir.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package fileutils
+
+import (
+	"net/url"
+	"path"
+	"path/filepath"
+)
+
+// Dir returns the directory portion of the given file.
+func Dir(file string) (string, error) {
+	u, err := url.Parse(file)
+	if err != nil {
+		return "", err
+	}
+	if u.IsAbs() {
+		u.Path = path.Dir(u.Path)
+		return u.String(), nil
+	}
+	return filepath.Dir(file), nil
+}

--- a/pkg/fileutils/dir_test.go
+++ b/pkg/fileutils/dir_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fileutils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectriff/riff/pkg/fileutils"
+)
+
+var _ = Describe("Dir", func() {
+	var (
+		file string
+		dir  string
+		err  error
+	)
+
+	JustBeforeEach(func() {
+	    dir, err = fileutils.Dir(file)
+	})
+
+	Context("when file is a URL", func() {
+	    BeforeEach(func() {
+	        file = "file:///dir/file"
+	    })
+
+	    It("should return the directory of the file", func() {
+	        Expect(err).NotTo(HaveOccurred())
+	        Expect(dir).To(Equal("file:///dir"))
+	    })
+	})
+
+	Context("when file is a path", func() {
+	    BeforeEach(func() {
+	        file = "/dir/file"
+	    })
+
+	    It("should return the directory of the file", func() {
+	        Expect(err).NotTo(HaveOccurred())
+	        Expect(dir).To(Equal("/dir"))
+	    })
+	})
+})

--- a/pkg/fileutils/doc.go
+++ b/pkg/fileutils/doc.go
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// package fileutils contains file manipulation functions.
+package fileutils

--- a/pkg/fileutils/fileutils_suite_test.go
+++ b/pkg/fileutils/fileutils_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fileutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFileutils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fileutils Suite")
+}

--- a/pkg/fileutils/fixtures/file.txt
+++ b/pkg/fileutils/fixtures/file.txt
@@ -1,0 +1,1 @@
+contents

--- a/pkg/fileutils/read.go
+++ b/pkg/fileutils/read.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package fileutils
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// Read reads the contents of the specified file. If the file is a relative path, it is relative to base.
+// Either file or base may be URLs.
+func Read(file string, base string) ([]byte, error) {
+	absoluteFile, err := absFile(file, base)
+	if err != nil {
+		return nil, err
+	}
+	return readAbsFile(absoluteFile)
+}
+
+func absFile(file string, base string) (string, error) {
+	u, err := url.Parse(file)
+	if err != nil {
+		return "", err
+	}
+	if u.IsAbs() {
+		return u.String(), nil
+	}
+
+	if filepath.IsAbs(file) {
+		return file, nil
+	}
+
+	b, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	if b.IsAbs() {
+		b.Path = path.Join(b.Path, file)
+		return b.String(), nil
+	}
+
+	if filepath.IsAbs(base) {
+		return filepath.Join(base, file), nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(wd, base, file), nil
+}
+
+func readAbsFile(file string) ([]byte, error) {
+	u, err := url.Parse(file)
+	if err != nil {
+		return nil, err
+	}
+	if u.IsAbs() {
+		return downloadFile(u.String())
+	}
+
+	if !filepath.IsAbs(file) {
+		panic(fmt.Sprintf("readAbsFile called with relative file path: %s", file))
+	}
+
+	return ioutil.ReadFile(file)
+}
+
+func downloadFile(url string) ([]byte, error) {
+	t := &http.Transport{}
+	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+	c := &http.Client{Transport: t}
+	resp, err := c.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/fileutils/read_test.go
+++ b/pkg/fileutils/read_test.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fileutils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectriff/riff/pkg/fileutils"
+	"os"
+	"path/filepath"
+)
+
+var _ = Describe("Read", func() {
+
+	var (
+		file    string
+		base    string
+		content []byte
+		err     error
+	)
+
+	JustBeforeEach(func() {
+		content, err = fileutils.Read(file, base)
+	})
+
+	Context("when file is a URL", func() {
+		BeforeEach(func() {
+			file = getwdAsURL() + "/fixtures/file.txt"
+
+			base = "" // irrelevant when file is absolute
+		})
+
+		It("should read the file content", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("contents"))
+		})
+	})
+
+	Context("when file is an absolute path", func() {
+		BeforeEach(func() {
+			cwd, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			file = filepath.Join(cwd, "fixtures", "file.txt")
+
+			base = "" // irrelevant when file is absolute
+		})
+
+		It("should read the file content", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("contents"))
+		})
+	})
+
+	Context("when file is a relative path", func() {
+		BeforeEach(func() {
+			file = filepath.Join("fixtures", "file.txt")
+
+			base = "" // irrelevant when file is absolute
+		})
+
+		Context("when base is empty", func() {
+			BeforeEach(func() {
+				base = ""
+			})
+
+			It("should read the file content", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("contents"))
+			})
+		})
+
+		Context("when base is a URL", func() {
+			BeforeEach(func() {
+				base = getwdAsURL()
+			})
+
+			It("should read the file content", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("contents"))
+			})
+		})
+
+		Context("when base is an absolute file path", func() {
+			BeforeEach(func() {
+				var err error
+				base, err = os.Getwd()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should read the file content", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("contents"))
+			})
+		})
+
+		Context("when base is a relative file path", func() {
+			BeforeEach(func() {
+				base = "fixtures"
+
+				file = "file.txt"
+			})
+
+			It("should read the file content", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("contents"))
+			})
+		})
+
+		Context("when base is a relative file path expressed using dot", func() {
+			BeforeEach(func() {
+				base = "./fixtures"
+
+				file = "file.txt"
+			})
+
+			It("should read the file content", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(Equal("contents"))
+			})
+		})
+	})
+
+})
+
+func getwdAsURL() string {
+	cwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+	return "file://" + filepath.ToSlash(cwd) // TODO: make this work on Windows
+}


### PR DESCRIPTION
This applies to the following commands:

* namespace init
* image relocate
* system install

Fixes https://github.com/projectriff/riff/issues/770