### PR TITLE
Fold log output for FATS

### DIFF
--- a/.travis/fats-channels.sh
+++ b/.travis/fats-channels.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # TODO make FATS channel tests modular enough to use here
+
+travis_fold start eventing
+echo "Eventing"
+
 test_name=echo
 
 kail --ns $NAMESPACE > $test_name.logs &
@@ -44,3 +48,5 @@ if [[ "$actual_data" != "$expected_data" ]]; then
   echo "   actual data: $actual_data"
   exit 1
 fi
+
+travis_fold end eventing

--- a/.travis/fats-cleanup.sh
+++ b/.travis/fats-cleanup.sh
@@ -2,9 +2,30 @@
 
 set -o nounset
 
+# duplicated since it may not be available via fats
+travis_fold() {
+  local action=$1
+  local name=$2
+  echo -en "travis_fold:${action}:${name}\r\033[0K"
+}
+
 fats_dir=`dirname "${BASH_SOURCE[0]}"`/fats
+
+# script failed, dump debug info
+if [ "$TRAVIS_TEST_RESULT" = "1" ]; then
+  travis_fold start debug
+  sudo free -m -t
+  sudo dmesg
+  travis_fold end debug
+fi
 
 # attempt to cleanup fats
 if [ -d "$fats_dir" ]; then
+  travis_fold start system-uninstall
+  echo "Uninstall riff system"
+  riff system uninstall --istio --force || true
+  kubectl delete namespace $NAMESPACE || true
+  travis_fold end system-uninstall
+
   source $fats_dir/cleanup.sh
 fi

--- a/.travis/fats-fetch.sh
+++ b/.travis/fats-fetch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 dir=${1}
-refspec=${2:-56d697a83ac1134af58f779d8c889a961a637ad5} # projectriff/fats master as of 2018-12-17
+refspec=${2:-5b8a86b504df14acb9a03a964b8353ca4e1d8713} # projectriff/fats master as of 2018-12-20
 
 if [ ! -f $dir ]; then
   mkdir -p $dir


### PR DESCRIPTION
Also run `riff system uninstall` which we always should have been doing.