### PR TITLE
Enable namespace cache for buildpack builds

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,4 +7,4 @@ knative:
 - https://storage.googleapis.com/knative-releases/eventing/previous/v20180919-777657e/release-clusterbus-stub.yaml
 namespace:
 - https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml
-- https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.pre.2.yaml
+- https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.pre.3.yaml

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -42,7 +42,7 @@ var manifests = map[string]*Manifest{
 		},
 		Namespace: []string{
 			"https://storage.googleapis.com/riff-releases/latest/riff-build.yaml",
-			"https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.pre.2.yaml",
+			"https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.pre.3.yaml",
 		},
 	},
 	"stable": &Manifest{
@@ -57,7 +57,7 @@ var manifests = map[string]*Manifest{
 		},
 		Namespace: []string{
 			"https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml",
-			"https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.pre.2.yaml",
+			"https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.pre.3.yaml",
 		},
 	},
 	"v0.1.2": &Manifest{


### PR DESCRIPTION
- update stable and latest manifests to point to build-template with cache enabled

- a PersistentVolumeClaim named riff-build-cache is created in the namespace

- this requires that a default StorageClass is defined

- both GKE and Minikube has a `standard` class as the default

- the claim is for 8Gi