### PR TITLE
Use a cluster BuildTemplate

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ var (
 				"https://storage.googleapis.com/knative-releases/serving/latest/serving.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/latest/eventing.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/latest/in-memory-channel.yaml",
-				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate.yaml"
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate.yaml",
 			},
 			Namespace: []string{
 				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-cache.yaml",

--- a/main.go
+++ b/main.go
@@ -27,12 +27,12 @@ import (
 
 var (
 	// TODO update to a release version before releasing riff
-	builderVersion  = "0.2.0-snapshot"
+	builderVersion  = "0.2.0-snapshot-ci-8ee79f9144fc"
 	builder         = fmt.Sprintf("projectriff/builder:%s", builderVersion)
 	defaultRunImage = "packs/run:v3alpha2"
 
 	manifests = map[string]*core.Manifest{
-		// validated, compatible versions of Knative. This manifest is not tested
+		// validated, compatible versions of Knative
 		"stable": {
 			ManifestVersion: "0.1",
 			Istio: []string{
@@ -66,7 +66,7 @@ var (
 				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-cache.yaml",
 			},
 		},
-		// most recent build of Knative from master
+		// most recent build of Knative from master. This manifest is not tested
 		"nightly": {
 			ManifestVersion: "0.1",
 			Istio: []string{

--- a/main.go
+++ b/main.go
@@ -26,7 +26,9 @@ import (
 )
 
 var (
-	builder         = "projectriff/builder:0.2.0-snapshot-ci-f2315fde2cae"
+	// TODO update to a release version before releasing riff
+	builderVersion  = "0.2.0-snapshot"
+	builder         = fmt.Sprintf("projectriff/builder:%s", builderVersion)
 	defaultRunImage = "packs/run:v3alpha2"
 
 	manifests = map[string]*core.Manifest{
@@ -41,9 +43,10 @@ var (
 				"https://storage.googleapis.com/knative-releases/serving/previous/v0.2.3/serving.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.2.1/eventing.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.2.1/in-memory-channel.yaml",
+				fmt.Sprintf("https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate-%s.yaml", builderVersion),
 			},
 			Namespace: []string{
-				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate-0.2.0-snapshot-ci-f2315fde2cae.yaml",
+				fmt.Sprintf("https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-cache-%s.yaml", builderVersion),
 			},
 		},
 		// most recent release of Knative. This manifest is not tested
@@ -57,9 +60,10 @@ var (
 				"https://storage.googleapis.com/knative-releases/serving/latest/serving.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/latest/eventing.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/latest/in-memory-channel.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate.yaml"
 			},
 			Namespace: []string{
-				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-cache.yaml",
 			},
 		},
 		// most recent build of Knative from master
@@ -73,9 +77,10 @@ var (
 				"https://storage.googleapis.com/knative-nightly/serving/latest/serving.yaml",
 				"https://storage.googleapis.com/knative-nightly/eventing/latest/eventing.yaml",
 				"https://storage.googleapis.com/knative-nightly/eventing/latest/in-memory-channel.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate.yaml",
 			},
 			Namespace: []string{
-				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-buildtemplate.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-cache.yaml",
 			},
 		},
 	}

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -38,7 +38,7 @@ import (
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/projectriff/riff/pkg/env"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -122,6 +122,7 @@ func (c *client) CreateFunction(buildpackBuilder Builder, options CreateFunction
 				Source:             c.makeBuildSourceSpec(options),
 				Template: &build.TemplateInstantiationSpec{
 					Name:      "riff-cnb",
+					Kind:      "ClusterBuildTemplate",
 					Arguments: c.makeBuildArguments(options),
 				},
 			},


### PR DESCRIPTION
A ClusterBuildTemplate has the advantage of being defined once in the
cluster and can be updated and maintained with the rest of riff.

The cache PVC has moved into a separate resource as it and a service
account are still required in each namespace in order to run builds.

Fixes #968