### PR TITLE
Add nightly manifest

### DIFF
--- a/docs/riff_namespace_init.md
+++ b/docs/riff_namespace_init.md
@@ -22,7 +22,7 @@ riff namespace init [flags]
       --dockerhub string   dockerhub username for authentication; password will be read from stdin
       --gcr string         path to a file containing Google Container Registry credentials
   -h, --help               help for init
-  -m, --manifest string    manifest of kubernetes configuration files to be applied; can be a named manifest (latest, stable) or a path of a manifest file (default "stable")
+  -m, --manifest string    manifest of kubernetes configuration files to be applied; can be a named manifest (latest, nightly, stable) or a path of a manifest file (default "stable")
       --no-secret          no secret required for the image registry
   -s, --secret secret      the name of a secret containing credentials for the image registry (default "push-credentials")
 ```

--- a/docs/riff_system_install.md
+++ b/docs/riff_system_install.md
@@ -31,7 +31,7 @@ riff system install [flags]
 ```
       --force             force the install of components without getting any prompts
   -h, --help              help for install
-  -m, --manifest string   manifest of kubernetes configuration files to be applied; can be a named manifest (latest, stable) or a path of a manifest file (default "stable")
+  -m, --manifest string   manifest of kubernetes configuration files to be applied; can be a named manifest (latest, nightly, stable) or a path of a manifest file (default "stable")
       --node-port         whether to use NodePort instead of LoadBalancer for ingress gateways
 ```
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,23 @@ var (
 	defaultRunImage = "packs/run"
 
 	manifests = map[string]*core.Manifest{
+		// validated, compatible versions of Knative. This manifest is not tested
+		"stable": {
+			ManifestVersion: "0.1",
+			Istio: []string{
+				"https://storage.googleapis.com/knative-releases/serving/previous/v0.2.3/istio.yaml",
+			},
+			Knative: []string{
+				"https://storage.googleapis.com/knative-releases/build/previous/v0.2.0/release.yaml",
+				"https://storage.googleapis.com/knative-releases/serving/previous/v0.2.3/serving.yaml",
+				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.2.1/eventing.yaml",
+				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.2.1/in-memory-channel.yaml",
+			},
+			Namespace: []string{
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate-0.1.0.yaml",
+			},
+		},
+		// most recent release of Knative. This manifest is not tested
 		"latest": {
 			ManifestVersion: "0.1",
 			Istio: []string{
@@ -45,19 +62,20 @@ var (
 				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml",
 			},
 		},
-		"stable": {
+		// most recent build of Knative from master
+		"nightly": {
 			ManifestVersion: "0.1",
 			Istio: []string{
-				"https://storage.googleapis.com/knative-releases/serving/previous/v0.2.3/istio.yaml",
+				"https://storage.googleapis.com/knative-nightly/serving/latest/istio.yaml",
 			},
 			Knative: []string{
-				"https://storage.googleapis.com/knative-releases/build/previous/v0.2.0/release.yaml",
-				"https://storage.googleapis.com/knative-releases/serving/previous/v0.2.3/serving.yaml",
-				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.2.1/eventing.yaml",
-				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.2.1/in-memory-channel.yaml",
+				"https://storage.googleapis.com/knative-nightly/build/latest/release.yaml",
+				"https://storage.googleapis.com/knative-nightly/serving/latest/serving.yaml",
+				"https://storage.googleapis.com/knative-nightly/eventing/latest/eventing.yaml",
+				"https://storage.googleapis.com/knative-nightly/eventing/latest/in-memory-channel.yaml",
 			},
 			Namespace: []string{
-				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate-0.1.0.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml",
 			},
 		},
 	}


### PR DESCRIPTION
There are three built-in manifests:

- nightly: nightly knative builds from master
- latest: most recent knative release
- stable: blessed and tested knative releases