### PR TITLE
Make unit tests pass on Windows

### DIFF
--- a/pkg/core/fixtures/manifest/absolutepath.windows.yaml
+++ b/pkg/core/fixtures/manifest/absolutepath.windows.yaml
@@ -1,0 +1,7 @@
+manifestVersion: 0.1
+istio:
+  - C:\x
+knative:
+  - y
+namespace:
+  - y

--- a/pkg/core/manifest.go
+++ b/pkg/core/manifest.go
@@ -99,6 +99,10 @@ func checkCompleteness(m Manifest) error {
 }
 
 func checkResource(resource string) error {
+	if filepath.IsAbs(resource) {
+		return fmt.Errorf("resources must use a http or https URL or a relative path: absolute path not supported: %s", resource)
+	}
+
 	u, err := url.Parse(resource)
 	if err != nil {
 		return err

--- a/pkg/core/manifest_test.go
+++ b/pkg/core/manifest_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectriff/riff/pkg/core"
+	"path/filepath"
+	"runtime"
 )
 
 var _ = Describe("Manifest", func() {
@@ -97,11 +99,16 @@ var _ = Describe("Manifest", func() {
 
 		Context("when the manifest contains a resource with an absolute path", func() {
 			BeforeEach(func() {
-				manifestPath = "./fixtures/manifest/absolutepath.yaml"
+				manifestPath = filepath.Join("fixtures", "manifest")
+				if runtime.GOOS == "windows" {
+					manifestPath = filepath.Join(manifestPath, "absolutepath.windows.yaml")
+				} else {
+					manifestPath = filepath.Join(manifestPath, "absolutepath.yaml")
+				}
 			})
 
 			It("should return a suitable error", func() {
-				Expect(err).To(MatchError("resources must use a http or https URL or a relative path: absolute path not supported: /x"))
+				Expect(err).To(MatchError(ContainSubstring("resources must use a http or https URL or a relative path: absolute path not supported: ")))
 			})
 		})
 

--- a/pkg/core/namespace_test.go
+++ b/pkg/core/namespace_test.go
@@ -66,7 +66,7 @@ var _ = Describe("The NamespaceInit function", func() {
 	It("should fail on wrong manifest", func() {
 		options := NamespaceInitOptions{Manifest: "wrong"}
 		err := kubectlClient.NamespaceInit(manifests, options)
-		Expect(err).To(MatchError(ContainSubstring("wrong: no such file")))
+		Expect(err).To(MatchError(ContainSubstring("wrong: "))) // error message is quite different on Windows and macOS
 	})
 
 	It("should create namespace and sa if needed", func() {

--- a/pkg/fileutils/dir.go
+++ b/pkg/fileutils/dir.go
@@ -24,6 +24,9 @@ import (
 
 // Dir returns the directory portion of the given file.
 func Dir(file string) (string, error) {
+	if filepath.IsAbs(file) {
+		return filepath.Dir(file), nil
+	}
 	u, err := url.Parse(file)
 	if err != nil {
 		return "", err

--- a/pkg/fileutils/dir_test.go
+++ b/pkg/fileutils/dir_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectriff/riff/pkg/fileutils"
+	"github.com/projectriff/riff/pkg/test_support"
+	"path/filepath"
 )
 
 var _ = Describe("Dir", func() {
@@ -44,14 +46,31 @@ var _ = Describe("Dir", func() {
 		})
 	})
 
-	Context("when file is a path", func() {
+	Context("when file is a relative path", func() {
 		BeforeEach(func() {
-			file = "/dir/file"
+			file = filepath.Join("dir", "file")
 		})
 
 		It("should return the directory of the file", func() {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(dir).To(Equal("/dir"))
+			Expect(dir).To(Equal("dir"))
+		})
+	})
+
+	Context("when file is an absolute path", func() {
+		var work string
+		BeforeEach(func() {
+			work = test_support.CreateTempDir()
+			file = filepath.Join(work, "file")
+		})
+
+		AfterEach(func() {
+			test_support.CleanupDirs(GinkgoT(), work)
+		})
+
+		It("should return the directory of the file", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dir).To(Equal(work))
 		})
 	})
 })

--- a/pkg/fileutils/read_test.go
+++ b/pkg/fileutils/read_test.go
@@ -139,5 +139,5 @@ var _ = Describe("Read", func() {
 func getwdAsURL() string {
 	cwd, err := os.Getwd()
 	Expect(err).NotTo(HaveOccurred())
-	return "file://" + filepath.ToSlash(cwd) // TODO: make this work on Windows
+	return "file:///" + filepath.ToSlash(cwd)
 }

--- a/pkg/test_support/file_operations.go
+++ b/pkg/test_support/file_operations.go
@@ -23,7 +23,7 @@ import (
 )
 
 func CreateTempDir() string {
-	tempDir, err := ioutil.TempDir("/tmp", "riff-test-")
+	tempDir, err := ioutil.TempDir("", "riff-test-")
 	check(err)
 	return tempDir
 }


### PR DESCRIPTION
* To disambiguate a string which could be either a file path or a URL,
  check for it being an absolute file path first in order to cope with
  Windows paths that look like URLs.

* Remove the leading slash of the path of a file URL on Windows when
  converting the URL into a file path. This is a known issue with Go.

* Skip symlink tests when symlinks cannot be created since, on some
  versions of Windows, creating symlinks needs administrator
  privileges.

* Tolerate behaviour when creating files on Windows: the permissions
  specified are not honoured.