### PR TITLE
Distribution creation

### DIFF
--- a/distro/commands/distro.go
+++ b/distro/commands/distro.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package commands
+
+import (
+	"github.com/projectriff/riff/cmd/commands"
+	"github.com/projectriff/riff/pkg/core"
+	"github.com/projectriff/riff/pkg/env"
+	"github.com/spf13/cobra"
+)
+
+func DistroCreate(c *core.ImageClient) *cobra.Command {
+	options := core.CreateDistroOptions{}
+
+	command := &cobra.Command{
+		Use:   "create",
+		Short: "Create a " + env.Cli.Name + " distribution.",
+		Long: "Create a " + env.Cli.Name + " distribution archive file (.tgz) from a given manifest.\n\n" +
+			"If the output path is that of an existing directory, the file \"distro.tgz\" will be written in that " +
+			"directory. Otherwise, the file will be written at the output path.",
+		Example: "  " + env.Cli.Name + " create --output=./my-distro.tgz",
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := (*c).CreateDistro(options)
+			if err != nil {
+				return err
+			}
+
+			commands.PrintSuccessfulCompletion(cmd)
+			return nil
+		},
+	}
+
+	command.Flags().StringVarP(&options.Manifest, "manifest", "m", "stable", "manifest for the download; can be a named manifest (stable or latest) or a path of a manifest file")
+
+	command.Flags().StringVarP(&options.Output, "output", "o", "", "path for the distribution archive (.tgz)")
+	command.MarkFlagRequired("output")
+
+	return command
+}

--- a/distro/commands/wiring.go
+++ b/distro/commands/wiring.go
@@ -70,6 +70,7 @@ See https://projectriff.io and https://github.com/knative/docs`,
 	rootCmd.AddCommand(
 		image,
 		system,
+        DistroCreate(&imageClient),
 		commands.Version(),
 		commands.Docs(rootCmd, commands.LocalFs{}),
 		commands.Completion(rootCmd),

--- a/distro/docs/riff-distro.md
+++ b/distro/docs/riff-distro.md
@@ -18,6 +18,7 @@ See https://projectriff.io and https://github.com/knative/docs
 ### SEE ALSO
 
 * [riff-distro completion](riff-distro_completion.md)	 - Generate shell completion scripts
+* [riff-distro create](riff-distro_create.md)	 - Create a riff-distro distribution.
 * [riff-distro image](riff-distro_image.md)	 - Interact with docker images
 * [riff-distro system](riff-distro_system.md)	 - Interact with riff-distro systems
 * [riff-distro version](riff-distro_version.md)	 - Print version information about riff-distro

--- a/distro/docs/riff-distro_create.md
+++ b/distro/docs/riff-distro_create.md
@@ -1,0 +1,32 @@
+## riff-distro create
+
+Create a riff-distro distribution.
+
+### Synopsis
+
+Create a riff-distro distribution archive file (.tgz) from a given manifest.
+
+If the output path is that of an existing directory, the file "distro.tgz" will be written in that directory. Otherwise, the file will be written at the output path.
+
+```
+riff-distro create [flags]
+```
+
+### Examples
+
+```
+  riff-distro create --output=./my-distro.tgz
+```
+
+### Options
+
+```
+  -h, --help              help for create
+  -m, --manifest string   manifest for the download; can be a named manifest (stable or latest) or a path of a manifest file (default "stable")
+  -o, --output string     path for the distribution archive (.tgz)
+```
+
+### SEE ALSO
+
+* [riff-distro](riff-distro.md)	 - Commands for creating a riff distribution
+

--- a/pkg/core/image_client.go
+++ b/pkg/core/image_client.go
@@ -39,6 +39,7 @@ type ImageClient interface {
 	RelocateImages(options RelocateImagesOptions) error
 	DownloadSystem(options DownloadSystemOptions) error
 	ListImages(options ListImagesOptions) error
+	CreateDistro(options CreateDistroOptions) error
 }
 
 type PushImagesOptions struct {

--- a/pkg/core/image_test.go
+++ b/pkg/core/image_test.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
+
+	"github.com/projectriff/riff/pkg/test_support"
 
 	"github.com/projectriff/riff/pkg/image_manifest"
 
@@ -426,6 +429,48 @@ var _ = Describe("SystemDownload", func() {
 			})
 
 		})
+	})
+})
+
+var _ = Describe("createArchive", func() {
+	var work string
+
+	BeforeEach(func() {
+		work = test_support.CreateTempDir()
+	})
+
+	AfterEach(func() {
+		test_support.CleanupDirs(GinkgoT(), work)
+	})
+
+	It("should create an archive containing the correct files", func() {
+		tarfile := filepath.Join(work, "test.tgz")
+		err := createArchive(filepath.Join("fixtures", "archive"), tarfile)
+		Expect(err).NotTo(HaveOccurred())
+		cmd := exec.Command("tar", "xzf", tarfile, "-C", work)
+		Expect(cmd.Run()).To(Succeed())
+		_, err = os.Stat(filepath.Join(work, "file"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create the directory of the archive", func() {
+		tarfile := filepath.Join(work, "newdir", "test.tgz")
+		err := createArchive(filepath.Join("fixtures", "archive"), tarfile)
+		Expect(err).NotTo(HaveOccurred())
+		cmd := exec.Command("tar", "xzf", tarfile, "-C", work)
+		Expect(cmd.Run()).To(Succeed())
+		_, err = os.Stat(filepath.Join(work, "file"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should default the name of the archive", func() {
+		err := createArchive(filepath.Join("fixtures", "archive"), work)
+		Expect(err).NotTo(HaveOccurred())
+		tarfile := filepath.Join(work, "distro.tgz")
+		cmd := exec.Command("tar", "xzf", tarfile, "-C", work)
+		Expect(cmd.Run()).To(Succeed())
+		_, err = os.Stat(filepath.Join(work, "file"))
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 

--- a/pkg/core/mocks/ImageClient.go
+++ b/pkg/core/mocks/ImageClient.go
@@ -10,6 +10,20 @@ type ImageClient struct {
 	mock.Mock
 }
 
+// CreateDistro provides a mock function with given fields: options
+func (_m *ImageClient) CreateDistro(options core.CreateDistroOptions) error {
+	ret := _m.Called(options)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(core.CreateDistroOptions) error); ok {
+		r0 = rf(options)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DownloadSystem provides a mock function with given fields: options
 func (_m *ImageClient) DownloadSystem(options core.DownloadSystemOptions) error {
 	ret := _m.Called(options)

--- a/pkg/resource/list.go
+++ b/pkg/resource/list.go
@@ -19,12 +19,13 @@ package resource
 
 import (
 	"fmt"
-	"github.com/ghodss/yaml"
 	"strings"
+
+	"github.com/ghodss/yaml"
 )
 
 func ListImages(resource string, baseDir string) ([]string, error) {
-	fmt.Printf("Searching %s\n", resource)
+	fmt.Printf("Scanning %s\n", resource)
 	contents, err := Load(resource, baseDir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`riff-distro create` downloads a manifest and its configuration files, scans
the files for images, downloads the images, and then creates a distribution
archive from the various downloads.