### PR TITLE
Improve system uninstall

### DIFF
--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -374,15 +374,15 @@ func deleteClusterResources(kc *kubectlClient, resourceType string, prefix strin
 
 func deleteKnativeServices(kc *kubectlClient) error {
 	fmt.Printf("Deleting Knative Services\n")
-	err := deleteAllKnative(kc, "service.serving")
+	err := deleteAllKnative(kc, "service.serving.knative.dev")
 	if err != nil {
 		return err
 	}
-	err = deleteAllKnative(kc, "configuration.serving")
+	err = deleteAllKnative(kc, "configuration.serving.knative.dev")
 	if err != nil {
 		return err
 	}
-	err = deleteAllKnative(kc, "route.serving")
+	err = deleteAllKnative(kc, "route.serving.knative.dev")
 	if err != nil {
 		return err
 	}

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -197,6 +197,10 @@ func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) (bool, 
 				return false, nil
 			}
 		}
+		err = deleteKnativeServices(kc)
+		if err != nil {
+			return false, err
+		}
 		fmt.Print("Removing Knative for " + env.Cli.Name + " components\n")
 		err = deleteCrds(kc, "knative.dev")
 		if err != nil {
@@ -266,8 +270,6 @@ func (kc *kubectlClient) SystemUninstall(options SystemUninstallOptions) (bool, 
 		if err != nil {
 			return false, err
 		}
-		// TODO: remove this once https://github.com/knative/serving/issues/2018 is resolved
-		deleteSingleResource(kc, "horizontalpodautoscaler.autoscaling", "istio-pilot", "")
 	}
 	return true, nil
 }
@@ -370,9 +372,45 @@ func deleteClusterResources(kc *kubectlClient, resourceType string, prefix strin
 	return nil
 }
 
+func deleteKnativeServices(kc *kubectlClient) error {
+	fmt.Printf("Deleting Knative Services\n")
+	err := deleteAllKnative(kc, "service.serving")
+	if err != nil {
+		return err
+	}
+	err = deleteAllKnative(kc, "configuration.serving")
+	if err != nil {
+		return err
+	}
+	err = deleteAllKnative(kc, "route.serving")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteAllKnative(kc *kubectlClient, resourceType string) error {
+	resourceList, err := kc.kubeCtl.Exec([]string{"get", resourceType, "--all-namespaces", "-ocustom-columns=ns:metadata.namespace,name:metadata.name", "--no-headers=true"})
+	if err != nil {
+		return err
+	}
+	resources := strings.Split(string(resourceList), "\n")
+	for _, resource := range resources {
+		if (len(resource) > 0) {
+			args := strings.Fields(resource)
+			delLog, err := kc.kubeCtl.Exec(append([]string{"delete", "-n", args[0], resourceType}, args[1]))
+			fmt.Printf("In namespace \"%s\" %s", args[0], delLog)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func deleteCrds(kc *kubectlClient, suffix string) error {
 	fmt.Printf("Deleting CRDs for %s\n", suffix)
-	crdList, err := kc.kubeCtl.Exec([]string{"get", "customresourcedefinitions", "-ocustom-columns=name:metadata.name"})
+	crdList, err := kc.kubeCtl.Exec([]string{"get", "customresourcedefinitions","-ocustom-columns=name:metadata.name", "--no-headers=true"})
 	if err != nil {
 		return err
 	}

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -412,8 +412,8 @@ func deleteAllKnative(kc *kubectlClient, resourceType string) error {
 
 func deleteCrds(kc *kubectlClient, suffix string) error {
 	fmt.Printf("Deleting CRDs for %s\n", suffix)
-	crdList, err := kc.kubeCtl.Exec([]string{"get", "customresourcedefinitions","-ocustom-columns=name:metadata.name", "--no-headers=true"})
-	if err == nil {
+	crdList, err := kc.kubeCtl.Exec([]string{"get", "customresourcedefinitions", "-ocustom-columns=name:metadata.name", "--no-headers=true"})
+	if err != nil {
 		return err
 	}
 	crds := strings.Split(string(crdList), "\n")

--- a/pkg/core/system.go
+++ b/pkg/core/system.go
@@ -392,16 +392,18 @@ func deleteKnativeServices(kc *kubectlClient) error {
 func deleteAllKnative(kc *kubectlClient, resourceType string) error {
 	resourceList, err := kc.kubeCtl.Exec([]string{"get", resourceType, "--all-namespaces", "-ocustom-columns=ns:metadata.namespace,name:metadata.name", "--no-headers=true"})
 	if err != nil {
-		return err
-	}
-	resources := strings.Split(string(resourceList), "\n")
-	for _, resource := range resources {
-		if (len(resource) > 0) {
-			args := strings.Fields(resource)
-			delLog, err := kc.kubeCtl.Exec(append([]string{"delete", "-n", args[0], resourceType}, args[1]))
-			fmt.Printf("In namespace \"%s\" %s", args[0], delLog)
-			if err != nil {
-				return err
+		fmt.Printf("Error while getting %s in all namespaces: %v\n", resourceType, err)
+		fmt.Printf("The system seems to be in an unstable state!\n")
+	} else {
+		resources := strings.Split(string(resourceList), "\n")
+		for _, resource := range resources {
+			if (len(resource) > 0) {
+				args := strings.Fields(resource)
+				delLog, err := kc.kubeCtl.Exec(append([]string{"delete", "-n", args[0], resourceType}, args[1]))
+				fmt.Printf("In namespace \"%s\" %s", args[0], delLog)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -411,7 +413,7 @@ func deleteAllKnative(kc *kubectlClient, resourceType string) error {
 func deleteCrds(kc *kubectlClient, suffix string) error {
 	fmt.Printf("Deleting CRDs for %s\n", suffix)
 	crdList, err := kc.kubeCtl.Exec([]string{"get", "customresourcedefinitions","-ocustom-columns=name:metadata.name", "--no-headers=true"})
-	if err != nil {
+	if err == nil {
 		return err
 	}
 	crds := strings.Split(string(crdList), "\n")


### PR DESCRIPTION
- Delete any Knative services, configurations and routes to avoid blocking issues when CRDs are deleted with existing Knative resources

- no longer necessary to delete "horizontalpodautoscaler.autoscaling" resource for istio-pilot

Fixes #1110 