### PR TITLE
Make the 'command' & node languages use buildpacks

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -34,12 +34,12 @@ This file is defined in the root of this repository and symbolically linked from
 
 var (
 	buildpacks = map[string]string{
-		"java": "projectriff/buildpack",
+		"java":    "projectriff/buildpack",
+		"command": "projectriff/buildpack",
+		"node":    "projectriff/buildpack",
 	}
 	invokers = map[string]string{
-		"jar":     "https://github.com/projectriff/java-function-invoker/raw/v0.1.1/java-invoker.yaml",
-		"command": "https://github.com/projectriff/command-function-invoker/raw/v0.0.7/command-invoker.yaml",
-		"node":    "https://github.com/projectriff/node-function-invoker/raw/v0.0.8/node-invoker.yaml",
+		"jar": "https://github.com/projectriff/java-function-invoker/raw/v0.1.1/java-invoker.yaml",
 	}
 	manifests = map[string]*core.Manifest{
 		"latest": {
@@ -55,7 +55,7 @@ var (
 			},
 			Namespace: []string{
 				"https://storage.googleapis.com/riff-releases/latest/riff-build.yaml",
-				"https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate-0.0.1-snapshot-ci-64830c3bbc6503beafdae382ead115806fa100ca.yaml",
 			},
 		},
 		"stable": {

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -8,10 +8,10 @@ Create a new function resource from the content of the provided Git repo/revisio
 
 The INVOKER arg defines the language runtime and function invoker that is added to the function code in the build step. The resulting image is then used to create a Knative Service (`service.serving.knative.dev`) instance of the name specified for the function. The following invokers are available:
 
-- 'command'
+- 'command': buildpack based
 - 'jar'
 - 'java': buildpack based
-- 'node'
+- 'node': buildpack based
 - 'custom': use a custom invoker. Specify with --invoker-url flag
 
 Buildpack based builds support building from local source or within the cluster. Images will be pushed to the registry specified in the image name, unless prefixed with 'dev.local/' in which case the image will only be available within the local Docker daemon.

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -133,6 +133,8 @@ func (c *client) CreateFunction(options CreateFunctionOptions, log io.Writer) (*
 					Name: "riff-cnb",
 					Arguments: []build.ArgumentSpec{
 						{Name: "IMAGE", Value: options.Image},
+						{Name: "FUNCTION_ARTIFACT", Value: options.Artifact},
+						{Name: "FUNCTION_HANDLER", Value: options.Handler},
 						// TODO configure buildtemplate based on buildpack image
 						// {Name: "TBD", Value: options.BuildpackImage},
 					},


### PR DESCRIPTION
Expose artifact and handler as BuildTemplate parameters

Fixes #905