### PR TITLE
Add custom '--invoker-url' to function create

### DIFF
--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -54,6 +54,8 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 		"node":    "https://github.com/projectriff/node-function-invoker/raw/v0.0.8/node-invoker.yaml",
 	}
 
+	flagsValidator := AtLeastOneOf("git-repo", "local-path")
+
 	command := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new function resource",
@@ -63,7 +65,7 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 			"- 'jar': uses riff's java-function-invoker build for a prebuilt JAR file\n" +
 			"- 'node': uses riff's node-function-invoker build\n" +
 			"- 'command': uses riff's command-function-invoker build\n" +
-			"- 'custom': use a custom invoker. Specify with --custom-url flag\n" +
+			"- 'custom': use a custom invoker. Specify with --invoker-url flag\n" +
 			"\nBuildpack based builds support building from local source or within the cluster. Images will be pushed to the registry specified in the image name, unless prefixed with 'dev.local/' in which case the image will only be available within the local Docker daemon.\n" +
 			"\nFrom then on you can use the sub-commands for the `service` command to interact with the service created for the function.\n\n" +
 			envFromLongDesc + "\n",
@@ -74,21 +76,32 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 			AtPosition(functionCreateInvokerIndex, ValidName()),
 			AtPosition(functionCreateFunctionNameIndex, ValidName()),
 		),
-		PreRunE: FlagsValidatorAsCobraRunE(AtLeastOneOf("git-repo", "local-path")),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := flagsValidator(cmd)
+			if err != nil {
+				return err
+			}
+
+			invoker := args[functionCreateInvokerIndex]
+			if invoker != "custom" && createFunctionOptions.InvokerURL != "" {
+				return fmt.Errorf("--invoker-url is only available for the custom invoker")
+			} else if invoker == "custom" && createFunctionOptions.InvokerURL == "" {
+				return fmt.Errorf("--invoker-url is required for the custom invoker")
+			}
+
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fnName := args[functionCreateFunctionNameIndex]
 
 			invoker := args[functionCreateInvokerIndex]
 			createFunctionOptions.Invoker = invoker
+
 			if buildpack, exists := buildpacks[invoker]; exists {
 				createFunctionOptions.BuildpackImage = buildpack
 			} else if invokerURL, exists := invokers[invoker]; exists {
 				createFunctionOptions.InvokerURL = invokerURL
-			} else if invoker == "custom" && createFunctionOptions.InvokerURL != "" {
-				// custom invoker with an Invoker URL configured
-			} else if invoker == "custom" && createFunctionOptions.InvokerURL == "" {
-				return fmt.Errorf("--invoker-url is required with custom invokers")
-			} else {
+			} else if invoker != "custom" {
 				return fmt.Errorf("unknown invoker: %s", invoker)
 			}
 

--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -63,6 +63,7 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 			"- 'jar': uses riff's java-function-invoker build for a prebuilt JAR file\n" +
 			"- 'node': uses riff's node-function-invoker build\n" +
 			"- 'command': uses riff's command-function-invoker build\n" +
+			"- 'custom': use a custom invoker. Specify with --custom-url flag\n" +
 			"\nBuildpack based builds support building from local source or within the cluster. Images will be pushed to the registry specified in the image name, unless prefixed with 'dev.local/' in which case the image will only be available within the local Docker daemon.\n" +
 			"\nFrom then on you can use the sub-commands for the `service` command to interact with the service created for the function.\n\n" +
 			envFromLongDesc + "\n",
@@ -83,6 +84,10 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 				createFunctionOptions.BuildpackImage = buildpack
 			} else if invokerURL, exists := invokers[invoker]; exists {
 				createFunctionOptions.InvokerURL = invokerURL
+			} else if invoker == "custom" && createFunctionOptions.InvokerURL != "" {
+				// custom invoker with an Invoker URL configured
+			} else if invoker == "custom" && createFunctionOptions.InvokerURL == "" {
+				return fmt.Errorf("--invoker-url is required with custom invokers")
 			} else {
 				return fmt.Errorf("unknown invoker: %s", invoker)
 			}
