### PR TITLE
AZP Fix downgrade docker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
   steps:
   - template: ci/install-gcloud.yml
-  - script: sudo apt-get update && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
+  - script: sudo apt-get update && sudo apt-get remove moby-engine moby-cli && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
     condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
     displayName: 'Downgrade Docker'
   - bash: ./ci/fats.sh lite


### PR DESCRIPTION
The name of the installed package switched from docker.io to moby-engine
and moby-cli. So we now uninstall moby-* before installing the older
version of docker.