### PR TITLE
Return an error instead of panicking

### DIFF
--- a/pkg/fileutils/read.go
+++ b/pkg/fileutils/read.go
@@ -49,7 +49,7 @@ func readAbsFile(file string) ([]byte, error) {
 	}
 
 	if !filepath.IsAbs(file) {
-		panic(fmt.Sprintf("readAbsFile called with relative file path: %s", file))
+		return nil, fmt.Errorf("absolute path expected instead of relative path: %s", file)
 	}
 
 	return ioutil.ReadFile(file)


### PR DESCRIPTION
A situation which currently panics is legitimate and so should be diagnosed using an error. For example under Git Bash on Windows:

riff namespace init ... --manifest file:///C:\somedir\manifest.yaml

currently results in:

panic: readAbsFile called with relative file path: C:somedirmanifest.yaml

because the backslashes are treated as Bash escape characters.

The diagnostics will now be:

Error: Error reading manifest file: absolute path expected instead of relative path: C:somedirmanifest.yaml

Fixes https://github.com/projectriff/riff/issues/1007