@@ -118,6 +123,7 @@ func FunctionCreate(fcTool *core.Client) *cobra.Command {
 	command.Flags().StringVarP(&createFunctionOptions.Namespace, "namespace", "n", "", "the `namespace` of the service")
 	command.Flags().BoolVarP(&createFunctionOptions.DryRun, "dry-run", "", false, dryRunUsage)
 	command.Flags().StringVar(&createFunctionOptions.Image, "image", "", "the name of the image to build; must be a writable `repository/image[:tag]` with credentials configured")
+	command.Flags().StringVar(&createFunctionOptions.InvokerURL, "invoker-url", "", "the path to a custom invoker url. Required if invoker is custom.")
 	command.MarkFlagRequired("image")
 	command.Flags().StringVar(&createFunctionOptions.GitRepo, "git-repo", "", "the `URL` for a git repository hosting the function code")
 	command.Flags().StringVar(&createFunctionOptions.GitRevision, "git-revision", "master", "the git `ref-spec` of the function code to use")

--- a/cmd/commands/function_test.go
+++ b/cmd/commands/function_test.go
@@ -70,6 +70,11 @@ var _ = Describe("The riff function create command", func() {
 			Expect(err).To(MatchError(ContainSubstring("--git-repo")))
 			Expect(err).To(MatchError(ContainSubstring("--local-path")))
 		})
+		It("should fail without invoker url with custom invoker", func() {
+			fc.SetArgs([]string{"custom", "square", "--git-repo", "http://git.com", "--image", "hello/image"})
+			err := fc.Execute()
+			Expect(err).To(MatchError(ContainSubstring("--invoker-url is required with custom invokers")))
+		})
 	})
 
 	Context("when given suitable args and flags", func() {
@@ -104,6 +109,25 @@ var _ = Describe("The riff function create command", func() {
 
 			asMock.On("CreateFunction", o, mock.Anything).Return(nil, nil)
 			err := fc.Execute()
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("should support custom invoker urls", func() {
+			fc.SetArgs([]string{"custom", "square", "--invoker-url", "http://github.com/acmelang/invoker.yaml", "--image", "foo/bar", "--git-repo", "https://github.com/repo"})
+
+			o := core.CreateFunctionOptions{
+				GitRepo:     "https://github.com/repo",
+				GitRevision: "master",
+				Invoker:     "custom",
+				InvokerURL:  "http://github.com/acmelang/invoker.yaml",
+			}
+			o.Name = "square"
+			o.Image = "foo/bar"
+			o.Env = []string{}
+			o.EnvFrom = []string{}
+
+			asMock.On("CreateFunction", o, mock.Anything).Return(nil, nil)
+			err := fc.Execute()
+			fmt.Print(err)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should propagate core.Client errors", func() {

--- a/cmd/commands/function_test.go
+++ b/cmd/commands/function_test.go
@@ -73,7 +73,12 @@ var _ = Describe("The riff function create command", func() {
 		It("should fail without invoker url with custom invoker", func() {
 			fc.SetArgs([]string{"custom", "square", "--git-repo", "http://git.com", "--image", "hello/image"})
 			err := fc.Execute()
-			Expect(err).To(MatchError(ContainSubstring("--invoker-url is required with custom invokers")))
+			Expect(err).To(MatchError(ContainSubstring("--invoker-url is required for the custom invoker")))
+		})
+		It("should fail with invoker url", func() {
+			fc.SetArgs([]string{"node", "square", "--git-repo", "http://git.com", "--image", "hello/image", "--invoker-url", "http://example.com"})
+			err := fc.Execute()
+			Expect(err).To(MatchError(ContainSubstring("--invoker-url is only available for the custom invoker")))
 		})
 	})
 

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -12,6 +12,7 @@ The INVOKER arg defines the language runtime and function invoker that is added 
 - 'jar': uses riff's java-function-invoker build for a prebuilt JAR file
 - 'node': uses riff's node-function-invoker build
 - 'command': uses riff's command-function-invoker build
+- 'custom': use a custom invoker. Specify with --custom-url flag
 
 Buildpack based builds support building from local source or within the cluster. Images will be pushed to the registry specified in the image name, unless prefixed with 'dev.local/' in which case the image will only be available within the local Docker daemon.
 
@@ -46,6 +47,7 @@ riff function create [flags]
       --handler method or class        the name of the method or class to invoke, depending on the invoker used
   -h, --help                           help for create
       --image repository/image[:tag]   the name of the image to build; must be a writable repository/image[:tag] with credentials configured
+      --invoker-url string             the path to a custom invoker url. Required if invoker is custom.
   -l, --local-path path                path to local source to build the image from
   -n, --namespace namespace            the namespace of the service
   -v, --verbose                        print details of command progress

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -12,7 +12,7 @@ The INVOKER arg defines the language runtime and function invoker that is added 
 - 'jar': uses riff's java-function-invoker build for a prebuilt JAR file
 - 'node': uses riff's node-function-invoker build
 - 'command': uses riff's command-function-invoker build
-- 'custom': use a custom invoker. Specify with --custom-url flag
+- 'custom': use a custom invoker. Specify with --invoker-url flag
 
 Buildpack based builds support building from local source or within the cluster. Images will be pushed to the registry specified in the image name, unless prefixed with 'dev.local/' in which case the image will only be available within the local Docker daemon.
 


### PR DESCRIPTION
As referenced in https://github.com/projectriff/riff/issues/634, as a possible solution for greater invoker flexibility...

While working on/testing an update to the python invoker, adding a custom flag definitely made my life easier. 

This still maintains the 'riff function create INVOKER FUNCTION_NAME  [flags]' pattern but adds a 'custom' type that requires the '-invoker-url' flag. 
