### PR TITLE
Add option to prevent service from scaling to zero instances

### DIFF
--- a/cmd/commands/service.go
+++ b/cmd/commands/service.go
@@ -122,6 +122,8 @@ func ServiceCreate(fcTool *core.Client) *cobra.Command {
 	command.Flags().StringVar(&createServiceOptions.Image, "image", "", "the `name[:tag]` reference of an image containing the application/function")
 	command.MarkFlagRequired("image")
 
+	command.Flags().BoolVarP(&createServiceOptions.NoScaleToZero, "no-scale-to-zero", "", false, "the service should not scale to zero instances")
+
 	command.Flags().StringArrayVar(&createServiceOptions.Env, "env", []string{}, envUsage)
 	command.Flags().StringArrayVar(&createServiceOptions.EnvFrom, "env-from", []string{}, envFromUsage)
 

--- a/docs/riff_service_create.md
+++ b/docs/riff_service_create.md
@@ -33,6 +33,7 @@ riff service create [flags]
   -h, --help                   help for create
       --image name[:tag]       the name[:tag] reference of an image containing the application/function
   -n, --namespace namespace    the namespace of the service
+      --no-scale-to-zero       the service should not scale to zero instances
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/annotations.go
+++ b/pkg/core/annotations.go
@@ -19,10 +19,20 @@ package core
 import (
 	"strconv"
 
+	"github.com/knative/serving/pkg/apis/autoscaling"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/reconciler/v1alpha1/configuration/resources"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+func (c *client) addMinScaleAnnotationForRevision(s *v1alpha1.Service, minScale int) {
+	annotations := s.Spec.RunLatest.Configuration.RevisionTemplate.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(minScale)
+	s.Spec.RunLatest.Configuration.RevisionTemplate.SetAnnotations(annotations)
+}
 
 func (c *client) bumpBuildAnnotationForRevision(s *v1alpha1.Service) {
 	annotations := s.Spec.RunLatest.Configuration.RevisionTemplate.Annotations

--- a/pkg/core/service.go
+++ b/pkg/core/service.go
@@ -41,14 +41,15 @@ func (c *client) ListServices(options ListServiceOptions) (*v1alpha1.ServiceList
 }
 
 type CreateOrUpdateServiceOptions struct {
-	Namespace string
-	Name      string
-	Image     string
-	Env       []string
-	EnvFrom   []string
-	DryRun    bool
-	Verbose   bool
-	Wait      bool
+	Namespace     string
+	Name          string
+	Image         string
+	Env           []string
+	EnvFrom       []string
+	NoScaleToZero bool
+	DryRun        bool
+	Verbose       bool
+	Wait          bool
 }
 
 func (c *client) CreateService(options CreateOrUpdateServiceOptions) (*v1alpha1.Service, error) {
@@ -57,6 +58,10 @@ func (c *client) CreateService(options CreateOrUpdateServiceOptions) (*v1alpha1.
 	s, err := newService(options)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.NoScaleToZero {
+		c.addMinScaleAnnotationForRevision(s, 1)
 	}
 
 	if !options.DryRun {


### PR DESCRIPTION
- add `--no-scale-to-zero` flag for `service create`

- all revisions will keep running until service is deleted unless manually removed

Resolves #1136 