### PR TITLE
Allow riff.toml to exist

### DIFF
--- a/cmd/riff/main.go
+++ b/cmd/riff/main.go
@@ -40,7 +40,7 @@ var (
 				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.4.0/eventing.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.4.0/in-memory-channel.yaml",
 				// TODO update to a release version before releasing riff
-				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate-0.2.0-snapshot-ci-92b29a6fb99c.yaml",
+				"https://storage.googleapis.com/projectriff/riff-buildtemplate/riff-cnb-clusterbuildtemplate-0.2.0-snapshot-ci-c957e7e83d23.yaml",
 			},
 		},
 		// most recent release of Knative. This manifest is not tested

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/projectriff/riff
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/boz/go-lifecycle v0.0.0-20170921044039-c39961a5a0ce // indirect
 	github.com/boz/go-logutil v0.0.0-20170814044541-9d21a9e4757d
 	github.com/boz/kail v0.6.0
 	github.com/boz/kcache v0.0.0-20171103002618-fb1338d32301
-	github.com/buildpack/pack v0.0.10-0.20190321150154-40640e5370f3
+	github.com/buildpack/lifecycle v0.0.0-20190314183328-a6ea5e18de72
+	github.com/buildpack/pack v0.0.10-0.20190326142214-ebc7c99fc236
 	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/emicklei/go-restful v2.8.1+incompatible // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/boz/kcache v0.0.0-20171103002618-fb1338d32301 h1:gmAO/HxKZ2ORAk25TZ2s
 github.com/boz/kcache v0.0.0-20171103002618-fb1338d32301/go.mod h1:IfCzwQoSBZFA8rxK0BFX6eVlKY9BDpTeozoX/40dD2w=
 github.com/buildpack/lifecycle v0.0.0-20190314183328-a6ea5e18de72 h1:tCYd4NvBTgrb+7VP8vgZmOO4ecK9i/RKAArO2EAJ20I=
 github.com/buildpack/lifecycle v0.0.0-20190314183328-a6ea5e18de72/go.mod h1:35fR8AHcmIc9UHt/XE0Js3UzA260lNqQMhgH4HQ3vPM=
-github.com/buildpack/pack v0.0.10-0.20190321150154-40640e5370f3 h1:9l3cIMvan0CvyGHDG9xkSRntNNzKUlv8lf0YL88BUp4=
-github.com/buildpack/pack v0.0.10-0.20190321150154-40640e5370f3/go.mod h1:B6Sw4h/d/hXwVPpIR1AKL0Xfl/eIpqsxXobjWrJ+yng=
+github.com/buildpack/pack v0.0.10-0.20190326142214-ebc7c99fc236 h1:raisEH3U01b8QU4+tVQolI1tCbw+lcqwcAcVmHLjRd0=
+github.com/buildpack/pack v0.0.10-0.20190326142214-ebc7c99fc236/go.mod h1:B6Sw4h/d/hXwVPpIR1AKL0Xfl/eIpqsxXobjWrJ+yng=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=

