### PR TITLE
DNM: Allow configuration of image pull secret during namespace init

### DIFF
--- a/cmd/commands/namespace.go
+++ b/cmd/commands/namespace.go
@@ -75,6 +75,7 @@ func NamespaceInit(manifests map[string]*core.Manifest, kc *core.KubectlClient) 
 	command.Flags().StringVarP(&options.SecretName, "secret", "s", "push-credentials", "the name of a `secret` containing credentials for the image registry")
 	command.Flags().StringVar(&options.GcrTokenPath, "gcr", "", "path to a file containing Google Container Registry credentials")
 	command.Flags().StringVar(&options.DockerHubUsername, "dockerhub", "", "dockerhub username for authentication; password will be read from stdin")
+	command.Flags().StringVar(&options.ImagePullSecretName, "image-pull-secret", "", "image pull secret name for the namespace default service account; this secret is used by Knative serving to pull images from private registries and serve them")
 
 	return command
 }

--- a/docs/riff_namespace_init.md
+++ b/docs/riff_namespace_init.md
@@ -19,12 +19,13 @@ riff namespace init [flags]
 ### Options
 
 ```
-      --dockerhub string   dockerhub username for authentication; password will be read from stdin
-      --gcr string         path to a file containing Google Container Registry credentials
-  -h, --help               help for init
-  -m, --manifest string    manifest of YAML files to be applied; can be a named manifest (stable or latest) or a path or URL of a manifest file (default "stable")
-      --no-secret          no secret required for the image registry
-  -s, --secret secret      the name of a secret containing credentials for the image registry (default "push-credentials")
+      --dockerhub string           dockerhub username for authentication; password will be read from stdin
+      --gcr string                 path to a file containing Google Container Registry credentials
+  -h, --help                       help for init
+      --image-pull-secret string   image pull secret name for the namespace default service account; this secret is used by Knative serving to pull images from private registries and serve them
+  -m, --manifest string            manifest of YAML files to be applied; can be a named manifest (stable or latest) or a path or URL of a manifest file (default "stable")
+      --no-secret                  no secret required for the image registry
+  -s, --secret secret              the name of a secret containing credentials for the image registry (default "push-credentials")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This will allow users to run functions from private registries.
See https://github.com/pivotal-cf/pfs/issues/159.