### PR TITLE
Apply the Istio patch to istio.yaml

### DIFF
--- a/cmd/riff/main.go
+++ b/cmd/riff/main.go
@@ -30,8 +30,8 @@ var (
 		"stable": {
 			ManifestVersion: "0.1",
 			Istio: []string{
-				"https://storage.googleapis.com/knative-releases/serving/previous/v0.4.1/istio.yaml",
-				"https://storage.googleapis.com/projectriff/istio/istio-riff-knative-serving-v0-4-1-patch.yaml",
+				// diff https://storage.googleapis.com/projectriff/istio/istio-riff-knative-serving-v0-4-1.diff
+				"https://storage.googleapis.com/projectriff/istio/istio-riff-knative-serving-v0-4-1.yaml",
 			},
 			Knative: []string{
 				"https://storage.googleapis.com/knative-releases/build/previous/v0.4.0/build.yaml",


### PR DESCRIPTION
The istio.yaml published as part of the Knative Serving release is too
heavy in both the number of replicas and reservations. We previously
scaled it back using a "patch" yaml that duplicates the resources that
needed to change. Now we use a single yaml file with the patch applied.

The diff from the Knative version is also published.