### PR TITLE
Add --text and --json shortcuts to set Content-Type

### DIFF
--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -377,6 +377,7 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 		Args: UpToDashDash(ArgValidationConjunction(
 			cobra.MinimumNArgs(serviceInvokeMaxNumberOfArgs-1),
 			cobra.MaximumNArgs(serviceInvokeMaxNumberOfArgs),
+			// TODO validate that at most one content-type flag is set
 			AtPosition(serviceInvokeServiceNameIndex, ValidName()),
 		)),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -401,6 +402,13 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 			hostHeader := fmt.Sprintf("Host: %s", hostName)
 			curlCmd.Args = append(curlCmd.Args, "-H", hostHeader)
 
+			// default Content-Type
+			if serviceInvokeOptions.ContentTypeJson {
+				curlCmd.Args = append(curlCmd.Args, "-H", "Content-Type: application/json")
+			} else if serviceInvokeOptions.ContentTypeText {
+				curlCmd.Args = append(curlCmd.Args, "-H", "Content-Type: text/plain")
+			}
+
 			if argsLengthAtDash > 0 {
 				curlCmd.Args = append(curlCmd.Args, args[argsLengthAtDash:]...)
 			}
@@ -418,6 +426,8 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 	LabelArgs(command, "SERVICE_NAME", "PATH")
 
 	command.Flags().StringVarP(&serviceInvokeOptions.Namespace, "namespace", "n", "", "the `namespace` of the service")
+	command.Flags().BoolVar(&serviceInvokeOptions.ContentTypeJson, "json", false, "set the request's content type to `application/json`")
+	command.Flags().BoolVar(&serviceInvokeOptions.ContentTypeText, "text", false, "set the request's content type to `text/plain`")
 
 	return command
 }

--- a/docs/riff_service_invoke.md
+++ b/docs/riff_service_invoke.md
@@ -24,8 +24,10 @@ riff service invoke [flags]
 ### Options
 
 ```
-  -h, --help                  help for invoke
-  -n, --namespace namespace   the namespace of the service
+  -h, --help                    help for invoke
+      --json application/json   set the request's content type to application/json
+  -n, --namespace namespace     the namespace of the service
+      --text text/plain         set the request's content type to text/plain
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -171,7 +171,9 @@ func (c *client) ServiceConditions(options ServiceStatusOptions) ([]v1alpha1.Ser
 
 type ServiceInvokeOptions struct {
 	Namespaced
-	Name string
+	Name            string
+	ContentTypeText bool
+	ContentTypeJson bool
 }
 
 func (c *client) ServiceCoordinates(options ServiceInvokeOptions) (string, string, error) {


### PR DESCRIPTION
`riff service invoke` now accepts `--text` to set the request's content
type to `text/plain`, and likewise `--json` sets `application/json`.

These are shortcuts to the more formal curl syntax like
`-H "Content-Type: text/plain`. Any content type may still be set using
the formal syntax.