### PR TITLE
Add the ability to output subscriptions as a graphviz dot file.

### DIFF
--- a/docs/riff_subscription_list.md
+++ b/docs/riff_subscription_list.md
@@ -22,6 +22,7 @@ riff subscription list [flags]
 ```
   -h, --help               help for list
   -n, --namespace string   the namespace of the subscriptions
+  -o, --output string      the custom output format to use. Use 'dot' to output graphviz representation
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This is a small thing I hacked for demos and talks and could turn out quite useful.

Example with the canonical "hello 49" example:

```
riff subscription list -odot | dot -T png | open -f -a /Applications/Preview.app
```

which gives

![chain](https://user-images.githubusercontent.com/313494/49546325-3d52cf00-f8e0-11e8-80b2-9f7bac170807.png)
