### PR TITLE
For in-cluster builds, use RUN_IMAGE from build template

### DIFF
--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -168,10 +168,6 @@ func (c *client) makeBuildArguments(options CreateFunctionOptions) []build.Argum
 		// TODO configure buildtemplate based on buildpack image
 		// {Name: "TBD", Value: options.BuildpackImage},
 	}
-	if options.RunImage != "" {
-		// don't overwrite the default with an empty value
-		args = append(args, build.ArgumentSpec{Name: "RUN_IMAGE", Value: options.RunImage})
-	}
 	return args
 }
 


### PR DESCRIPTION
... rather than hard-coded default

Fixes https://github.com/projectriff/riff/issues/1081