### PR TITLE
Fix Docker Hub references for namespace init

### DIFF
--- a/docs/riff_namespace_init.md
+++ b/docs/riff_namespace_init.md
@@ -19,10 +19,10 @@ riff namespace init [flags]
 ### Options
 
 ```
-      --dockerhub string       dockerhub username for authentication; password will be read from stdin
+      --docker-hub string      Docker ID for authenticating with Docker Hub; password will be read from stdin
       --gcr string             path to a file containing Google Container Registry credentials
   -h, --help                   help for init
-      --image-prefix string    image prefix to use for commands that would otherwise require an --image argument. If not set, this value will be derived for DockerHub and GCR
+      --image-prefix string    image prefix to use for commands that would otherwise require an --image argument. If not set, this value will be derived for Docker Hub and GCR
   -m, --manifest string        manifest of kubernetes configuration files to be applied; can be a named manifest (latest, nightly, stable) or a path of a manifest file (default "stable")
       --no-secret              no secret required for the image registry
       --registry string        registry server host, scheme must be "http" or "https" (default "https")

--- a/pkg/core/namespace.go
+++ b/pkg/core/namespace.go
@@ -54,10 +54,10 @@ type NamespaceInitOptions struct {
 
 	ImagePrefix string
 
-	NoSecret          bool
-	SecretName        string
-	GcrTokenPath      string
-	DockerHubUsername string
+	NoSecret     bool
+	SecretName   string
+	GcrTokenPath string
+	DockerHubId  string
 
 	Registry     string
 	RegistryUser string
@@ -73,7 +73,7 @@ func (o *NamespaceInitOptions) secretType() secretType {
 	switch {
 	case o.NoSecret:
 		return secretTypeNone
-	case o.DockerHubUsername != "":
+	case o.DockerHubId != "":
 		return secretTypeDockerHub
 	case o.GcrTokenPath != "":
 		return secretTypeGcr
@@ -257,7 +257,7 @@ func (c *client) checkSecretExists(options NamespaceInitOptions) error {
 }
 
 func (c *client) createDockerHubSecret(options NamespaceInitOptions, labels map[string]string) error {
-	username := options.DockerHubUsername
+	username := options.DockerHubId
 	password, err := readPassword(fmt.Sprintf("Enter password for user %q", username))
 	if err != nil {
 		return err
@@ -266,7 +266,7 @@ func (c *client) createDockerHubSecret(options NamespaceInitOptions, labels map[
 }
 
 func (c *client) dockerHubImagePrefix(options NamespaceInitOptions) string {
-	return fmt.Sprintf("docker.io/%s", options.DockerHubUsername)
+	return fmt.Sprintf("docker.io/%s", options.DockerHubId)
 }
 
 func (c *client) createGcrSecret(options NamespaceInitOptions, labels map[string]string) error {

--- a/pkg/core/namespace_test.go
+++ b/pkg/core/namespace_test.go
@@ -167,10 +167,10 @@ var _ = Describe("namespace", func() {
 			It("should create secret for dockerhub", func() {
 
 				options := core.NamespaceInitOptions{
-					Manifest:          "fixtures/empty.yaml",
-					NamespaceName:     "foo",
-					DockerHubUsername: "roger",
-					SecretName:        "push-credentials",
+					Manifest:      "fixtures/empty.yaml",
+					NamespaceName: "foo",
+					DockerHubId:   "roger",
+					SecretName:    "push-credentials",
 				}
 
 				namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}

--- a/pkg/riff/commands/namespace.go
+++ b/pkg/riff/commands/namespace.go
@@ -111,6 +111,7 @@ func NamespaceInit(manifests map[string]*core.Manifest, c *core.Client) *cobra.C
 	// ToDo: remove this deprecated flag in favor of --docker-hub
 	command.Flags().StringVar(&options.DockerHubId, "dockerhub", "", "dockerhub username for authentication; password will be read from stdin")
 	command.Flags().MarkHidden("dockerhub")
+	command.Flags().MarkDeprecated("dockerhub", "use --docker-hub instead")
 	command.Flags().StringVar(&options.DockerHubId, "docker-hub", "", "Docker ID for authenticating with Docker Hub; password will be read from stdin")
 	command.Flags().StringVar(&options.Registry, "registry", "", "registry server host, scheme must be \"http\" or \"https\" (default \"https\")")
 	command.Flags().StringVar(&options.RegistryUser, "registry-user", "", "registry username; password will be read from stdin")

--- a/pkg/riff/commands/namespace.go
+++ b/pkg/riff/commands/namespace.go
@@ -62,7 +62,7 @@ func NamespaceInit(manifests map[string]*core.Manifest, c *core.Client) *cobra.C
 		),
 		PreRunE: FlagsValidatorAsCobraRunE(
 			FlagsValidationConjunction(
-				AtMostOneOf("gcr", "dockerhub", "no-secret", "registry-user"),
+				AtMostOneOf("gcr", "docker-hub", "dockerhub", "no-secret", "registry-user"),
 				AtMostOneOf("secret", "no-secret"),
 				NotBlank("secret"),
 				FlagsDependency(Set("registry-user"), NotBlank("registry")),
@@ -108,10 +108,13 @@ func NamespaceInit(manifests map[string]*core.Manifest, c *core.Client) *cobra.C
 	command.Flags().BoolVarP(&options.NoSecret, "no-secret", "", false, "no secret required for the image registry")
 	command.Flags().StringVarP(&options.SecretName, "secret", "s", "push-credentials", "the name of a `secret` containing credentials for the image registry")
 	command.Flags().StringVar(&options.GcrTokenPath, "gcr", "", "path to a file containing Google Container Registry credentials")
-	command.Flags().StringVar(&options.DockerHubUsername, "dockerhub", "", "dockerhub username for authentication; password will be read from stdin")
+	// ToDo: remove this deprecated flag in favor of --docker-hub
+	command.Flags().StringVar(&options.DockerHubId, "dockerhub", "", "dockerhub username for authentication; password will be read from stdin")
+	command.Flags().MarkHidden("dockerhub")
+	command.Flags().StringVar(&options.DockerHubId, "docker-hub", "", "Docker ID for authenticating with Docker Hub; password will be read from stdin")
 	command.Flags().StringVar(&options.Registry, "registry", "", "registry server host, scheme must be \"http\" or \"https\" (default \"https\")")
 	command.Flags().StringVar(&options.RegistryUser, "registry-user", "", "registry username; password will be read from stdin")
-	command.Flags().StringVar(&options.ImagePrefix, "image-prefix", "", "image prefix to use for commands that would otherwise require an --image argument. If not set, this value will be derived for DockerHub and GCR")
+	command.Flags().StringVar(&options.ImagePrefix, "image-prefix", "", "image prefix to use for commands that would otherwise require an --image argument. If not set, this value will be derived for Docker Hub and GCR")
 
 	return command
 }

--- a/pkg/riff/commands/namespace_test.go
+++ b/pkg/riff/commands/namespace_test.go
@@ -65,7 +65,7 @@ var _ = Describe("The riff namespace init command", func() {
 			Expect(err).To(MatchError(ContainSubstring("must start and end with an alphanumeric character")))
 		})
 
-		dockerHubArgs := []string{"--dockerhub", "projectriff"}
+		dockerHubArgs := []string{"--docker-hub", "projectriff"}
 		gcrArgs := []string{"--gcr", "/path/to/gcr.json"}
 		noSecretArgs := []string{"--no-secret"}
 		basicAuthArgs := []string{"--registry", "registry.example.com", "--registry-user", "beth"}
@@ -75,7 +75,7 @@ var _ = Describe("The riff namespace init command", func() {
 
 				err := namespaceInit.Execute()
 
-				Expect(err).To(MatchError("at most one of --gcr, --dockerhub, --no-secret, --registry-user may be set"))
+				Expect(err).To(MatchError("at most one of --gcr, --docker-hub, --dockerhub, --no-secret, --registry-user may be set"))
 			},
 			Entry("all modes                =>", dockerHubArgs, gcrArgs, noSecretArgs, basicAuthArgs),
 			Entry("docker+grc+nosecret      =>", dockerHubArgs, gcrArgs, noSecretArgs),
@@ -170,12 +170,26 @@ var _ = Describe("The riff namespace init command", func() {
 		})
 
 		It("involves the core.Client with Dockerhub config", func() {
+			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--docker-hub", "username"})
+			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				DockerHubId:   "username",
+				SecretName:    "push-credentials",
+			}).Return(nil)
+
+			err := namespaceInit.Execute()
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("involves the core.Client with deprecated dockerhub flag", func() {
 			namespaceInit.SetArgs([]string{"ns", "--manifest", "some-path", "--dockerhub", "username"})
 			clientMock.On("NamespaceInit", manifests, core.NamespaceInitOptions{
-				NamespaceName:     "ns",
-				Manifest:          "some-path",
-				DockerHubUsername: "username",
-				SecretName:        "push-credentials",
+				NamespaceName: "ns",
+				Manifest:      "some-path",
+				DockerHubId:   "username",
+				SecretName:    "push-credentials",
 			}).Return(nil)
 
 			err := namespaceInit.Execute()


### PR DESCRIPTION
- Docker Hub is two words so flag should be `--docker-hub`

- refer to Docker username as Docker ID

- leaving the deprecated `--dockerhub` flag as hidden to accommodate existing scripts, should remove it for next release