### PR TITLE
Back-port fixes from master

### DIFF
--- a/cmd/riff/main.go
+++ b/cmd/riff/main.go
@@ -35,8 +35,8 @@ var (
 			},
 			Knative: []string{
 				"https://storage.googleapis.com/knative-releases/build/previous/v0.5.0/build.yaml",
-				"https://storage.googleapis.com/knative-releases/serving/previous/v0.5.0/serving.yaml",
-				"https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml",
+				"https://storage.googleapis.com/knative-releases/serving/previous/v0.5.1/serving.yaml",
+				"https://raw.githubusercontent.com/knative/serving/v0.5.1/third_party/config/build/clusterrole.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.4.0/eventing.yaml",
 				"https://storage.googleapis.com/knative-releases/eventing/previous/v0.4.0/in-memory-channel.yaml",
 				// TODO update to a release version before releasing riff

--- a/pkg/core/function.go
+++ b/pkg/core/function.go
@@ -145,6 +145,7 @@ func (c *client) CreateFunction(buildpackBuilder Builder, options CreateFunction
 							{Name: "FUNCTION_ARTIFACT", Value: options.Artifact},
 							{Name: "FUNCTION_HANDLER", Value: options.Handler},
 							{Name: "FUNCTION_LANGUAGE", Value: options.Invoker},
+							{Name: "USE_CRED_HELPERS", Value: "false"},
 							{Name: "CACHE", Value: "cache"},
 						},
 					},


### PR DESCRIPTION
Update to Knative serving v0.5.1

Fix builds on PKS/GCP with GCR by setting USE_CRED_HELPERS to false. See comments here: https://github.com/buildpack/knative-integration/issues/2#issuecomment-482624665 

Fixes #1249