### PR TITLE
rename function "build" and service "revise" commands to "update"

### DIFF
--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -30,8 +30,8 @@ const (
 )
 
 const (
-	functionBuildFunctionNameIndex = iota
-	functionBuildNumberOfArgs
+	functionUpdateFunctionNameIndex = iota
+	functionUpdateNumberOfArgs
 )
 
 func Function() *cobra.Command {
@@ -123,24 +123,24 @@ func FunctionCreate(fcTool *core.Client, defaults FunctionCreateDefaults) *cobra
 	return command
 }
 
-func FunctionBuild(fcTool *core.Client) *cobra.Command {
+func FunctionUpdate(fcTool *core.Client) *cobra.Command {
 
-	buildFunctionOptions := core.BuildFunctionOptions{}
+	updateFunctionOptions := core.UpdateFunctionOptions{}
 
 	command := &cobra.Command{
-		Use:     "build",
-		Short:   "Trigger a revision build for a function resource",
-		Example: `  ` + env.Cli.Name + ` function build square`,
+		Use:     "update",
+		Short:   "Trigger a build to generate a new revision for a function resource",
+		Example: `  ` + env.Cli.Name + ` function update square`,
 		Args: ArgValidationConjunction(
-			cobra.ExactArgs(functionBuildNumberOfArgs),
-			AtPosition(functionBuildFunctionNameIndex, ValidName()),
+			cobra.ExactArgs(functionUpdateNumberOfArgs),
+			AtPosition(functionUpdateFunctionNameIndex, ValidName()),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			fnName := args[functionBuildFunctionNameIndex]
+			fnName := args[functionUpdateFunctionNameIndex]
 
-			buildFunctionOptions.Name = fnName
-			err := (*fcTool).BuildFunction(buildFunctionOptions, cmd.OutOrStdout())
+			updateFunctionOptions.Name = fnName
+			err := (*fcTool).UpdateFunction(updateFunctionOptions, cmd.OutOrStdout())
 			if err != nil {
 				return err
 			}
@@ -153,10 +153,10 @@ func FunctionBuild(fcTool *core.Client) *cobra.Command {
 
 	LabelArgs(command, "FUNCTION_NAME")
 
-	command.Flags().StringVarP(&buildFunctionOptions.Namespace, "namespace", "n", "", "the `namespace` of the function")
-	command.Flags().StringVarP(&buildFunctionOptions.LocalPath, "local-path", "l", "", "path to local source to build the image from; only build-pack builds are supported at this time")
-	command.Flags().BoolVarP(&buildFunctionOptions.Verbose, "verbose", "v", false, verboseUsage)
-	command.Flags().BoolVarP(&buildFunctionOptions.Wait, "wait", "w", false, waitUsage)
+	command.Flags().StringVarP(&updateFunctionOptions.Namespace, "namespace", "n", "", "the `namespace` of the function")
+	command.Flags().StringVarP(&updateFunctionOptions.LocalPath, "local-path", "l", "", "path to local source to build the image from; only build-pack builds are supported at this time")
+	command.Flags().BoolVarP(&updateFunctionOptions.Verbose, "verbose", "v", false, verboseUsage)
+	command.Flags().BoolVarP(&updateFunctionOptions.Wait, "wait", "w", false, waitUsage)
 
 	return command
 }

--- a/cmd/commands/function_test.go
+++ b/cmd/commands/function_test.go
@@ -241,7 +241,7 @@ status: {}
 ---
 `
 
-var _ = Describe("The riff function build command", func() {
+var _ = Describe("The riff function update command", func() {
 	Context("when given wrong args or flags", func() {
 		var (
 			mockClient core.Client
@@ -249,7 +249,7 @@ var _ = Describe("The riff function build command", func() {
 		)
 		BeforeEach(func() {
 			mockClient = nil
-			fc = commands.FunctionBuild(&mockClient)
+			fc = commands.FunctionUpdate(&mockClient)
 		})
 		It("should fail with no args", func() {
 			fc.SetArgs([]string{})
@@ -257,7 +257,7 @@ var _ = Describe("The riff function build command", func() {
 			Expect(err).To(MatchError("accepts 1 arg(s), received 0"))
 		})
 		It("should fail with invalid function name", func() {
-			//fc = commands.FunctionBuild(&mockClient)
+			//fc = commands.FunctionUpdate(&mockClient)
 			fc.SetArgs([]string{"invålid"})
 			err := fc.Execute()
 			Expect(err).To(MatchError(ContainSubstring("must start and end with an alphanumeric character")))
@@ -274,7 +274,7 @@ var _ = Describe("The riff function build command", func() {
 			client = new(mocks.Client)
 			asMock = client.(*mocks.Client)
 
-			fc = commands.FunctionBuild(&client)
+			fc = commands.FunctionUpdate(&client)
 		})
 		AfterEach(func() {
 			asMock.AssertExpectations(GinkgoT())
@@ -283,11 +283,11 @@ var _ = Describe("The riff function build command", func() {
 		It("should involve the core.Client", func() {
 			fc.SetArgs([]string{"square", "--namespace", "ns"})
 
-			o := core.BuildFunctionOptions{}
+			o := core.UpdateFunctionOptions{}
 			o.Name = "square"
 			o.Namespace = "ns"
 
-			asMock.On("BuildFunction", o, mock.Anything).Return(nil)
+			asMock.On("UpdateFunction", o, mock.Anything).Return(nil)
 			err := fc.Execute()
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -295,7 +295,7 @@ var _ = Describe("The riff function build command", func() {
 			fc.SetArgs([]string{"square", "--namespace", "ns"})
 
 			e := fmt.Errorf("some error")
-			asMock.On("BuildFunction", mock.Anything, mock.Anything).Return(e)
+			asMock.On("UpdateFunction", mock.Anything, mock.Anything).Return(e)
 			err := fc.Execute()
 			Expect(err).To(MatchError(e))
 		})

--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -37,8 +37,8 @@ const (
 )
 
 const (
-	serviceReviseServiceNameIndex = iota
-	serviceReviseNumberOfArgs
+	serviceUpdateServiceNameIndex = iota
+	serviceUpdateNumberOfArgs
 )
 
 const (
@@ -71,7 +71,7 @@ func Service() *cobra.Command {
 
 func ServiceCreate(fcTool *core.Client) *cobra.Command {
 
-	createServiceOptions := core.CreateOrReviseServiceOptions{}
+	createServiceOptions := core.CreateOrUpdateServiceOptions{}
 
 	command := &cobra.Command{
 		Use:   "create",
@@ -123,26 +123,26 @@ func ServiceCreate(fcTool *core.Client) *cobra.Command {
 	return command
 }
 
-func ServiceRevise(client *core.Client) *cobra.Command {
-	reviseServiceOptions := core.CreateOrReviseServiceOptions{}
+func ServiceUpdate(client *core.Client) *cobra.Command {
+	updateServiceOptions := core.CreateOrUpdateServiceOptions{}
 
 	command := &cobra.Command{
-		Use:     "revise",
+		Use:     "update",
 		Short:   "Create a new revision for a service, with updated attributes",
 		Long:    `Create a new revision for a service, updating the application/function image and/or environment.`,
-		Example: `  ` + env.Cli.Name + ` service revise square --image acme/square:1.1 --namespace joseph-ns`,
+		Example: `  ` + env.Cli.Name + ` service update square --image acme/square:1.1 --namespace joseph-ns`,
 		Args: ArgValidationConjunction(
-			cobra.ExactArgs(serviceReviseNumberOfArgs),
-			AtPosition(serviceReviseServiceNameIndex, ValidName()),
+			cobra.ExactArgs(serviceUpdateNumberOfArgs),
+			AtPosition(serviceUpdateServiceNameIndex, ValidName()),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fnName := args[serviceReviseServiceNameIndex]
-			reviseServiceOptions.Name = fnName
-			svc, err := (*client).ReviseService(reviseServiceOptions)
+			fnName := args[serviceUpdateServiceNameIndex]
+			updateServiceOptions.Name = fnName
+			svc, err := (*client).UpdateService(updateServiceOptions)
 			if err != nil {
 				return err
 			}
-			if reviseServiceOptions.DryRun {
+			if updateServiceOptions.DryRun {
 				marshaller := NewMarshaller(cmd.OutOrStdout())
 				if err = marshaller.Marshal(svc); err != nil {
 					return err
@@ -157,11 +157,11 @@ func ServiceRevise(client *core.Client) *cobra.Command {
 
 	LabelArgs(command, "SERVICE_NAME")
 
-	command.Flags().StringVarP(&reviseServiceOptions.Namespace, "namespace", "n", "", "the `namespace` of the service")
-	command.Flags().BoolVar(&reviseServiceOptions.DryRun, "dry-run", false, dryRunUsage)
-	command.Flags().StringVar(&reviseServiceOptions.Image, "image", "", "the `name[:tag]` reference of an image containing the application/function")
-	command.Flags().StringArrayVar(&reviseServiceOptions.Env, "env", []string{}, envUsage)
-	command.Flags().StringArrayVar(&reviseServiceOptions.EnvFrom, "env-from", []string{}, envFromUsage)
+	command.Flags().StringVarP(&updateServiceOptions.Namespace, "namespace", "n", "", "the `namespace` of the service")
+	command.Flags().BoolVar(&updateServiceOptions.DryRun, "dry-run", false, dryRunUsage)
+	command.Flags().StringVar(&updateServiceOptions.Image, "image", "", "the `name[:tag]` reference of an image containing the application/function")
+	command.Flags().StringArrayVar(&updateServiceOptions.Env, "env", []string{}, envUsage)
+	command.Flags().StringArrayVar(&updateServiceOptions.EnvFrom, "env-from", []string{}, envFromUsage)
 
 	return command
 }

--- a/cmd/commands/service_test.go
+++ b/cmd/commands/service_test.go
@@ -85,7 +85,7 @@ var _ = Describe("The riff service create command", func() {
 		It("should involve the core.Client", func() {
 			sc.SetArgs([]string{"my-service", "--image", "foo/bar", "--namespace", "ns"})
 
-			o := core.CreateOrReviseServiceOptions{
+			o := core.CreateOrUpdateServiceOptions{
 				Name:    "my-service",
 				Image:   "foo/bar",
 				Env:     []string{},
@@ -109,7 +109,7 @@ var _ = Describe("The riff service create command", func() {
 			sc.SetArgs([]string{"my-service", "--image", "foo/bar", "--namespace", "ns", "--env", "FOO=bar",
 				"--env", "BAZ=qux", "--env-from", "secretKeyRef:foo:bar"})
 
-			o := core.CreateOrReviseServiceOptions{
+			o := core.CreateOrUpdateServiceOptions{
 				Name:    "my-service",
 				Image:   "foo/bar",
 				Env:     []string{"FOO=bar", "BAZ=qux"},
@@ -124,7 +124,7 @@ var _ = Describe("The riff service create command", func() {
 		It("should print when --dry-run is set", func() {
 			sc.SetArgs([]string{"square", "--image", "foo/bar", "--dry-run"})
 
-			serviceOptions := core.CreateOrReviseServiceOptions{
+			serviceOptions := core.CreateOrUpdateServiceOptions{
 				Name:    "square",
 				Image:   "foo/bar",
 				Env:     []string{},
@@ -160,7 +160,7 @@ status: {}
 ---
 `
 
-var _ = Describe("The riff service revise command", func() {
+var _ = Describe("The riff service update command", func() {
 	Context("when given wrong args or flags", func() {
 		var (
 			mockClient core.Client
@@ -168,7 +168,7 @@ var _ = Describe("The riff service revise command", func() {
 		)
 		BeforeEach(func() {
 			mockClient = nil
-			cc = commands.ServiceRevise(&mockClient)
+			cc = commands.ServiceUpdate(&mockClient)
 		})
 		It("should fail with no args", func() {
 			cc.SetArgs([]string{})
@@ -192,7 +192,7 @@ var _ = Describe("The riff service revise command", func() {
 			client = new(mocks.Client)
 			asMock = client.(*mocks.Client)
 
-			sc = commands.ServiceRevise(&client)
+			sc = commands.ServiceUpdate(&client)
 		})
 		AfterEach(func() {
 			asMock.AssertExpectations(GinkgoT())
@@ -200,7 +200,7 @@ var _ = Describe("The riff service revise command", func() {
 		It("should involve the core.Client", func() {
 			sc.SetArgs([]string{"my-service", "--image", "foo/bar", "--namespace", "ns"})
 
-			o := core.CreateOrReviseServiceOptions{
+			o := core.CreateOrUpdateServiceOptions{
 				Name:    "my-service",
 				Image:   "foo/bar",
 				Env:     []string{},
@@ -208,7 +208,7 @@ var _ = Describe("The riff service revise command", func() {
 			}
 			o.Namespace = "ns"
 
-			asMock.On("ReviseService", o).Return(nil, nil)
+			asMock.On("UpdateService", o).Return(nil, nil)
 			err := sc.Execute()
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -216,7 +216,7 @@ var _ = Describe("The riff service revise command", func() {
 			sc.SetArgs([]string{"my-service", "--image", "foo/bar"})
 
 			e := fmt.Errorf("some error")
-			asMock.On("ReviseService", mock.Anything).Return(nil, e)
+			asMock.On("UpdateService", mock.Anything).Return(nil, e)
 			err := sc.Execute()
 			Expect(err).To(MatchError(e))
 		})
@@ -224,7 +224,7 @@ var _ = Describe("The riff service revise command", func() {
 			sc.SetArgs([]string{"my-service", "--image", "foo/bar", "--namespace", "ns", "--env", "FOO=bar",
 				"--env", "BAZ=qux", "--env-from", "secretKeyRef:foo:bar"})
 
-			o := core.CreateOrReviseServiceOptions{
+			o := core.CreateOrUpdateServiceOptions{
 				Name:    "my-service",
 				Image:   "foo/bar",
 				Env:     []string{"FOO=bar", "BAZ=qux"},
@@ -232,14 +232,14 @@ var _ = Describe("The riff service revise command", func() {
 			}
 			o.Namespace = "ns"
 
-			asMock.On("ReviseService", o).Return(nil, nil)
+			asMock.On("UpdateService", o).Return(nil, nil)
 			err := sc.Execute()
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should print when --dry-run is set", func() {
 			sc.SetArgs([]string{"square", "--image", "foo/bar", "--dry-run"})
 
-			serviceOptions := core.CreateOrReviseServiceOptions{
+			serviceOptions := core.CreateOrUpdateServiceOptions{
 				Name:    "square",
 				Image:   "foo/bar",
 				Env:     []string{},
@@ -264,7 +264,7 @@ var _ = Describe("The riff service revise command", func() {
 					},
 				},
 			}
-			asMock.On("ReviseService", serviceOptions).Return(&svc, nil)
+			asMock.On("UpdateService", serviceOptions).Return(&svc, nil)
 
 			stdout := &strings.Builder{}
 			sc.SetOutput(stdout)
@@ -272,13 +272,13 @@ var _ = Describe("The riff service revise command", func() {
 			err := sc.Execute()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(stdout.String()).To(Equal(serviceReviseDryRun))
+			Expect(stdout.String()).To(Equal(serviceUpdateDryRun))
 		})
 
 	})
 })
 
-const serviceReviseDryRun = `metadata:
+const serviceUpdateDryRun = `metadata:
   creationTimestamp: null
   name: square
 spec:

--- a/cmd/commands/wiring.go
+++ b/cmd/commands/wiring.go
@@ -102,7 +102,7 @@ See https://projectriff.io and https://github.com/knative/docs`,
 	installKubeConfigSupport(function, &client, &kc)
 	function.AddCommand(
 		FunctionCreate(&client, FunctionCreateDefaults{LocalBuilder: localBuilder, DefaultRunImage: defaultRunImage}),
-		FunctionBuild(&client),
+		FunctionUpdate(&client),
 	)
 
 	service := Service()

--- a/cmd/commands/wiring.go
+++ b/cmd/commands/wiring.go
@@ -110,7 +110,7 @@ See https://projectriff.io and https://github.com/knative/docs`,
 	service.AddCommand(
 		ServiceList(&client),
 		ServiceCreate(&client),
-		ServiceRevise(&client),
+		ServiceUpdate(&client),
 		ServiceStatus(&client),
 		ServiceInvoke(&client),
 		ServiceDelete(&client),

--- a/docs/riff_function.md
+++ b/docs/riff_function.md
@@ -17,6 +17,6 @@ Interact with function related resources
 ### SEE ALSO
 
 * [riff](riff.md)	 - Commands for creating and managing function resources
-* [riff function build](riff_function_build.md)	 - Trigger a revision build for a function resource
 * [riff function create](riff_function_create.md)	 - Create a new function resource
+* [riff function update](riff_function_update.md)	 - Trigger a build to generate a new revision for a function resource
 

--- a/docs/riff_function_update.md
+++ b/docs/riff_function_update.md
@@ -1,25 +1,25 @@
-## riff function build
+## riff function update
 
-Trigger a revision build for a function resource
+Trigger a build to generate a new revision for a function resource
 
 ### Synopsis
 
-Trigger a revision build for a function resource
+Trigger a build to generate a new revision for a function resource
 
 ```
-riff function build [flags]
+riff function update [flags]
 ```
 
 ### Examples
 
 ```
-  riff function build square
+  riff function update square
 ```
 
 ### Options
 
 ```
-  -h, --help                  help for build
+  -h, --help                  help for update
   -l, --local-path string     path to local source to build the image from; only build-pack builds are supported at this time
   -n, --namespace namespace   the namespace of the function
   -v, --verbose               print details of command progress

--- a/docs/riff_service.md
+++ b/docs/riff_service.md
@@ -21,6 +21,6 @@ Interact with service (as in `service.serving.knative.dev`) related resources.
 * [riff service delete](riff_service_delete.md)	 - Delete an existing service
 * [riff service invoke](riff_service_invoke.md)	 - Invoke a service
 * [riff service list](riff_service_list.md)	 - List service resources
-* [riff service revise](riff_service_revise.md)	 - Create a new revision for a service, with updated attributes
 * [riff service status](riff_service_status.md)	 - Display the status of a service
+* [riff service update](riff_service_update.md)	 - Create a new revision for a service, with updated attributes
 

--- a/docs/riff_service_update.md
+++ b/docs/riff_service_update.md
@@ -1,4 +1,4 @@
-## riff service revise
+## riff service update
 
 Create a new revision for a service, with updated attributes
 
@@ -7,13 +7,13 @@ Create a new revision for a service, with updated attributes
 Create a new revision for a service, updating the application/function image and/or environment.
 
 ```
-riff service revise [flags]
+riff service update [flags]
 ```
 
 ### Examples
 
 ```
-  riff service revise square --image acme/square:1.1 --namespace joseph-ns
+  riff service update square --image acme/square:1.1 --namespace joseph-ns
 ```
 
 ### Options
@@ -22,7 +22,7 @@ riff service revise [flags]
       --dry-run                don't create resources but print yaml representation on stdout
       --env stringArray        environment variable expressed in a 'key=value' format
       --env-from stringArray   environment variable created from a source reference; see command help for supported formats
-  -h, --help                   help for revise
+  -h, --help                   help for update
       --image name[:tag]       the name[:tag] reference of an image containing the application/function
   -n, --namespace namespace    the namespace of the service
 ```

--- a/pkg/core/client.go
+++ b/pkg/core/client.go
@@ -31,7 +31,7 @@ import (
 
 type Client interface {
 	CreateFunction(options CreateFunctionOptions, log io.Writer) (*serving.Service, error)
-	BuildFunction(options BuildFunctionOptions, log io.Writer) error
+	UpdateFunction(options UpdateFunctionOptions, log io.Writer) error
 
 	CreateSubscription(options CreateSubscriptionOptions) (*eventing.Subscription, error)
 	DeleteSubscription(options DeleteSubscriptionOptions) error

--- a/pkg/core/client.go
+++ b/pkg/core/client.go
@@ -42,8 +42,8 @@ type Client interface {
 	DeleteChannel(options DeleteChannelOptions) error
 
 	ListServices(options ListServiceOptions) (*serving.ServiceList, error)
-	CreateService(options CreateOrReviseServiceOptions) (*serving.Service, error)
-	ReviseService(options CreateOrReviseServiceOptions) (*serving.Service, error)
+	CreateService(options CreateOrUpdateServiceOptions) (*serving.Service, error)
+	UpdateService(options CreateOrUpdateServiceOptions) (*serving.Service, error)
 	DeleteService(options DeleteServiceOptions) error
 	ServiceStatus(options ServiceStatusOptions) (*v1alpha1.ServiceCondition, error)
 	ServiceCoordinates(options ServiceInvokeOptions) (ingressIP string, hostName string, err error)

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -52,7 +52,7 @@ const (
 )
 
 type CreateFunctionOptions struct {
-	CreateOrReviseServiceOptions
+	CreateOrUpdateServiceOptions
 
 	LocalPath   string
 	GitRepo     string
@@ -69,7 +69,7 @@ type CreateFunctionOptions struct {
 func (c *client) CreateFunction(options CreateFunctionOptions, log io.Writer) (*v1alpha1.Service, error) {
 	ns := c.explicitOrConfigNamespace(options.Namespace)
 
-	s, err := newService(options.CreateOrReviseServiceOptions)
+	s, err := newService(options.CreateOrUpdateServiceOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -484,7 +484,7 @@ func (selectorDisjunction) String() string {
 	panic("implement me")
 }
 
-type BuildFunctionOptions struct {
+type UpdateFunctionOptions struct {
 	Namespace string
 	Name      string
 	LocalPath string
@@ -500,7 +500,7 @@ func (c *client) getServiceSpecGeneration(namespace string, name string) (int64,
 	return s.Spec.Generation, nil
 }
 
-func (c *client) BuildFunction(options BuildFunctionOptions, log io.Writer) error {
+func (c *client) UpdateFunction(options UpdateFunctionOptions, log io.Writer) error {
 	ns := c.explicitOrConfigNamespace(options.Namespace)
 
 	service, err := c.service(options.Namespace, options.Name)
@@ -525,7 +525,7 @@ func (c *client) BuildFunction(options BuildFunctionOptions, log io.Writer) erro
 	c.bumpNonceAnnotation(service)
 
 	if build == nil {
-		// function was build locally, attempt to reconstruct configuration
+		// function was built locally, attempt to reconstruct configuration
 		appDir := options.LocalPath
 		buildImage := annotations[buildpackBuildImageAnnotation]
 		runImage := annotations[buildpackRunImageAnnotation]
@@ -559,7 +559,7 @@ func (c *client) BuildFunction(options BuildFunctionOptions, log io.Writer) erro
 		)
 		for i := 0; i < 10; i++ {
 			if i >= 10 {
-				return fmt.Errorf("build unsuccesful for \"%s\", service resource was never updated", options.Name)
+				return fmt.Errorf("update unsuccesful for \"%s\", service resource was never updated", options.Name)
 			}
 			time.Sleep(500 * time.Millisecond)
 			nextGen, err = c.getServiceSpecGeneration(options.Namespace, options.Name)

--- a/pkg/core/mocks/Client.go
+++ b/pkg/core/mocks/Client.go
@@ -13,20 +13,6 @@ type Client struct {
 	mock.Mock
 }
 
-// BuildFunction provides a mock function with given fields: options, log
-func (_m *Client) BuildFunction(options core.BuildFunctionOptions, log io.Writer) error {
-	ret := _m.Called(options, log)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(core.BuildFunctionOptions, io.Writer) error); ok {
-		r0 = rf(options, log)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // CreateChannel provides a mock function with given fields: options
 func (_m *Client) CreateChannel(options core.CreateChannelOptions) (*v1alpha1.Channel, error) {
 	ret := _m.Called(options)
@@ -302,4 +288,18 @@ func (_m *Client) ServiceStatus(options core.ServiceStatusOptions) (*servingv1al
 	}
 
 	return r0, r1
+}
+
+// UpdateFunction provides a mock function with given fields: options, log
+func (_m *Client) UpdateFunction(options core.UpdateFunctionOptions, log io.Writer) error {
+	ret := _m.Called(options, log)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(core.UpdateFunctionOptions, io.Writer) error); ok {
+		r0 = rf(options, log)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }

--- a/pkg/core/mocks/Client.go
+++ b/pkg/core/mocks/Client.go
@@ -60,11 +60,11 @@ func (_m *Client) CreateFunction(options core.CreateFunctionOptions, log io.Writ
 }
 
 // CreateService provides a mock function with given fields: options
-func (_m *Client) CreateService(options core.CreateOrReviseServiceOptions) (*servingv1alpha1.Service, error) {
+func (_m *Client) CreateService(options core.CreateOrUpdateServiceOptions) (*servingv1alpha1.Service, error) {
 	ret := _m.Called(options)
 
 	var r0 *servingv1alpha1.Service
-	if rf, ok := ret.Get(0).(func(core.CreateOrReviseServiceOptions) *servingv1alpha1.Service); ok {
+	if rf, ok := ret.Get(0).(func(core.CreateOrUpdateServiceOptions) *servingv1alpha1.Service); ok {
 		r0 = rf(options)
 	} else {
 		if ret.Get(0) != nil {
@@ -73,7 +73,7 @@ func (_m *Client) CreateService(options core.CreateOrReviseServiceOptions) (*ser
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(core.CreateOrReviseServiceOptions) error); ok {
+	if rf, ok := ret.Get(1).(func(core.CreateOrUpdateServiceOptions) error); ok {
 		r1 = rf(options)
 	} else {
 		r1 = ret.Error(1)
@@ -216,29 +216,6 @@ func (_m *Client) ListSubscriptions(options core.ListSubscriptionsOptions) (*v1a
 	return r0, r1
 }
 
-// ReviseService provides a mock function with given fields: options
-func (_m *Client) ReviseService(options core.CreateOrReviseServiceOptions) (*servingv1alpha1.Service, error) {
-	ret := _m.Called(options)
-
-	var r0 *servingv1alpha1.Service
-	if rf, ok := ret.Get(0).(func(core.CreateOrReviseServiceOptions) *servingv1alpha1.Service); ok {
-		r0 = rf(options)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*servingv1alpha1.Service)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(core.CreateOrReviseServiceOptions) error); ok {
-		r1 = rf(options)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // ServiceCoordinates provides a mock function with given fields: options
 func (_m *Client) ServiceCoordinates(options core.ServiceInvokeOptions) (string, string, error) {
 	ret := _m.Called(options)
@@ -302,4 +279,27 @@ func (_m *Client) UpdateFunction(options core.UpdateFunctionOptions, log io.Writ
 	}
 
 	return r0
+}
+
+// UpdateService provides a mock function with given fields: options
+func (_m *Client) UpdateService(options core.CreateOrUpdateServiceOptions) (*servingv1alpha1.Service, error) {
+	ret := _m.Called(options)
+
+	var r0 *servingv1alpha1.Service
+	if rf, ok := ret.Get(0).(func(core.CreateOrUpdateServiceOptions) *servingv1alpha1.Service); ok {
+		r0 = rf(options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*servingv1alpha1.Service)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(core.CreateOrUpdateServiceOptions) error); ok {
+		r1 = rf(options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -39,7 +39,7 @@ func (c *client) ListServices(options ListServiceOptions) (*v1alpha1.ServiceList
 	return c.serving.ServingV1alpha1().Services(ns).List(meta_v1.ListOptions{})
 }
 
-type CreateOrReviseServiceOptions struct {
+type CreateOrUpdateServiceOptions struct {
 	Namespace string
 	Name      string
 	Image     string
@@ -50,7 +50,7 @@ type CreateOrReviseServiceOptions struct {
 	Wait      bool
 }
 
-func (c *client) CreateService(options CreateOrReviseServiceOptions) (*v1alpha1.Service, error) {
+func (c *client) CreateService(options CreateOrUpdateServiceOptions) (*v1alpha1.Service, error) {
 	ns := c.explicitOrConfigNamespace(options.Namespace)
 
 	s, err := newService(options)
@@ -67,7 +67,7 @@ func (c *client) CreateService(options CreateOrReviseServiceOptions) (*v1alpha1.
 
 }
 
-func (c *client) ReviseService(options CreateOrReviseServiceOptions) (*v1alpha1.Service, error) {
+func (c *client) UpdateService(options CreateOrUpdateServiceOptions) (*v1alpha1.Service, error) {
 	ns := c.explicitOrConfigNamespace(options.Namespace)
 
 	existingSvc, err := c.serving.ServingV1alpha1().Services(ns).Get(options.Name, meta_v1.GetOptions{})
@@ -101,7 +101,7 @@ func (c *client) ReviseService(options CreateOrReviseServiceOptions) (*v1alpha1.
 
 }
 
-func newService(options CreateOrReviseServiceOptions) (*v1alpha1.Service, error) {
+func newService(options CreateOrUpdateServiceOptions) (*v1alpha1.Service, error) {
 	envVars, err := ParseEnvVar(options.Env)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
rename `function build` to `function update`

Fixes #963 

rename `service revise` to `service update`

Fixes #966
