### PR TITLE
typo in image list command

### DIFF
--- a/distro/README.md
+++ b/distro/README.md
@@ -32,7 +32,7 @@ riff-distro system download -m stable -o .
 Scan the release yaml files to generate a list of images into `image-manifest.yaml`.  In general this list will require additional validation. 
 
 ```sh
-riff-distro image list -m stable --no-check
+riff-distro image list -m manifest.yaml --no-check
 ```
 
 Using ` --no-check` avoids checking each image. Checks are performed by attempting to pull the images using the local docker daemon.


### PR DESCRIPTION
@glyn I assume this is a typo, since running the command as documented produced the following error:

```
Error: Error reading manifest file: open /Users/mark/release-new/stable: no such file or directory
```
