### PR TITLE
Bump stable manifest versions

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,11 @@
 manifestVersion: 0.1
 istio:
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181002-536fa6b/istio.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/istio.yaml
 knative:
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181002-536fa6b/release-no-mon.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20181002-52cc1aa/release.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20181002-52cc1aa/release-clusterbus-stub.yaml
+- https://storage.googleapis.com/knative-releases/build/previous/v20181008-9825433/release.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/serving.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release-clusterbus-stub.yaml
 namespace:
 - https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml
 - https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ manifestVersion: 0.1
 istio:
 - https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/istio.yaml
 knative:
-- https://storage.googleapis.com/knative-releases/build/previous/v20181008-9825433/release.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/build.yaml
 - https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/serving.yaml
 - https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release.yaml
 - https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release-clusterbus-stub.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,11 +1,11 @@
 manifestVersion: 0.1
 istio:
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/istio.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/istio.yaml
 knative:
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/build.yaml
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/serving.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release-clusterbus-stub.yaml
+- https://storage.googleapis.com/knative-releases/build/previous/v20181009-62d2284/release.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/serving.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release-clusterbus-stub.yaml
 namespace:
 - https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml
 - https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.yaml

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -52,7 +52,9 @@ var manifests = map[string]*Manifest{
 			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/istio.yaml",
 		},
 		Knative: []string{
-			"https://storage.googleapis.com/knative-releases/build/previous/v20181008-9825433/release.yaml",
+			// TODO switch to a proper build release
+			// "https://storage.googleapis.com/knative-releases/build/previous/v20181008-9825433/release.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/build.yaml",
 			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/serving.yaml",
 			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release.yaml",
 			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release-clusterbus-stub.yaml",

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -36,7 +36,8 @@ var manifests = map[string]*Manifest{
 			"https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml",
 		},
 		Knative: []string{
-			"https://storage.googleapis.com/knative-releases/serving/latest/release-no-mon.yaml",
+			"https://storage.googleapis.com/knative-releases/build/latest/release.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/latest/serving.yaml",
 			"https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml",
 			"https://storage.googleapis.com/knative-releases/eventing/latest/release-clusterbus-stub.yaml",
 		},
@@ -48,12 +49,13 @@ var manifests = map[string]*Manifest{
 	"stable": &Manifest{
 		ManifestVersion: manifestVersion_0_1,
 		Istio: []string{
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181002-536fa6b/istio.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/istio.yaml",
 		},
 		Knative: []string{
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181002-536fa6b/release-no-mon.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181002-52cc1aa/release.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181002-52cc1aa/release-clusterbus-stub.yaml",
+			"https://storage.googleapis.com/knative-releases/build/previous/v20181008-9825433/release.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/serving.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release-clusterbus-stub.yaml",
 		},
 		Namespace: []string{
 			"https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml",

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -49,15 +49,13 @@ var manifests = map[string]*Manifest{
 	"stable": &Manifest{
 		ManifestVersion: manifestVersion_0_1,
 		Istio: []string{
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/istio.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/istio.yaml",
 		},
 		Knative: []string{
-			// TODO switch to a proper build release
-			// "https://storage.googleapis.com/knative-releases/build/previous/v20181008-9825433/release.yaml",
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/build.yaml",
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181008-d8283a8/serving.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181008-0fd0e19/release-clusterbus-stub.yaml",
+			"https://storage.googleapis.com/knative-releases/build/previous/v20181009-62d2284/release.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/serving.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release-clusterbus-stub.yaml",
 		},
 		Namespace: []string{
 			"https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml",


### PR DESCRIPTION
Build can now be released independently of serving, we will no longer
need serving to update the build release for us.

Fixes #870