### PR TITLE
URL Cleanup

### DIFF
--- a/pkg/core/fixtures/manifest/valid.yaml
+++ b/pkg/core/fixtures/manifest/valid.yaml
@@ -1,7 +1,7 @@
 manifestVersion: 0.1
 istio:
   - istio-crds
-  - http://istio-release
+  - https://istio-release
 knative:
   - build-release
   - https://serving-release

--- a/pkg/core/kustomize/kustomize_test.go
+++ b/pkg/core/kustomize/kustomize_test.go
@@ -85,7 +85,7 @@ spec:
 			err := test_support.Serve(resourceListener, httpResponse)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		resourceUrl := unsafeParseUrl(fmt.Sprintf("http://%s/%s", resourceListener.Addr().String(), "pvc.yaml"))
+		resourceUrl := unsafeParseUrl(fmt.Sprintf("https://%s/%s", resourceListener.Addr().String(), "pvc.yaml"))
 
 		result, err := kustomizer.ApplyLabels(resourceUrl, initLabels)
 
@@ -125,7 +125,7 @@ spec:
 			err := test_support.ServeSlow(resourceListener, httpResponse, 3*timeout)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		resourceUrl := unsafeParseUrl(fmt.Sprintf("http://%s/%s", resourceListener.Addr().String(), "pvc.yaml"))
+		resourceUrl := unsafeParseUrl(fmt.Sprintf("https://%s/%s", resourceListener.Addr().String(), "pvc.yaml"))
 
 		_, err := kustomizer.ApplyLabels(resourceUrl, initLabels)
 

--- a/pkg/core/manifest_test.go
+++ b/pkg/core/manifest_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Manifest", func() {
 			})
 
 			It("should parse the istio array", func() {
-				Expect(manifest.Istio).To(ConsistOf("istio-crds", "http://istio-release"))
+				Expect(manifest.Istio).To(ConsistOf("istio-crds", "https://istio-release"))
 			})
 
 			It("should parse the Knative array", func() {
@@ -157,7 +157,7 @@ var _ = Describe("Manifest", func() {
 				})
 
 				It("should return a http URL unchanged", func() {
-					Expect(manifest.ResourceAbsolutePath("http://istio-release")).To(Equal("http://istio-release"))
+					Expect(manifest.ResourceAbsolutePath("https://istio-release")).To(Equal("https://istio-release"))
 				})
 
 				It("should return a https URL unchanged", func() {

--- a/pkg/fileutils/abs_test.go
+++ b/pkg/fileutils/abs_test.go
@@ -56,7 +56,7 @@ var _ = Describe("IsAbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()
@@ -159,7 +159,7 @@ var _ = Describe("AbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()

--- a/pkg/fileutils/copier.go
+++ b/pkg/fileutils/copier.go
@@ -41,7 +41,7 @@ const (
 type Copier interface {
 	/*
 		Copy copies a source file to a destination file. File contents are copied. File mode and permissions
-		(as described in http://golang.org/pkg/os/#FileMode) are copied.
+		(as described in https://golang.org/pkg/os/#FileMode) are copied.
 
 		Directories are copied, along with their contents.
 

--- a/pkg/fileutils/read_test.go
+++ b/pkg/fileutils/read_test.go
@@ -177,7 +177,7 @@ var _ = Describe("ReadUrl", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		resourceUrl, _ := url.Parse(fmt.Sprintf("http://%s/%s", listener.Addr().String(), ""))
+		resourceUrl, _ := url.Parse(fmt.Sprintf("https://%s/%s", listener.Addr().String(), ""))
 
 		result, err := fileutils.ReadUrl(resourceUrl, timeout)
 
@@ -191,7 +191,7 @@ var _ = Describe("ReadUrl", func() {
 			err := test_support.ServeSlow(resourceListener, test_support.HttpResponse{}, 2*timeout)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		resourceUrl, _ := url.Parse(fmt.Sprintf("http://%s/%s", resourceListener.Addr().String(), ""))
+		resourceUrl, _ := url.Parse(fmt.Sprintf("https://%s/%s", resourceListener.Addr().String(), ""))
 
 		_, err := fileutils.ReadUrl(resourceUrl, timeout)
 

--- a/pkg/riff/commands/cobra_test.go
+++ b/pkg/riff/commands/cobra_test.go
@@ -157,11 +157,11 @@ var _ = Describe("The cobra extensions", func() {
 					},
 				}
 				command.Flags().StringVar(&foobar, "foobar", "", "some meaningful flag")
-				command.SetArgs([]string{"--foobar", "http://example.com"})
+				command.SetArgs([]string{"--foobar", "https://example.com"})
 				command.SetOutput(ioutil.Discard)
 
 				Expect(command.Execute()).
-					To(MatchError(`flag --foobar cannot have value "http://example.com", it should not start with "http://" nor "https://"`))
+					To(MatchError(`flag --foobar cannot have value "https://example.com", it should not start with "http://" nor "https://"`))
 			})
 		})
 	})


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://%s/%s (UnknownHostException) with 4 occurrences migrated to:  
  https://%s/%s ([https](https://%s/%s) result UnknownHostException).
* http://istio-release (UnknownHostException) with 4 occurrences migrated to:  
  https://istio-release ([https](https://istio-release) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://example.com with 2 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* http://golang.org/pkg/os/ with 1 occurrences migrated to:  
  https://golang.org/pkg/os/ ([https](https://golang.org/pkg/os/) result 200).
* http://projectriff.io with 2 occurrences migrated to:  
  https://projectriff.io ([https](https://projectriff.io) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:12345/nope.yaml with 1 occurrences