### PR TITLE
URL Cleanup

### DIFF
--- a/cmd/commands/cobra_test.go
+++ b/cmd/commands/cobra_test.go
@@ -157,11 +157,11 @@ var _ = Describe("The cobra extensions", func() {
 					},
 				}
 				command.Flags().StringVar(&foobar, "foobar", "", "some meaningful flag")
-				command.SetArgs([]string{"--foobar", "http://example.com"})
+				command.SetArgs([]string{"--foobar", "https://example.com"})
 				command.SetOutput(ioutil.Discard)
 
 				Expect(command.Execute()).
-					To(MatchError(`flag --foobar cannot have value "http://example.com", it should not start with "http://" nor "https://"`))
+					To(MatchError(`flag --foobar cannot have value "https://example.com", it should not start with "http://" nor "https://"`))
 			})
 		})
 	})

--- a/pkg/fileutils/abs_test.go
+++ b/pkg/fileutils/abs_test.go
@@ -56,7 +56,7 @@ var _ = Describe("IsAbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()
@@ -159,7 +159,7 @@ var _ = Describe("AbsFile", func() {
 
 	Context("when the input path is a http URL", func() {
 		BeforeEach(func() {
-			path = "http://projectriff.io"
+			path = "https://projectriff.io"
 		})
 
 		checkAbsolute()

--- a/pkg/fileutils/copier.go
+++ b/pkg/fileutils/copier.go
@@ -41,7 +41,7 @@ const (
 type Copier interface {
 	/*
 		Copy copies a source file to a destination file. File contents are copied. File mode and permissions
-		(as described in http://golang.org/pkg/os/#FileMode) are copied.
+		(as described in https://golang.org/pkg/os/#FileMode) are copied.
 
 		Directories are copied, along with their contents.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://apt.starkandwayne.com (200) with 1 occurrences could not be migrated:  
   ([https](https://apt.starkandwayne.com) result ReadTimeoutException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://example.com with 2 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://golang.org/pkg/os/ with 1 occurrences migrated to:  
  https://golang.org/pkg/os/ ([https](https://golang.org/pkg/os/) result 200).
* [ ] http://projectriff.io with 2 occurrences migrated to:  
  https://projectriff.io ([https](https://projectriff.io) result 200).

# Ignored
These URLs were intentionally ignored.

* http://%s/%s with 4 occurrences
* http://istio-release with 4 occurrences
* http://localhost:12345/nope.yaml with 1 occurrences