### PR TITLE
Make the full Help message appear when there is an error, rather than Usage.

### DIFF
--- a/cmd/commands/wiring.go
+++ b/cmd/commands/wiring.go
@@ -96,6 +96,7 @@ func CreateAndWireRootCommand() *cobra.Command {
 riff is a CLI for functions on Knative.
 See https://projectriff.io and https://github.com/knative/docs`,
 		SilenceErrors:              true, // We'll print errors ourselves (after usage rather than before)
+		SilenceUsage:               true, // We'll print the *help* message instead of *usage* ourselves
 		DisableAutoGenTag:          true,
 		SuggestionsMinimumDistance: 2,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/main.go
+++ b/main.go
@@ -28,9 +28,12 @@ func main() {
 
 	root := commands.CreateAndWireRootCommand()
 
-	err := root.Execute()
+	sub, err := root.ExecuteC()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		if !sub.SilenceUsage { // May have been switched to true once we're past PreRunE()
+			sub.Help()
+		}
+		fmt.Fprintf(os.Stderr, "\nError: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixes #797