### PR TITLE
More idiomatic use of interfaces.

### DIFF
--- a/pkg/core/channel.go
+++ b/pkg/core/channel.go
@@ -22,24 +22,32 @@ import (
 )
 
 type ListChannelOptions struct {
-	Namespaced
+	Namespace string
+}
+
+func (l *ListChannelOptions) GetNamespace() string {
+	return l.Namespace
 }
 
 func (c *client) ListChannels(options ListChannelOptions) (*v1alpha1.ChannelList, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 	return c.eventing.ChannelsV1alpha1().Channels(ns).List(meta_v1.ListOptions{})
 }
 
 type CreateChannelOptions struct {
-	Namespaced
+	Namespace  string
 	Name       string
 	Bus        string
 	ClusterBus string
 	DryRun     bool
 }
 
+func (c *CreateChannelOptions) GetNamespace() string {
+	return c.Namespace
+}
+
 func (c *client) CreateChannel(options CreateChannelOptions) (*v1alpha1.Channel, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 	channel := v1alpha1.Channel{
 		TypeMeta: meta_v1.TypeMeta{
 			APIVersion: "channels.knative.dev/v1alpha1",
@@ -63,12 +71,16 @@ func (c *client) CreateChannel(options CreateChannelOptions) (*v1alpha1.Channel,
 }
 
 type DeleteChannelOptions struct {
-	Namespaced
-	Name string
+	Namespace string
+	Name      string
+}
+
+func (d *DeleteChannelOptions) GetNamespace() string {
+	return d.Namespace
 }
 
 func (c *client) DeleteChannel(options DeleteChannelOptions) error {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 
 	err := c.eventing.ChannelsV1alpha1().Channels(ns).Delete(options.Name, nil)
 

--- a/pkg/core/namespace.go
+++ b/pkg/core/namespace.go
@@ -43,8 +43,8 @@ const (
 	secretTypeDockerHub
 )
 
-type Namespaced struct {
-	Namespace string
+type Namespaced interface {
+	GetNamespace() string
 }
 
 type NamespaceInitOptions struct {
@@ -68,8 +68,8 @@ func (o *NamespaceInitOptions) secretType() secretType {
 }
 
 func (c *client) explicitOrConfigNamespace(namespaced Namespaced) string {
-	if namespaced.Namespace != "" {
-		return namespaced.Namespace
+	if namespaced.GetNamespace() != "" {
+		return namespaced.GetNamespace()
 	} else {
 		namespace, _, _ := c.clientConfig.Namespace()
 		return namespace

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -31,27 +31,35 @@ const (
 )
 
 type ListServiceOptions struct {
-	Namespaced
+	Namespace string
+}
+
+func (l *ListServiceOptions) GetNamespace() string {
+	return l.Namespace
 }
 
 func (c *client) ListServices(options ListServiceOptions) (*v1alpha1.ServiceList, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 	return c.serving.ServingV1alpha1().Services(ns).List(meta_v1.ListOptions{})
 }
 
 type CreateOrReviseServiceOptions struct {
-	Namespaced
-	Name    string
-	Image   string
-	Env     []string
-	EnvFrom []string
-	DryRun  bool
-	Verbose bool
-	Wait    bool
+	Namespace string
+	Name      string
+	Image     string
+	Env       []string
+	EnvFrom   []string
+	DryRun    bool
+	Verbose   bool
+	Wait      bool
+}
+
+func (c *CreateOrReviseServiceOptions) GetNamespace() string {
+	return c.Namespace
 }
 
 func (c *client) CreateService(options CreateOrReviseServiceOptions) (*v1alpha1.Service, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 
 	s, err := newService(options)
 	if err != nil {
@@ -68,7 +76,7 @@ func (c *client) CreateService(options CreateOrReviseServiceOptions) (*v1alpha1.
 }
 
 func (c *client) ReviseService(options CreateOrReviseServiceOptions) (*v1alpha1.Service, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 
 	existingSvc, err := c.serving.ServingV1alpha1().Services(ns).Get(options.Name, meta_v1.GetOptions{})
 	if err != nil {
@@ -140,8 +148,12 @@ func newService(options CreateOrReviseServiceOptions) (*v1alpha1.Service, error)
 }
 
 type ServiceStatusOptions struct {
-	Namespaced
-	Name string
+	Namespace string
+	Name      string
+}
+
+func (s *ServiceStatusOptions) GetNamespace() string {
+	return s.Namespace
 }
 
 func (c *client) ServiceStatus(options ServiceStatusOptions) (*v1alpha1.ServiceCondition, error) {
@@ -162,7 +174,7 @@ func (c *client) ServiceStatus(options ServiceStatusOptions) (*v1alpha1.ServiceC
 
 func (c *client) ServiceConditions(options ServiceStatusOptions) ([]v1alpha1.ServiceCondition, error) {
 
-	s, err := c.service(options.Namespaced, options.Name)
+	s, err := c.service(&options, options.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -170,10 +182,14 @@ func (c *client) ServiceConditions(options ServiceStatusOptions) ([]v1alpha1.Ser
 }
 
 type ServiceInvokeOptions struct {
-	Namespaced
+	Namespace       string
 	Name            string
 	ContentTypeText bool
 	ContentTypeJson bool
+}
+
+func (s *ServiceInvokeOptions) GetNamespace() string {
+	return s.Namespace
 }
 
 func (c *client) ServiceCoordinates(options ServiceInvokeOptions) (string, string, error) {
@@ -209,7 +225,7 @@ func (c *client) ServiceCoordinates(options ServiceInvokeOptions) (string, strin
 		}
 	}
 
-	s, err := c.service(options.Namespaced, options.Name)
+	s, err := c.service(&options, options.Name)
 	if err != nil {
 		return "", "", err
 	}
@@ -217,21 +233,21 @@ func (c *client) ServiceCoordinates(options ServiceInvokeOptions) (string, strin
 	return ingress, s.Status.Domain, nil
 }
 
-func (c *client) service(namespace Namespaced, name string) (*v1alpha1.Service, error) {
-
-	ns := c.explicitOrConfigNamespace(namespace)
-
+func (c *client) service(namespaced Namespaced, name string) (*v1alpha1.Service, error) {
+	ns := c.explicitOrConfigNamespace(namespaced)
 	return c.serving.ServingV1alpha1().Services(ns).Get(name, meta_v1.GetOptions{})
 }
 
 type DeleteServiceOptions struct {
-	Namespaced
-	Name string
+	Namespace string
+	Name      string
+}
+
+func (d *DeleteServiceOptions) GetNamespace() string {
+	return d.Namespace
 }
 
 func (c *client) DeleteService(options DeleteServiceOptions) error {
-
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
-
+	ns := c.explicitOrConfigNamespace(&options)
 	return c.serving.ServingV1alpha1().Services(ns).Delete(options.Name, nil)
 }

--- a/pkg/core/subscription.go
+++ b/pkg/core/subscription.go
@@ -24,7 +24,7 @@ import (
 )
 
 type CreateSubscriptionOptions struct {
-	Namespaced
+	Namespace  string
 	Name       string
 	Channel    string
 	Subscriber string
@@ -32,17 +32,29 @@ type CreateSubscriptionOptions struct {
 	DryRun     bool
 }
 
+func (c *CreateSubscriptionOptions) GetNamespace() string {
+	return c.Namespace
+}
+
 type DeleteSubscriptionOptions struct {
-	Namespaced
-	Name       string
+	Namespace string
+	Name      string
+}
+
+func (d *DeleteSubscriptionOptions) GetNamespace() string {
+	return d.Namespace
 }
 
 type ListSubscriptionsOptions struct {
-	Namespaced
+	Namespace string
+}
+
+func (l *ListSubscriptionsOptions) GetNamespace() string {
+	return l.Namespace
 }
 
 func (c *client) CreateSubscription(options CreateSubscriptionOptions) (*v1alpha1.Subscription, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 	if options.ReplyTo != "" {
 		options.ReplyTo = fmt.Sprintf("%s-channel", options.ReplyTo)
 	}
@@ -72,13 +84,12 @@ func (c *client) CreateSubscription(options CreateSubscriptionOptions) (*v1alpha
 }
 
 func (c *client) DeleteSubscription(options DeleteSubscriptionOptions) error {
-	namespace := c.explicitOrConfigNamespace(options.Namespaced)
+	namespace := c.explicitOrConfigNamespace(&options)
 	return c.eventing.ChannelsV1alpha1().Subscriptions(namespace).Delete(options.Name, nil)
 }
 
-
 func (c *client) ListSubscriptions(options ListSubscriptionsOptions) (*v1alpha1.SubscriptionList, error) {
-	ns := c.explicitOrConfigNamespace(options.Namespaced)
+	ns := c.explicitOrConfigNamespace(&options)
 
 	list, err := c.eventing.ChannelsV1alpha1().Subscriptions(ns).List(meta_v1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
This is what I originally intended with `Namespaced` and being able
to pass an instance of it to `explicitOrConfigNamespace()`