### PR TITLE
Modify the way files paths/URLs/schemes are handled

### DIFF
--- a/pkg/fileutils/paths_test.go
+++ b/pkg/fileutils/paths_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/projectriff/riff/pkg/fileutils"
+	"os"
+	"strings"
 )
 
 var _ = Describe("StartsWithHomeDirAsTilde", func() {
@@ -58,7 +60,8 @@ var _ = Describe("ResolveTilde", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(path).NotTo(ContainSubstring("~"))
-		Expect(path).To(HaveSuffix(initialPath[2:]))
+		// on windows the path separator might have changed so replace / with the OS specific separator
+		Expect(path).To(HaveSuffix(strings.Replace( initialPath[2:], "/", string(os.PathSeparator), -1)))
 	})
 
 	It("returns path without tilde as is", func() {

--- a/pkg/fileutils/read_test.go
+++ b/pkg/fileutils/read_test.go
@@ -201,6 +201,135 @@ var _ = Describe("ReadUrl", func() {
 	})
 })
 
+var _ = Describe("EmptyScheme", func() {
+
+	var (
+		os      string
+		file	string
+		u       *url.URL
+		err     error
+		empty   bool
+	)
+
+	JustBeforeEach(func() {
+		u, err = url.Parse(file)
+		empty = fileutils.EmptyScheme(u, os)
+	})
+
+	Context("on Windows", func() {
+
+		BeforeEach(func() {
+			os = "windows"
+		})
+
+		Context("when file: is the scheme and using unix separators", func() {
+			BeforeEach(func() {
+				file = "file:///my/file"
+			})
+
+			It("scheme should not be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeFalse())
+			})
+		})
+
+		Context("when no scheme and using windows separators and no drive letter", func() {
+			BeforeEach(func() {
+				file = "\\my\\file"
+			})
+
+			It("scheme should be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeTrue())
+			})
+		})
+
+		Context("when no scheme and using windows separators and drive letter", func() {
+			BeforeEach(func() {
+				file = "C:\\my\\file"
+			})
+
+			It("scheme should be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeTrue())
+			})
+		})
+
+		Context("when http: is the scheme", func() {
+			BeforeEach(func() {
+				file = "http://foo.com/bar"
+			})
+
+			It("scheme should not be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeFalse())
+			})
+		})
+
+		Context("when https: is the scheme", func() {
+			BeforeEach(func() {
+				u, err = url.Parse("https://foo.com/bar")
+			})
+
+			It("scheme should not be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeFalse())
+			})
+		})
+	})
+
+	Context("on Unix-style OS", func() {
+
+		BeforeEach(func() {
+			os = "linux"
+		})
+
+		Context("when file: is the scheme and using unix separators", func() {
+			BeforeEach(func() {
+				file = "file:///my/file"
+			})
+
+			It("scheme should not be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeFalse())
+			})
+		})
+
+		Context("when no scheme and using unix separators", func() {
+			BeforeEach(func() {
+				file = "/my/file"
+			})
+
+			It("scheme should be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeTrue())
+			})
+		})
+
+		Context("when http: is the scheme", func() {
+			BeforeEach(func() {
+				file = "http://foo.com/bar"
+			})
+
+			It("scheme should not be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeFalse())
+			})
+		})
+
+		Context("when https: is the scheme", func() {
+			BeforeEach(func() {
+				u, err = url.Parse("https://foo.com/bar")
+			})
+
+			It("scheme should not be empty", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeFalse())
+			})
+		})
+	})
+})
+
 func getwdAsURL() string {
 	cwd, err := os.Getwd()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- on Windows using net/url.Parse with an absolute file path without a scheme but with a drive letter will cause the URL to report the drive letter as the scheme

Fixes #1036
