### PR TITLE
URL Cleanup

### DIFF
--- a/pkg/fileutils/abs_test.go
+++ b/pkg/fileutils/abs_test.go
@@ -56,7 +56,7 @@ var _ = Describe("IsAbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()
@@ -159,7 +159,7 @@ var _ = Describe("AbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()

--- a/pkg/fileutils/copier.go
+++ b/pkg/fileutils/copier.go
@@ -41,7 +41,7 @@ const (
 type Copier interface {
 	/*
 		Copy copies a source file to a destination file. File contents are copied. File mode and permissions
-		(as described in http://golang.org/pkg/os/#FileMode) are copied.
+		(as described in https://golang.org/pkg/os/#FileMode) are copied.
 
 		Directories are copied, along with their contents.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://apt.starkandwayne.com (200) with 1 occurrences could not be migrated:  
   ([https](https://apt.starkandwayne.com) result ReadTimeoutException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://golang.org/pkg/os/ with 1 occurrences migrated to:  
  https://golang.org/pkg/os/ ([https](https://golang.org/pkg/os/) result 200).
* [ ] http://projectriff.io with 2 occurrences migrated to:  
  https://projectriff.io ([https](https://projectriff.io) result 200).

# Ignored
These URLs were intentionally ignored.

* http://istio-release with 2 occurrences