### PR TITLE
[DNM?] Ensure riff service invoke always prints any HTTP error

### DIFF
--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -17,9 +17,13 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"regexp"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -281,8 +285,16 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 				curlCmd.Args = append(curlCmd.Args, "-H", "Content-Type: text/plain")
 			}
 
+			verbose := false
+
 			if argsLengthAtDash > 0 {
-				curlCmd.Args = append(curlCmd.Args, args[argsLengthAtDash:]...)
+				curlArgs := args[argsLengthAtDash:]
+				for _, a := range curlArgs {
+					if verboseCurl(a) {
+						verbose = true
+					}
+				}
+				curlCmd.Args = append(curlCmd.Args, curlArgs...)
 			}
 
 			quoted, err := shellquote.Quote(curlCmd.Args)
@@ -291,7 +303,22 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), quoted)
 
-			return curlCmd.Run()
+			if verbose {
+				return curlCmd.Run()
+			}
+
+			// curl is not verbose, so make it verbose, capture standard error, and print any HTTP errors
+			curlCmd.Args = append(curlCmd.Args, "-v")
+
+			buffer := new(bytes.Buffer)
+			errStream := curlCmd.Stderr
+			curlCmd.Stderr = buffer
+
+			curlErr := curlCmd.Run()
+
+			PrintCurlHttpErrors(buffer.String(), errStream)
+
+			return curlErr
 		},
 	}
 
@@ -302,6 +329,33 @@ Additional curl arguments and flags may be specified after a double dash (--).`,
 	command.Flags().BoolVar(&serviceInvokeOptions.ContentTypeText, "text", false, "set the request's content type to 'text/plain'")
 
 	return command
+}
+
+// Print any HTTP errors in the given string to the given writer
+func PrintCurlHttpErrors(curlErrOutput string, w io.Writer) {
+	matched, err := regexp.MatchString("< HTTP/[\\d\\.]* 200", curlErrOutput)
+	if err != nil {
+		panic(err) // Should never happen unless the regex is invalid
+	}
+
+	if !matched {
+		for _, line := range strings.Split(curlErrOutput, "\n") {
+			matched, err := regexp.MatchString("< HTTP/[\\d\\.]* ", line)
+			if err != nil {
+				panic(err) // Should never happen unless the regex is invalid
+			}
+
+			if matched {
+				fmt.Fprintf(w, "%s\n", line)
+			}
+		}
+	}
+}
+
+func verboseCurl(curlArg string) bool {
+	return curlArg == "-v" || curlArg == "--verbose" ||
+		// short flags can be used next to each other, e.g. -Lv
+		(strings.HasPrefix(curlArg, "-") && !strings.HasPrefix(curlArg, "--") && strings.Contains(curlArg, "v"))
 }
 
 func ServiceDelete(riffClient *core.Client) *cobra.Command {


### PR DESCRIPTION
This has only been tested on macOS, but it should be tested on Windows too, so please do not merge 
_unless_ you have tested on Windows. To provoke a 404, hack `service.go` thus:
```
hostHeader := fmt.Sprintf("Host: %s", hostName+"x")
```
(I can do this next week - I left my Windows VM at home!)

The curl flags -sS are supposed to suppress output, but print any errors. This
would be the ideal solution here. Unfortunately, this doesn't appear to work
(at least with curl 7.54.0 on macOS).

Fixes https://github.com/projectriff/riff/issues/982