### PR TITLE
Require Go 1.11.4 or later

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ This is the best option if you want to modify the riff CLI.
 
 You need:
 
-* A working Go 1.11 environment
+* A working Go 1.11.4 (or later) environment
 
 === Get the main riff repo
 


### PR DESCRIPTION
Go changed its checksum algorithm recently and anyone building with 1.11.2 or
earlier will hit checksum mismatches.