### PR TITLE
Disable go modules when installing mockery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
   - stage: test
     install:
-    - "go get -u github.com/vektra/mockery/.../"
+    - "(cd ~ && go get -u github.com/vektra/mockery/.../)"
     before_script: make gen-mocks && test $(git status --porcelain | wc -l) -eq 0 || exit 1
     script: make build test verify-docs
   - &test-windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
   - stage: test
     install:
-    - "(cd ~ && go get -u github.com/vektra/mockery/.../)"
+    - "GO111MODULE=off go get -u github.com/vektra/mockery/.../"
     before_script: make gen-mocks && test $(git status --porcelain | wc -l) -eq 0 || exit 1
     script: make build test verify-docs
   - &test-windows
@@ -22,7 +22,7 @@ matrix:
     os: windows # Git Bash
     install:
     - "choco install make"
-    - "go get -u github.com/vektra/mockery/.../"
+    - "GO111MODULE=off go get -u github.com/vektra/mockery/.../"
     before_script: make gen-mocks && test $(git status --porcelain | wc -l) -eq 0 || exit 1
     script: make build test verify-docs
   - stage: fats-lite


### PR DESCRIPTION
This afternoon, [Travis started](https://changelog.travis-ci.com/go-modules-support-added-for-go-1-11-and-up-88993) to set `GO111MODULES=on` for projects with golang 1.11 and a `go.mod` file. This causes mockery to fail to install. We can get mockery installing again, by turning modules back off for that command.