### PR TITLE
Ignore credentials file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ debug
 ### Coverage artefacts ###
 *.coverprofile
 
+### Credentials
+gcr-storage-admin.json
+
 .DS_Store
 
 /riff


### PR DESCRIPTION
This file is created when following the getting started docs and should not be
checked in.