### PR TITLE
Remove vestigial reference to channels in `riff function create`.

### DIFF
--- a/cmd/commands/channel.go
+++ b/cmd/commands/channel.go
@@ -82,8 +82,8 @@ func ChannelCreate(fcTool *core.Client) *cobra.Command {
 
 	LabelArgs(command, "CHANNEL_NAME")
 
-	command.Flags().StringVar(&options.Bus, "bus", "", busUsage)
-	command.Flags().StringVar(&options.ClusterBus, "cluster-bus", "", clusterBusUsage)
+	command.Flags().StringVar(&options.Bus, "bus", "", "the `name` of the bus to create the channel in.")
+	command.Flags().StringVar(&options.ClusterBus, "cluster-bus", "", "the `name` of the cluster bus to create the channel in.")
 	command.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the `namespace` of the channel and any non-cluster bus")
 
 	command.Flags().BoolVar(&options.DryRun, "dry-run", false, dryRunUsage)

--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -56,10 +56,7 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 		Long: "Create a new function resource from the content of the provided Git repo/revision.\n" +
 			"\nThe INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (`service.serving.knative.dev`) instance of the name specified for the function." +
 			"\nFrom then on you can use the sub-commands for the `service` command to interact with the service created for the function.\n\n" +
-			channelLongDesc + `
-
-` + envFromLongDesc + `
-`,
+			envFromLongDesc + "\n",
 		Example: `  riff function create node square --git-repo https://github.com/acme/square --image acme/square --namespace joseph-ns
   riff function create java tweets-logger --git-repo https://github.com/acme/tweets --image acme/tweets-logger:1.0.0`,
 		Args: ArgValidationConjunction(

--- a/cmd/commands/shared.go
+++ b/cmd/commands/shared.go
@@ -17,12 +17,9 @@
 package commands
 
 const (
-	clusterBusUsage = "the `name` of the cluster bus to create the channel in."
-	busUsage        = "the `name` of the bus to create the channel in."
 	dryRunUsage     = "don't create resources but print yaml representation on stdout"
 	envUsage        = "environment variable expressed in a 'key=value' format"
 	envFromUsage    = "environment variable created from a source reference; see command help for supported formats"
-	channelLongDesc = "If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel."
 	envFromLongDesc = "If `--env-from` is specified the source reference can be `configMapKeyRef` to select a key from a ConfigMap or `secretKeyRef` to select a key from a Secret. The following formats are supported:" +
 		`
 

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -9,8 +9,6 @@ Create a new function resource from the content of the provided Git repo/revisio
 The INVOKER arg defines the language invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (`service.serving.knative.dev`) instance of the name specified for the function.
 From then on you can use the sub-commands for the `service` command to interact with the service created for the function.
 
-If an input channel and bus are specified, create the channel in the bus and subscribe the service to the channel.
-
 If `--env-from` is specified the source reference can be `configMapKeyRef` to select a key from a ConfigMap or `secretKeyRef` to select a key from a Secret. The following formats are supported:
 
     --env-from configMapKeyRef:{config-map-name}:{key-to-select}


### PR DESCRIPTION
Fixes #800

Remove no longer needed constants.