### PR TITLE
Use the latest golang 1.11 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- '1.11.4'
+- '1.11.x'
 cache:
   directories:
   - $GOPATH/pkg/mod


### PR DESCRIPTION
Travis now uses a version of go that correctly handles module hashes.