### PR TITLE
Allow builds from directories within git repos

### DIFF
--- a/cmd/commands/function.go
+++ b/cmd/commands/function.go
@@ -123,6 +123,7 @@ func FunctionCreate(buildpackBuilder core.Builder, fcTool *core.Client) *cobra.C
 	command.Flags().StringVar(&createFunctionOptions.Image, "image", "", "the name of the image to build; must be a writable `repository/image[:tag]` with credentials configured")
 	command.Flags().StringVar(&createFunctionOptions.GitRepo, "git-repo", "", "the `URL` for a git repository hosting the function code")
 	command.Flags().StringVar(&createFunctionOptions.GitRevision, "git-revision", "master", "the git `ref-spec` of the function code to use")
+	command.Flags().StringVar(&createFunctionOptions.SubPath, "sub-path", "", "the directory within the git repo to expose, files outside of this directory will not be available during the build")
 	command.Flags().StringVarP(&createFunctionOptions.LocalPath, "local-path", "l", "", "`path` to local source to build the image from; only build-pack builds are supported at this time")
 	command.Flags().BoolVarP(&createFunctionOptions.Verbose, "verbose", "v", false, verboseUsage)
 	command.Flags().BoolVarP(&createFunctionOptions.Wait, "wait", "w", false, waitUsage)

--- a/cmd/commands/function_test.go
+++ b/cmd/commands/function_test.go
@@ -110,11 +110,12 @@ var _ = Describe("The riff function create command", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should pass correct options from flags", func() {
-			fc.SetArgs([]string{"square", "--image", "foo/bar", "--git-repo", "https://github.com/repo", "--invoker", "pascal"})
+			fc.SetArgs([]string{"square", "--image", "foo/bar", "--git-repo", "https://github.com/repo", "--sub-path", "path/in/repo", "--invoker", "pascal"})
 
 			options := core.CreateFunctionOptions{
 				GitRepo:     "https://github.com/repo",
 				GitRevision: "master",
+				SubPath:     "path/in/repo",
 				BuildOptions: core.BuildOptions{
 					Invoker: "pascal",
 				},

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -44,6 +44,7 @@ riff function create [flags]
       --invoker language               invoker runtime to override language detected by buildpack
   -l, --local-path path                path to local source to build the image from; only build-pack builds are supported at this time
   -n, --namespace namespace            the namespace of the service
+      --sub-path string                the directory within the git repo to expose, files outside of this directory will not be available during the build
   -v, --verbose                        print details of command progress
   -w, --wait                           wait until the created resource reaches either a successful or an error state (automatic with --verbose)
 ```

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -68,6 +68,7 @@ type CreateFunctionOptions struct {
 
 	GitRepo     string
 	GitRevision string
+	SubPath     string
 }
 
 func (c *client) CreateFunction(buildpackBuilder Builder, options CreateFunctionOptions, log io.Writer) (*v1alpha1.Service, *corev1.PersistentVolumeClaim, error) {
@@ -228,6 +229,7 @@ func (c *client) makeBuildSourceSpec(options CreateFunctionOptions) *build.Sourc
 			Url:      options.GitRepo,
 			Revision: options.GitRevision,
 		},
+		SubPath: options.SubPath,
 	}
 }
 


### PR DESCRIPTION
Builds can now be triggered from directories nested in a git repo. This
means that a single repo can host multiple functions. Only files within
the path will exist at build time.

```
riff function create <name> --git-repo <repo> --sub-path path/within/repo
```

Fixes #1089