### PR TITLE
Change the way builds are annotated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be // indirect
-	github.com/knative/build v0.3.0
+	github.com/knative/build v0.4.0
 	github.com/knative/eventing v0.4.0
 	github.com/knative/pkg v0.0.0-20190219005745-729d5ada5f62
 	github.com/knative/serving v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -236,7 +236,6 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -253,8 +252,8 @@ github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBv
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/knative/build v0.3.0 h1:WRWGzJZmFxBPjehIEcsa0pgsKE6j5BGuDqvFRJRQt8I=
-github.com/knative/build v0.3.0/go.mod h1:/sU74ZQkwlYA5FwYDJhYTy61i/Kn+5eWfln2jDbw3Qo=
+github.com/knative/build v0.4.0 h1:gutTiIVXeKsqv3f1ybhBL/qCPfNMcwPS9GI7u6rd2TI=
+github.com/knative/build v0.4.0/go.mod h1:/sU74ZQkwlYA5FwYDJhYTy61i/Kn+5eWfln2jDbw3Qo=
 github.com/knative/eventing v0.4.0 h1:UBckfuKiVnXi3FTOvli26huj2q1/pNIT/vRCWMIizeg=
 github.com/knative/eventing v0.4.0/go.mod h1:SkBc5JFsl70Fq/Bjc97+uix8759e4ho0imxq8DQm4DA=
 github.com/knative/pkg v0.0.0-20190219005745-729d5ada5f62 h1:ggNd88p7Sx7yjIqmltRJD1RXPaxYpIWn6QuMyz/lrZc=

--- a/pkg/core/function_test.go
+++ b/pkg/core/function_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	build "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -244,7 +245,15 @@ var _ = Describe("Function", func() {
 				testService.Spec = v1alpha1.ServiceSpec{
 					RunLatest: &v1alpha1.RunLatestType{
 						Configuration: v1alpha1.ConfigurationSpec{
-							Build: &v1alpha1.RawExtension{}, // non-nil build === cluster-built
+							Build: &v1alpha1.RawExtension{ // non-nil build === cluster-built
+								Object: &build.Build{
+									TypeMeta: v1.TypeMeta{
+										APIVersion: "build.knative.dev/v1alpha1",
+										Kind: "Build",
+									},
+									Spec: build.BuildSpec{},
+								},
+							},
 							RevisionTemplate: v1alpha1.RevisionTemplateSpec{
 								ObjectMeta: v1.ObjectMeta{
 									Labels: map[string]string{"riff.projectriff.io/function": functionName},

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -90,7 +90,7 @@ func (c *client) UpdateService(options CreateOrUpdateServiceOptions) (*v1alpha1.
 	existingSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env = append(existingSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env, envVars...)
 	existingSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env = append(existingSvc.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Env, envVarsFrom...)
 
-	c.bumpNonceAnnotation(existingSvc)
+	c.bumpNonceAnnotationForRevision(existingSvc)
 
 	if !options.DryRun {
 		_, err := c.serving.ServingV1alpha1().Services(ns).Update(existingSvc)


### PR DESCRIPTION
- due to changes in Knative Serving we need to add a full Build as an Unstructured object

- we can then annotated the Build instead of the Revision to trigger a build

- this is necessary after the changes in https://github.com/knative/serving/pull/2402

Fixes #939 
