### PR TITLE
 Update to artifacts from v20181029

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,11 +1,11 @@
 manifestVersion: 0.1
 istio:
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/istio.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181029-1d5c521/istio.yaml
 knative:
-- https://storage.googleapis.com/knative-releases/build/previous/v20181009-62d2284/release.yaml
-- https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/serving.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release.yaml
-- https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release-clusterbus-stub.yaml
+- https://storage.googleapis.com/knative-releases/build/previous/v20181029-e9f5b24/release.yaml
+- https://storage.googleapis.com/knative-releases/serving/previous/v20181029-1d5c521/serving.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20181029-642bfc1/release.yaml
+- https://storage.googleapis.com/knative-releases/eventing/previous/v20181029-642bfc1/release-clusterbus-stub.yaml
 namespace:
 - https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml
 - https://storage.googleapis.com/riff-releases/riff-cnb-buildtemplate-0.1.0.yaml

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -327,6 +327,11 @@ func (c *client) waitForSuccessOrFailure(namespace string, name string, gen int6
 						someStateIsUnknown = true
 						break
 					}
+					// ignore any "scaled to zero" status messages - wait for the revision to start
+					if strings.Contains(c.Message, "The target is not receiving traffic") {
+						someStateIsUnknown = true
+						break
+					}
 				}
 			}
 			if !someStateIsUnknown {

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -328,6 +328,7 @@ func (c *client) waitForSuccessOrFailure(namespace string, name string, gen int6
 						break
 					}
 					// ignore any "scaled to zero" status messages - wait for the revision to start
+					// TODO: remove this once https://github.com/knative/serving/issues/2346 is resolved
 					if strings.Contains(c.Message, "The target is not receiving traffic") {
 						someStateIsUnknown = true
 						break

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -49,13 +49,13 @@ var manifests = map[string]*Manifest{
 	"stable": &Manifest{
 		ManifestVersion: manifestVersion_0_1,
 		Istio: []string{
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/istio.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181029-1d5c521/istio.yaml",
 		},
 		Knative: []string{
-			"https://storage.googleapis.com/knative-releases/build/previous/v20181009-62d2284/release.yaml",
-			"https://storage.googleapis.com/knative-releases/serving/previous/v20181009-38c0d50/serving.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release.yaml",
-			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181009-95ed4b7/release-clusterbus-stub.yaml",
+			"https://storage.googleapis.com/knative-releases/build/previous/v20181029-e9f5b24/release.yaml",
+			"https://storage.googleapis.com/knative-releases/serving/previous/v20181029-1d5c521/serving.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181029-642bfc1/release.yaml",
+			"https://storage.googleapis.com/knative-releases/eventing/previous/v20181029-642bfc1/release-clusterbus-stub.yaml",
 		},
 		Namespace: []string{
 			"https://storage.googleapis.com/riff-releases/previous/riff-build/riff-build-0.1.0.yaml",


### PR DESCRIPTION
Function create fails unless we ignore the "scale to zero" status message that we now see between the build and the revision being ready

Fixes #907 
Fixes #908 