--- a/pkg/core/client.go
+++ b/pkg/core/client.go
@@ -65,7 +65,7 @@ type Client interface {
 }
 
 type Builder interface {
-	Build(appDir, buildImage, runImage, repoName string, log io.Writer) error
+	Build(repoName string, options BuildOptions, log io.Writer) error
 }
 
 type client struct {

--- a/pkg/core/function_test.go
+++ b/pkg/core/function_test.go
@@ -18,8 +18,6 @@ package core_test
 
 import (
 	"io/ioutil"
-	"os"
-	"path/filepath"
 
 	build "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1alpha1"
@@ -113,7 +111,7 @@ var _ = Describe("Function", func() {
 
 			BeforeEach(func() {
 				createFunctionOptions.LocalPath = workDir
-				mockBuilder.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			})
 
 			Context("when buildpack and run images are provided", func() {
@@ -155,32 +153,6 @@ var _ = Describe("Function", func() {
 					// The returned service should be the input to service create, not the output.
 					Expect(service).To(Equal(createdService))
 					Expect(cache).To(BeNil())
-				})
-			})
-
-			Context("when riff.toml is already present", func() {
-				BeforeEach(func() {
-					if err := ioutil.WriteFile(filepath.Join(workDir, "riff.toml"), []byte{}, os.FileMode(0400)); err != nil {
-						panic(err)
-					}
-				})
-
-				It("should fail", func() {
-					msg := "found riff.toml file in local path. Please delete this file and let the CLI create it from flags"
-					Expect(err).To(MatchError(msg))
-				})
-			})
-
-			Context("when riff.toml is not initially present", func() {
-				BeforeEach(func() {
-					createFunctionOptions.BuildpackImage = "some/buildpack"
-					createFunctionOptions.RunImage = "some/run"
-				})
-
-				It("should clean up created riff.toml upon function creation", func() {
-					Expect(err).To(Not(HaveOccurred()))
-					Expect(test_support.FileExists(filepath.Join(workDir, "riff.toml"))).To(BeFalse(),
-						"expected riff.toml to be deleted upon function creation completion")
 				})
 			})
 		})
@@ -230,7 +202,7 @@ var _ = Describe("Function", func() {
 					},
 				}
 				updateFunctionOptions.LocalPath = workDir
-				mockBuilder.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			})
 
 			It("should succeed", func() {
@@ -284,37 +256,11 @@ var _ = Describe("Function", func() {
 		Context("when building locally", func() {
 			BeforeEach(func() {
 				buildFunctionOptions.LocalPath = workDir
-				mockBuilder.On("Build", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockBuilder.On("Build", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			})
 
 			It("should succeed", func() {
 				Expect(err).NotTo(HaveOccurred())
-			})
-
-			Context("when riff.toml is already present", func() {
-				BeforeEach(func() {
-					if err := ioutil.WriteFile(filepath.Join(workDir, "riff.toml"), []byte{}, os.FileMode(0400)); err != nil {
-						panic(err)
-					}
-				})
-
-				It("should fail", func() {
-					msg := "found riff.toml file in local path. Please delete this file and let the CLI create it from flags"
-					Expect(err).To(MatchError(msg))
-				})
-			})
-
-			Context("when riff.toml is not initially present", func() {
-				BeforeEach(func() {
-					buildFunctionOptions.BuildpackImage = "some/buildpack"
-					buildFunctionOptions.RunImage = "some/run"
-				})
-
-				It("should clean up created riff.toml upon function creation", func() {
-					Expect(err).To(Not(HaveOccurred()))
-					Expect(test_support.FileExists(filepath.Join(workDir, "riff.toml"))).To(BeFalse(),
-						"expected riff.toml to be deleted upon function creation completion")
-				})
 			})
 		})
 

--- a/pkg/core/mocks/mockbuilder/Builder.go
+++ b/pkg/core/mocks/mockbuilder/Builder.go
@@ -2,6 +2,7 @@
 
 package mockbuilder
 
+import core "github.com/projectriff/riff/pkg/core"
 import io "io"
 import mock "github.com/stretchr/testify/mock"
 
@@ -10,13 +11,13 @@ type Builder struct {
 	mock.Mock
 }
 
-// Build provides a mock function with given fields: appDir, buildImage, runImage, repoName, log
-func (_m *Builder) Build(appDir string, buildImage string, runImage string, repoName string, log io.Writer) error {
-	ret := _m.Called(appDir, buildImage, runImage, repoName, log)
+// Build provides a mock function with given fields: repoName, options, log
+func (_m *Builder) Build(repoName string, options core.BuildOptions, log io.Writer) error {
+	ret := _m.Called(repoName, options, log)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, io.Writer) error); ok {
-		r0 = rf(appDir, buildImage, runImage, repoName, log)
+	if rf, ok := ret.Get(0).(func(string, core.BuildOptions, io.Writer) error); ok {
+		r0 = rf(repoName, options, log)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Function authors may define and commit their own riff.toml file which
will be used for both local and on-cluster builds. The riff cli allows
users to override values in the riff.toml when creating a function.

packs now allows environment variables to be passed to the detect and
build phases. The riff cli no longer writes its own riff.toml instead
defering to the user's riff.toml and instead passes it's custom config
as env vars. Function buildpacks understand both riff.toml and the env
var, favoring the environment when there is a conflict.

Refs #1192