### PR TITLE
[DNM] Update to latest release artifacts for serving and build

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,15 +36,17 @@ var (
 		"stable": {
 			ManifestVersion: "0.1",
 			Istio: []string{
-				"https://storage.googleapis.com/knative-releases/serving/previous/v0.3.0/istio.yaml",
-				"https://storage.googleapis.com/projectriff/istio/istio-riff-knative-serving-v0-3-0-patch.yaml",
+				"https://storage.googleapis.com/knative-releases/serving/previous/v0.4.0/istio.yaml",
 			},
 			Knative: []string{
-				// NOTE: build should be in the knative-releases bucket, but is hiding in knative-nightly
-				"https://storage.googleapis.com/knative-nightly/build/previous/v0.3.0/release.yaml",
-				"https://storage.googleapis.com/knative-releases/serving/previous/v0.3.0/serving.yaml",
-				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.3.0/eventing.yaml",
-				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.3.0/in-memory-channel.yaml",
+				// NOTE: build release 0.4.0 is currently broken, using nightly instead
+				// https://github.com/knative/build/issues/566
+				"https://storage.googleapis.com/knative-nightly/build/latest/build.yaml",
+				// ToDo: update the following with a published file when available
+				"https://raw.githubusercontent.com/knative/serving/release-0.4/third_party/config/build/clusterrole.yaml",
+				"https://storage.googleapis.com/knative-releases/serving/previous/v0.4.0/serving.yaml",
+				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.4.0/eventing.yaml",
+				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.4.0/in-memory-channel.yaml",
 				fmt.Sprintf("https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate-%s.yaml", builderVersion),
 			},
 			Namespace: []string{
@@ -58,7 +60,11 @@ var (
 				"https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml",
 			},
 			Knative: []string{
-				"https://storage.googleapis.com/knative-releases/build/latest/release.yaml",
+				// NOTE: build release 0.4.0 is currently broken, using nightly instead
+				// https://github.com/knative/build/issues/566
+				"https://storage.googleapis.com/knative-nightly/build/latest/build.yaml",
+				// ToDo: update the following with a published file when available
+				"https://raw.githubusercontent.com/knative/serving/release-0.4/third_party/config/build/clusterrole.yaml",
 				"https://storage.googleapis.com/knative-releases/serving/latest/serving.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/latest/eventing.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/latest/in-memory-channel.yaml",

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ var (
 				"https://storage.googleapis.com/knative-nightly/serving/latest/istio.yaml",
 			},
 			Knative: []string{
-				"https://storage.googleapis.com/knative-nightly/build/latest/release.yaml",
+				"https://storage.googleapis.com/knative-nightly/build/latest/build.yaml",
 				"https://storage.googleapis.com/knative-nightly/serving/latest/serving.yaml",
 				"https://storage.googleapis.com/knative-nightly/eventing/latest/eventing.yaml",
 				"https://storage.googleapis.com/knative-nightly/eventing/latest/in-memory-channel.yaml",

--- a/main.go
+++ b/main.go
@@ -76,6 +76,8 @@ var (
 			},
 			Knative: []string{
 				"https://storage.googleapis.com/knative-nightly/build/latest/build.yaml",
+				//ToDo: update the following with a published file when available
+				"https://raw.githubusercontent.com/knative/serving/master/third_party/config/build/clusterrole.yaml",
 				"https://storage.googleapis.com/knative-nightly/serving/latest/serving.yaml",
 				"https://storage.googleapis.com/knative-nightly/eventing/latest/eventing.yaml",
 				"https://storage.googleapis.com/knative-nightly/eventing/latest/in-memory-channel.yaml",


### PR DESCRIPTION
- looks like release file for build was renamed from `release.yaml` to `build.yaml`

Fixes #1109 

once all issues are resolved