### PR TITLE
Make --cluster-provisioner optional for create channel

### DIFF
--- a/.travis/fats-channels.sh
+++ b/.travis/fats-channels.sh
@@ -16,7 +16,7 @@ kail_controller_pid=$!
 riff service create correlator --image projectriff/correlator:fats-20181214 --namespace $NAMESPACE
 wait_kservice_ready correlator $NAMESPACE
 
-riff channel create $test_name --cluster-provisioner in-memory-channel --namespace $NAMESPACE
+riff channel create $test_name --namespace $NAMESPACE
 riff subscription create $test_name --channel $test_name --subscriber correlator --namespace $NAMESPACE
 
 wait_channel_ready $test_name $NAMESPACE

--- a/cmd/commands/channel.go
+++ b/cmd/commands/channel.go
@@ -48,8 +48,6 @@ const (
 	channelDeleteNumberOfArgs
 )
 
-var exactlyOneProvisioner = ExactlyOneOf("cluster-provisioner")
-
 func ChannelCreate(fcTool *core.Client) *cobra.Command {
 	options := core.CreateChannelOptions{}
 
@@ -60,8 +58,7 @@ func ChannelCreate(fcTool *core.Client) *cobra.Command {
 			cobra.ExactArgs(channelCreateNumberOfArgs),
 			AtPosition(channelCreateNameIndex, ValidName())),
 		Example: `  ` + env.Cli.Name + ` channel create tweets --cluster-provisioner kafka --namespace steve-ns
-  ` + env.Cli.Name + ` channel create orders --cluster-provisioner global-rabbit`,
-		PreRunE: FlagsValidatorAsCobraRunE(exactlyOneProvisioner),
+  ` + env.Cli.Name + ` channel create orders`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			channelName := args[channelCreateNameIndex]
 			options.Name = channelName
@@ -86,7 +83,7 @@ func ChannelCreate(fcTool *core.Client) *cobra.Command {
 
 	LabelArgs(command, "CHANNEL_NAME")
 
-	command.Flags().StringVar(&options.ClusterChannelProvisioner, "cluster-provisioner", "", "the `name` of the cluster channel provisioner to provision the channel with.")
+	command.Flags().StringVar(&options.ClusterChannelProvisioner, "cluster-provisioner", "", "the `name` of the cluster channel provisioner to provision the channel with. Uses the cluster's default provisioner if not specified.")
 	command.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the `namespace` of the channel")
 
 	command.Flags().BoolVar(&options.DryRun, "dry-run", false, dryRunUsage)

--- a/cmd/commands/channel_test.go
+++ b/cmd/commands/channel_test.go
@@ -55,11 +55,6 @@ var _ = Describe("The riff channel create command", func() {
 			err := cc.Execute()
 			Expect(err).To(MatchError(ContainSubstring("must start and end with an alphanumeric character")))
 		})
-		It("should fail without required flags", func() {
-			cc.SetArgs([]string{"my-channel"})
-			err := cc.Execute()
-			Expect(err).To(MatchError("at least one of --cluster-provisioner must be set"))
-		})
 	})
 
 	Context("when given suitable args and flags", func() {
@@ -77,6 +72,17 @@ var _ = Describe("The riff channel create command", func() {
 		AfterEach(func() {
 			asMock.AssertExpectations(GinkgoT())
 
+		})
+		It("should involve the core.Client with no flags", func() {
+			cc.SetArgs([]string{"my-channel"})
+
+			o := core.CreateChannelOptions{
+				Name: "my-channel",
+			}
+
+			asMock.On("CreateChannel", o).Return(nil, nil)
+			err := cc.Execute()
+			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should involve the core.Client", func() {
 			cc.SetArgs([]string{"my-channel", "--cluster-provisioner", "ccp", "--namespace", "ns"})

--- a/docs/riff_channel_create.md
+++ b/docs/riff_channel_create.md
@@ -14,13 +14,13 @@ riff channel create [flags]
 
 ```
   riff channel create tweets --cluster-provisioner kafka --namespace steve-ns
-  riff channel create orders --cluster-provisioner global-rabbit
+  riff channel create orders
 ```
 
 ### Options
 
 ```
-      --cluster-provisioner name   the name of the cluster channel provisioner to provision the channel with.
+      --cluster-provisioner name   the name of the cluster channel provisioner to provision the channel with. Uses the cluster's default provisioner if not specified.
       --dry-run                    don't create resources but print yaml representation on stdout
   -h, --help                       help for create
   -n, --namespace namespace        the namespace of the channel

--- a/pkg/core/channel.go
+++ b/pkg/core/channel.go
@@ -49,11 +49,7 @@ func (c *client) CreateChannel(options CreateChannelOptions) (*v1alpha1.Channel,
 			Name: options.Name,
 		},
 		Spec: v1alpha1.ChannelSpec{
-			Provisioner: &corev1.ObjectReference{
-				APIVersion: "eventing.knative.dev/v1alpha1",
-				Kind:       "ClusterChannelProvisioner",
-				Name:       options.ClusterChannelProvisioner,
-			},
+			Provisioner: makeProvisioner(options),
 		},
 	}
 
@@ -62,6 +58,17 @@ func (c *client) CreateChannel(options CreateChannelOptions) (*v1alpha1.Channel,
 		return &channel, err
 	} else {
 		return &channel, nil
+	}
+}
+
+func makeProvisioner(options CreateChannelOptions) *corev1.ObjectReference {
+	if options.ClusterChannelProvisioner == "" {
+		return nil
+	}
+	return &corev1.ObjectReference{
+		APIVersion: "eventing.knative.dev/v1alpha1",
+		Kind:       "ClusterChannelProvisioner",
+		Name:       options.ClusterChannelProvisioner,
 	}
 }
 


### PR DESCRIPTION
The cluster will automatically assign a new channel to the default
cluster channel provisioner. This means that we don't need to force the
user to specify the provisioner when creating a channel.