### PR TITLE
Provide a cache volume for builds

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// TODO update to a release version before releasing riff
-	builderVersion  = "0.2.0-snapshot-ci-1aa01f4f464c"
+	builderVersion  = "0.2.0-snapshot-ci-a974b8e885d3"
 	builder         = fmt.Sprintf("projectriff/builder:%s", builderVersion)
 	defaultRunImage = "packs/run:v3alpha2"
 

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -38,7 +38,7 @@ import (
 	"github.com/projectriff/riff/pkg/env"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -149,7 +149,15 @@ func (c *client) CreateFunction(buildpackBuilder Builder, options CreateFunction
 							{Name: "FUNCTION_ARTIFACT", Value: options.Artifact},
 							{Name: "FUNCTION_HANDLER", Value: options.Handler},
 							{Name: "FUNCTION_LANGUAGE", Value: options.Invoker},
-							{Name: "CACHE_VOLUME", Value: buildCache.Name},
+							{Name: "CACHE", Value: "cache"},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "cache",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: buildCache.Name},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
The build template now defaults the cache to an empty dir, individual
builds may define their own volume and define the CACHE argument to use
that volume.

This behavior makes the build template more useable, since it no longer
requires as PVC, and preserves the current cache behavior.

Depends on https://github.com/projectriff/riff-buildpack-group/pull/36