### PR TITLE
Consume decomposed function buildpack builder

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// TODO update to a release version before releasing riff
-	builderVersion  = "0.2.0-snapshot-ci-63cd05079e1f"
+	builderVersion  = "0.2.0-snapshot-ci-912b954091ca"
 	builder         = fmt.Sprintf("projectriff/builder:%s", builderVersion)
 	defaultRunImage = "packs/run:v3alpha2"
 


### PR DESCRIPTION
There should be no change in functionality, this is a refactoring of
riff-buildpack to decompose into individual function buildpacks.

Refs #1093