### PR TITLE
Merge --registry-host and --registry-protocol

### DIFF
--- a/cmd/commands/cobra.go
+++ b/cmd/commands/cobra.go
@@ -18,14 +18,12 @@ package commands
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
+	"io"
 	"strings"
-
+	"text/template"
 	"unicode"
 
-	"io"
-	"text/template"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -228,7 +226,7 @@ func AtMostOneOf(flagNames ...string) FlagsValidator {
 			}
 		}
 		if set > 1 {
-			return fmt.Errorf("at most one of --%s must be set", strings.Join(flagNames, ", --"))
+			return fmt.Errorf("at most one of --%s may be set", strings.Join(flagNames, ", --"))
 		} else {
 			return nil
 		}

--- a/cmd/commands/namespace.go
+++ b/cmd/commands/namespace.go
@@ -69,10 +69,7 @@ func NamespaceInit(manifests map[string]*core.Manifest, c *core.Client) *cobra.C
 				// NOTE this should be relaxed when we add support for bearer auth
 				FlagsDependency(Set("registry"), NotBlank("registry-user")),
 				FlagsDependency(Set("registry"), func(cmd *cobra.Command) error {
-					if parts := strings.SplitN(options.Registry, "://", 2); len(parts) == 1 {
-						// default to https
-						options.Registry = fmt.Sprintf("https://%s", options.Registry)
-					} else if parts[0] != "http" && parts[0] != "https" {
+					if parts := strings.SplitN(options.Registry, "://", 2); len(parts) == 2 && parts[0] != "http" && parts[0] != "https" {
 						return fmt.Errorf("valid protocols are: %q, %q, found: %q", "http", "https", parts[0])
 					}
 					return nil
@@ -80,8 +77,14 @@ func NamespaceInit(manifests map[string]*core.Manifest, c *core.Client) *cobra.C
 			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nsName := args[channelCreateNameIndex]
+			nsName := args[namespaceInitNameIndex]
 			options.NamespaceName = nsName
+
+			if options.Registry != "" && !strings.Contains(options.Registry, "://") {
+				// default to https
+				options.Registry = fmt.Sprintf("https://%s", options.Registry)
+			}
+
 			err := (*c).NamespaceInit(manifests, options)
 			if err != nil {
 				return err

--- a/cmd/commands/namespace_test.go
+++ b/cmd/commands/namespace_test.go
@@ -49,25 +49,29 @@ var _ = Describe("The riff namespace init command", func() {
 			Expect(err).To(MatchError(ContainSubstring("must start and end with an alphanumeric character")))
 		})
 
+		dockerHubArgs := []string{"--dockerhub", "projectriff"}
+		gcrArgs := []string{"--gcr", "/path/to/gcr.json"}
+		noSecretArgs := []string{"--no-secret"}
+		basicAuthArgs := []string{"--registry", "registry.example.com", "--registry-user", "beth"}
 		DescribeTable("fails with too many auth configuration modes",
 			func(modes ...[]string) {
 				namespaceInit.SetArgs(concat([]string{"ns", "--manifest", "some-path"}, concat(modes...)))
 
 				err := namespaceInit.Execute()
 
-				Expect(err).To(MatchError("at most one of --gcr, --dockerhub, --no-secret, --registry-host must be set"))
+				Expect(err).To(MatchError("at most one of --gcr, --dockerhub, --no-secret, --registry-user may be set"))
 			},
-			Entry("all modes					=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--gcr", "/path/to/gcr.json"}, []string{"--no-secret"}, []string{"--registry-host", "registry.example.com"}),
-			Entry("docker+grc+nosecret		=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--gcr", "/path/to/gcr.json"}, []string{"--no-secret"}),
-			Entry("docker+grc+registry		=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--gcr", "/path/to/gcr.json"}, []string{"--registry-host", "registry.example.com"}),
-			Entry("docker+grc				=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--gcr", "/path/to/gcr.json"}),
-			Entry("docker+nosecret+registry	=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--no-secret"}, []string{"--registry-host", "registry.example.com"}),
-			Entry("docker+nosecret			=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--no-secret"}),
-			Entry("docker+registry			=>", []string{"--dockerhub", "/path/to/.docker/config.json"}, []string{"--registry-host", "registry.example.com"}),
-			Entry("gcr+nosecret+registry		=>", []string{"--gcr", "/path/to/gcr.json"}, []string{"--no-secret"}, []string{"--registry-host", "registry.example.com"}),
-			Entry("gcr+nosecret 				=>", []string{"--gcr", "/path/to/gcr.json"}, []string{"--no-secret"}),
-			Entry("gcr+registry 				=>", []string{"--gcr", "/path/to/gcr.json"}, []string{"--registry-host", "registry.example.com"}),
-			Entry("nosecret+registry			=>", []string{"--no-secret"}, []string{"--registry-host", "registry.example.com"}),
+			Entry("all modes                =>", dockerHubArgs, gcrArgs, noSecretArgs, basicAuthArgs),
+			Entry("docker+grc+nosecret      =>", dockerHubArgs, gcrArgs, noSecretArgs),
+			Entry("docker+grc+registry      =>", dockerHubArgs, gcrArgs, basicAuthArgs),
+			Entry("docker+grc               =>", dockerHubArgs, gcrArgs),
+			Entry("docker+nosecret+registry =>", dockerHubArgs, noSecretArgs, basicAuthArgs),
+			Entry("docker+nosecret          =>", dockerHubArgs, noSecretArgs),
+			Entry("docker+registry          =>", dockerHubArgs, basicAuthArgs),
+			Entry("gcr+nosecret+registry    =>", gcrArgs, noSecretArgs, basicAuthArgs),
+			Entry("gcr+nosecret             =>", gcrArgs, noSecretArgs),
+			Entry("gcr+registry             =>", gcrArgs, basicAuthArgs),
+			Entry("nosecret+registry        =>", noSecretArgs, basicAuthArgs),
 		)
 
 		It("fails with ambiguous secret configuration", func() {
@@ -75,7 +79,7 @@ var _ = Describe("The riff namespace init command", func() {
 
 			err := namespaceInit.Execute()
 
-			Expect(err).To(MatchError("at most one of --secret, --no-secret must be set"))
+			Expect(err).To(MatchError("at most one of --secret, --no-secret may be set"))
 		})
 
 		It("fails with blank secret name", func() {
@@ -94,36 +98,29 @@ var _ = Describe("The riff namespace init command", func() {
 			Expect(err).To(MatchError("required flag(s) \"manifest\" not set"))
 		})
 
-		It("fails if the registry server is set but not the registry username", func() {
-			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry-host", "registry.example.com"})
+		It("fails if the registry is set but not the registry username", func() {
+			// NOTE: this should be relaxed when we add bearer auth support
+			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry", "registry.example.com"})
 
 			err := namespaceInit.Execute()
 
-			Expect(err).To(MatchError("when --registry-host is set, flag --registry-user cannot be empty"))
+			Expect(err).To(MatchError("when --registry is set, flag --registry-user cannot be empty"))
 		})
 
-		It("fails if the registry user is set but not the registry host", func() {
+		It("fails if the registry user is set but not the registry", func() {
 			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry-user", "me"})
 
 			err := namespaceInit.Execute()
 
-			Expect(err).To(MatchError("when --registry-user is set, flag --registry-host cannot be empty"))
-		})
-
-		It("fails if the registry protocol is set but not the registry host", func() {
-			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry-protocol", "http"})
-
-			err := namespaceInit.Execute()
-
-			Expect(err).To(MatchError("when --registry-protocol is set, flag --registry-host cannot be empty"))
+			Expect(err).To(MatchError("when --registry-user is set, flag --registry cannot be empty"))
 		})
 
 		It("fails if the registry protocol is not supported", func() {
-			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry-protocol", "ftp", "--registry-host", "registry.example.com", "--registry-user", "me"})
+			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry", "ftp://registry.example.com", "--registry-user", "me"})
 
 			err := namespaceInit.Execute()
 
-			Expect(err).To(MatchError(`when --registry-host is set, flag --registry-protocol cannot have value "ftp", valid values are: "https", "http"`))
+			Expect(err).To(MatchError("when --registry is set, valid protocols are: \"http\", \"https\", found: \"ftp\""))
 		})
 	})
 
@@ -132,10 +129,9 @@ var _ = Describe("The riff namespace init command", func() {
 		It("involves the core.Client", func() {
 			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--secret", "s3cr3t"})
 			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
-				NamespaceName:    "ns",
-				Manifest:         "some-path",
-				SecretName:       "s3cr3t",
-				RegistryProtocol: "https",
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				SecretName:    "s3cr3t",
 			}).Return(nil)
 
 			err := namespaceInit.Execute()
@@ -146,11 +142,10 @@ var _ = Describe("The riff namespace init command", func() {
 		It("involves the core.Client with GCR config", func() {
 			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--gcr", "/path/to/gcr/config.json"})
 			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
-				NamespaceName:    "ns",
-				Manifest:         "some-path",
-				GcrTokenPath:     "/path/to/gcr/config.json",
-				SecretName:       "push-credentials",
-				RegistryProtocol: "https",
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				GcrTokenPath:  "/path/to/gcr/config.json",
+				SecretName:    "push-credentials",
 			}).Return(nil)
 
 			err := namespaceInit.Execute()
@@ -165,7 +160,6 @@ var _ = Describe("The riff namespace init command", func() {
 				Manifest:          "some-path",
 				DockerHubUsername: "username",
 				SecretName:        "push-credentials",
-				RegistryProtocol:  "https",
 			}).Return(nil)
 
 			err := namespaceInit.Execute()
@@ -176,11 +170,10 @@ var _ = Describe("The riff namespace init command", func() {
 		It("involves the core.Client without any secret", func() {
 			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--no-secret"})
 			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
-				NamespaceName:    "ns",
-				Manifest:         "some-path",
-				NoSecret:         true,
-				SecretName:       "push-credentials",
-				RegistryProtocol: "https",
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				NoSecret:      true,
+				SecretName:    "push-credentials",
 			}).Return(nil)
 
 			err := namespaceInit.Execute()
@@ -189,14 +182,13 @@ var _ = Describe("The riff namespace init command", func() {
 		})
 
 		It("involves the core.Client with explicit registry configuration", func() {
-			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry-host", "registry.example.com", "--registry-user", "me"})
+			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--registry", "registry.example.com", "--registry-user", "me"})
 			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
-				NamespaceName:    "ns",
-				Manifest:         "some-path",
-				RegistryProtocol: "https",
-				RegistryHost:     "registry.example.com",
-				RegistryUser:     "me",
-				SecretName:       "push-credentials",
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				Registry:      "https://registry.example.com",
+				RegistryUser:  "me",
+				SecretName:    "push-credentials",
 			}).Return(nil)
 
 			err := namespaceInit.Execute()
@@ -208,10 +200,9 @@ var _ = Describe("The riff namespace init command", func() {
 			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--secret", "s3cr3t"})
 			expectedError := fmt.Errorf("oopsie")
 			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
-				NamespaceName:    "ns",
-				Manifest:         "some-path",
-				SecretName:       "s3cr3t",
-				RegistryProtocol: "https",
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				SecretName:    "s3cr3t",
 			}).Return(expectedError)
 
 			err := namespaceInit.Execute()

--- a/docs/riff_namespace_init.md
+++ b/docs/riff_namespace_init.md
@@ -19,16 +19,15 @@ riff namespace init [flags]
 ### Options
 
 ```
-      --dockerhub string           dockerhub username for authentication; password will be read from stdin
-      --gcr string                 path to a file containing Google Container Registry credentials
-  -h, --help                       help for init
-      --image-prefix string        image prefix to use for commands that would otherwise require an --image argument. If not set, this value will be derived for DockerHub and GCR
-  -m, --manifest string            manifest of kubernetes configuration files to be applied; can be a named manifest (latest, nightly, stable) or a path of a manifest file (default "stable")
-      --no-secret                  no secret required for the image registry
-      --registry-host string       registry server host
-      --registry-protocol string   registry protocol (http or https) (default "https")
-      --registry-user string       registry username; password will be read from stdin
-  -s, --secret secret              the name of a secret containing credentials for the image registry (default "push-credentials")
+      --dockerhub string       dockerhub username for authentication; password will be read from stdin
+      --gcr string             path to a file containing Google Container Registry credentials
+  -h, --help                   help for init
+      --image-prefix string    image prefix to use for commands that would otherwise require an --image argument. If not set, this value will be derived for DockerHub and GCR
+  -m, --manifest string        manifest of kubernetes configuration files to be applied; can be a named manifest (latest, nightly, stable) or a path of a manifest file (default "stable")
+      --no-secret              no secret required for the image registry
+      --registry string        registry server host, scheme must be "http" or "https" (default "https")
+      --registry-user string   registry username; password will be read from stdin
+  -s, --secret secret          the name of a secret containing credentials for the image registry (default "push-credentials")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/core/namespace.go
+++ b/pkg/core/namespace.go
@@ -59,9 +59,8 @@ type NamespaceInitOptions struct {
 	GcrTokenPath      string
 	DockerHubUsername string
 
-	RegistryProtocol string
-	RegistryHost     string
-	RegistryUser     string
+	Registry     string
+	RegistryUser string
 }
 
 type NamespaceCleanupOptions struct {
@@ -78,7 +77,7 @@ func (o *NamespaceInitOptions) secretType() secretType {
 		return secretTypeDockerHub
 	case o.GcrTokenPath != "":
 		return secretTypeGcr
-	case o.RegistryHost != "":
+	case o.RegistryUser != "":
 		return secretTypeBasicAuth
 	default:
 		return secretTypeUserProvided
@@ -302,8 +301,7 @@ func (c *client) createRegistrySecret(options NamespaceInitOptions, labels map[s
 	if err != nil {
 		return err
 	}
-	registryAddress := fmt.Sprintf("%s://%s", options.RegistryProtocol, options.RegistryHost)
-	return c.createBasicAuthSecret(options.NamespaceName, options.SecretName, username, password, registryAddress, labels)
+	return c.createBasicAuthSecret(options.NamespaceName, options.SecretName, username, password, options.Registry, labels)
 }
 
 func (c *client) createBasicAuthSecret(namespace string,

--- a/pkg/core/namespace_test.go
+++ b/pkg/core/namespace_test.go
@@ -227,12 +227,11 @@ var _ = Describe("namespace", func() {
 			It("should create a secret for the registry", func() {
 
 				options := core.NamespaceInitOptions{
-					Manifest:         "fixtures/empty.yaml",
-					NamespaceName:    "foo",
-					RegistryProtocol: "https",
-					RegistryHost:     "registry.example.com",
-					RegistryUser:     "roger",
-					SecretName:       "push-credentials",
+					Manifest:      "fixtures/empty.yaml",
+					NamespaceName: "foo",
+					Registry:      "https://registry.example.com",
+					RegistryUser:  "roger",
+					SecretName:    "push-credentials",
 				}
 
 				namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}


### PR DESCRIPTION
The --registry-host and --registry-protocol fields are hopelessly
entangled. We can provide a better user experiance by combining them
into a single flag named --registry.

Fixes #1140