### PR TITLE
Use tables as output for list commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.12
 
 require (
 	github.com/google/go-cmp v0.3.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/knative/pkg v0.0.0-20190417151928-418e675f88c2
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/projectriff/system v0.0.0-20190514230324-6e07cd39cb97
 	github.com/spf13/cobra v0.0.3
@@ -29,7 +31,6 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.6 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/knative/build v0.5.0 // indirect
 	github.com/knative/serving v0.5.2 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
@@ -41,6 +42,7 @@ require (
 	go.uber.org/zap v1.10.0 // indirect
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
+	golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20190502190224-411b2483e503 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -250,6 +252,8 @@ golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=

--- a/pkg/cli/format.go
+++ b/pkg/cli/format.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"time"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+func FormatTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+func FormatEmptyString(str string) string {
+	if str == "" {
+		return "<empty>"
+	}
+	return str
+}
+
+func FormatConditionStatus(cond *duckv1alpha1.Condition) string {
+	if cond == nil {
+		return "<unknown>"
+	}
+	return FormatEmptyString(string(cond.Status))
+}
+
+func FormatConditionMessage(cond *duckv1alpha1.Condition) string {
+	if cond == nil {
+		return "<unknown>"
+	}
+	return cond.Message
+}

--- a/pkg/cli/printers/interface.go
+++ b/pkg/cli/printers/interface.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// repackaged from https://github.com/kubernetes/kubernetes/tree/v1.15.0-beta.0/pkg/printers
+// TODO remove once we can depend directly on k8s 1.15
+
+package printers
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ResourcePrinter is an interface that knows how to print runtime objects.
+type ResourcePrinter interface {
+	// Print receives a runtime object, formats it and prints it to a writer.
+	PrintObj(runtime.Object, io.Writer) error
+}
+
+// ResourcePrinterFunc is a function that can print objects
+type ResourcePrinterFunc func(runtime.Object, io.Writer) error
+
+// PrintObj implements ResourcePrinter
+func (fn ResourcePrinterFunc) PrintObj(obj runtime.Object, w io.Writer) error {
+	return fn(obj, w)
+}
+
+// PrintOptions struct defines a struct for various print options
+type PrintOptions struct {
+	// supported Format types can be found in pkg/printers/printers.go
+	OutputFormatType     string
+	OutputFormatArgument string
+
+	NoHeaders          bool
+	WithNamespace      bool
+	WithKind           bool
+	Wide               bool
+	ShowLabels         bool
+	AbsoluteTimestamps bool
+	Kind               schema.GroupKind
+	ColumnLabels       []string
+
+	SortBy string
+
+	// indicates if it is OK to ignore missing keys for rendering an output template.
+	AllowMissingKeys bool
+}

--- a/pkg/cli/printers/tablegenerator.go
+++ b/pkg/cli/printers/tablegenerator.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// repackaged from https://github.com/kubernetes/kubernetes/tree/v1.15.0-beta.0/pkg/printers
+// TODO remove once we can depend directly on k8s 1.15
+
+package printers
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// TableGenerator - an interface for generating metav1beta1.Table provided a runtime.Object
+type TableGenerator interface {
+	GenerateTable(obj runtime.Object, options PrintOptions) (*metav1beta1.Table, error)
+}
+
+// PrintHandler - interface to handle printing provided an array of metav1beta1.TableColumnDefinition
+type PrintHandler interface {
+	TableHandler(columns []metav1beta1.TableColumnDefinition, printFunc interface{}) error
+}
+
+type handlerEntry struct {
+	columnDefinitions []metav1beta1.TableColumnDefinition
+	printFunc         reflect.Value
+	args              []reflect.Value
+}
+
+// HumanReadablePrinter is an implementation of ResourcePrinter which attempts to provide
+// more elegant output. It is not threadsafe, but you may call PrintObj repeatedly; headers
+// will only be printed if the object type changes. This makes it useful for printing items
+// received from watches.
+type HumanReadablePrinter struct {
+	handlerMap  map[reflect.Type]*handlerEntry
+	options     PrintOptions
+	lastType    interface{}
+	lastColumns []metav1beta1.TableColumnDefinition
+}
+
+var _ TableGenerator = &HumanReadablePrinter{}
+var _ PrintHandler = &HumanReadablePrinter{}
+
+// NewTableGenerator creates a HumanReadablePrinter suitable for calling GenerateTable().
+func NewTableGenerator() *HumanReadablePrinter {
+	return &HumanReadablePrinter{
+		handlerMap: make(map[reflect.Type]*handlerEntry),
+	}
+}
+
+// With method - accepts a list of builder functions that modify HumanReadablePrinter
+func (h *HumanReadablePrinter) With(fns ...func(PrintHandler)) *HumanReadablePrinter {
+	for _, fn := range fns {
+		fn(h)
+	}
+	return h
+}
+
+// GenerateTable returns a table for the provided object, using the printer registered for that type. It returns
+// a table that includes all of the information requested by options, but will not remove rows or columns. The
+// caller is responsible for applying rules related to filtering rows or columns.
+func (h *HumanReadablePrinter) GenerateTable(obj runtime.Object, options PrintOptions) (*metav1beta1.Table, error) {
+	t := reflect.TypeOf(obj)
+	handler, ok := h.handlerMap[t]
+	if !ok {
+		return nil, fmt.Errorf("no table handler registered for this type %v", t)
+	}
+
+	args := []reflect.Value{reflect.ValueOf(obj), reflect.ValueOf(options)}
+	results := handler.printFunc.Call(args)
+	if !results[1].IsNil() {
+		return nil, results[1].Interface().(error)
+	}
+
+	var columns []metav1beta1.TableColumnDefinition
+	if !options.NoHeaders {
+		columns = handler.columnDefinitions
+		if !options.Wide {
+			columns = make([]metav1beta1.TableColumnDefinition, 0, len(handler.columnDefinitions))
+			for i := range handler.columnDefinitions {
+				if handler.columnDefinitions[i].Priority != 0 {
+					continue
+				}
+				columns = append(columns, handler.columnDefinitions[i])
+			}
+		}
+	}
+	table := &metav1beta1.Table{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "",
+		},
+		ColumnDefinitions: columns,
+		Rows:              results[0].Interface().([]metav1beta1.TableRow),
+	}
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+		// riff modification as RemainingItemCount does not exist in k8s 1.12
+		// table.RemainingItemCount = m.GetRemainingItemCount()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
+	if err := decorateTable(table, options); err != nil {
+		return nil, err
+	}
+	return table, nil
+}
+
+// TableHandler adds a print handler with a given set of columns to HumanReadablePrinter instance.
+// See ValidateRowPrintHandlerFunc for required method signature.
+func (h *HumanReadablePrinter) TableHandler(columnDefinitions []metav1beta1.TableColumnDefinition, printFunc interface{}) error {
+	printFuncValue := reflect.ValueOf(printFunc)
+	if err := ValidateRowPrintHandlerFunc(printFuncValue); err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to register print function: %v", err))
+		return err
+	}
+	entry := &handlerEntry{
+		columnDefinitions: columnDefinitions,
+		printFunc:         printFuncValue,
+	}
+
+	objType := printFuncValue.Type().In(0)
+	if _, ok := h.handlerMap[objType]; ok {
+		err := fmt.Errorf("registered duplicate printer for %v", objType)
+		utilruntime.HandleError(err)
+		return err
+	}
+	h.handlerMap[objType] = entry
+	return nil
+}
+
+// ValidateRowPrintHandlerFunc validates print handler signature.
+// printFunc is the function that will be called to print an object.
+// It must be of the following type:
+//  func printFunc(object ObjectType, options PrintOptions) ([]metav1beta1.TableRow, error)
+// where ObjectType is the type of the object that will be printed, and the first
+// return value is an array of rows, with each row containing a number of cells that
+// match the number of columns defined for that printer function.
+func ValidateRowPrintHandlerFunc(printFunc reflect.Value) error {
+	if printFunc.Kind() != reflect.Func {
+		return fmt.Errorf("invalid print handler. %#v is not a function", printFunc)
+	}
+	funcType := printFunc.Type()
+	if funcType.NumIn() != 2 || funcType.NumOut() != 2 {
+		return fmt.Errorf("invalid print handler." +
+			"Must accept 2 parameters and return 2 value.")
+	}
+	if funcType.In(1) != reflect.TypeOf((*PrintOptions)(nil)).Elem() ||
+		funcType.Out(0) != reflect.TypeOf((*[]metav1beta1.TableRow)(nil)).Elem() ||
+		funcType.Out(1) != reflect.TypeOf((*error)(nil)).Elem() {
+		return fmt.Errorf("invalid print handler. The expected signature is: "+
+			"func handler(obj %v, options PrintOptions) ([]metav1beta1.TableRow, error)", funcType.In(0))
+	}
+	return nil
+}

--- a/pkg/cli/printers/tableprinter.go
+++ b/pkg/cli/printers/tableprinter.go
@@ -1,0 +1,439 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// repackaged from https://github.com/kubernetes/kubernetes/tree/v1.15.0-beta.0/pkg/printers
+// TODO remove once we can depend directly on k8s 1.15
+
+package printers
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/liggitt/tabwriter"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+var _ ResourcePrinter = &HumanReadablePrinter{}
+
+var (
+	defaultHandlerEntry = &handlerEntry{
+		columnDefinitions: objectMetaColumnDefinitions,
+		printFunc:         reflect.ValueOf(printObjectMeta),
+	}
+
+	objectMetaColumnDefinitions = []metav1beta1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
+	}
+
+	withNamespacePrefixColumns = []string{"NAMESPACE"} // TODO(erictune): print cluster name too.
+)
+
+// NewTablePrinter creates a printer suitable for calling PrintObj().
+// TODO(seans3): Change return type to ResourcePrinter interface once we no longer need
+// to constuct the "handlerMap".
+func NewTablePrinter(options PrintOptions) *HumanReadablePrinter {
+	printer := &HumanReadablePrinter{
+		handlerMap: make(map[reflect.Type]*handlerEntry),
+		options:    options,
+	}
+	return printer
+}
+
+func printHeader(columnNames []string, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "%s\n", strings.Join(columnNames, "\t")); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PrintObj prints the obj in a human-friendly format according to the type of the obj.
+func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
+	w, found := output.(*tabwriter.Writer)
+	if !found {
+		w = GetNewTabWriter(output)
+		output = w
+		defer w.Flush()
+	}
+
+	// Case 1: Parameter "obj" is a table from server; print it.
+	// display tables following the rules of options
+	if table, ok := obj.(*metav1beta1.Table); ok {
+		// Do not print headers if this table has no column definitions, or they are the same as the last ones we printed
+		localOptions := h.options
+		if len(table.ColumnDefinitions) == 0 || reflect.DeepEqual(table.ColumnDefinitions, h.lastColumns) {
+			localOptions.NoHeaders = true
+		}
+
+		if len(table.ColumnDefinitions) == 0 {
+			// If this table has no column definitions, use the columns from the last table we printed for decoration and layout.
+			// This is done when receiving tables in watch events to save bandwidth.
+			localOptions.NoHeaders = true
+			table.ColumnDefinitions = h.lastColumns
+		} else {
+			// If this table has column definitions, remember them for future use.
+			h.lastColumns = table.ColumnDefinitions
+		}
+
+		if err := decorateTable(table, localOptions); err != nil {
+			return err
+		}
+		return printTable(table, output, localOptions)
+	}
+
+	// Case 2: Parameter "obj" is not a table; search for a handler to print it.
+	// TODO(seans3): Remove this case in 1.16, since table should be returned from server-side printing.
+	// print with a registered handler
+	t := reflect.TypeOf(obj)
+	if handler := h.handlerMap[t]; handler != nil {
+		includeHeaders := h.lastType != t && !h.options.NoHeaders
+
+		if h.lastType != nil && h.lastType != t && !h.options.NoHeaders {
+			fmt.Fprintln(output)
+		}
+
+		if err := printRowsForHandlerEntry(output, handler, obj, h.options, includeHeaders); err != nil {
+			return err
+		}
+		h.lastType = t
+		return nil
+	}
+
+	// Case 3: Could not find print handler for "obj"; use the default print handler.
+	// Print with the default handler, and use the columns from the last time
+	includeHeaders := h.lastType != defaultHandlerEntry && !h.options.NoHeaders
+
+	if h.lastType != nil && h.lastType != defaultHandlerEntry && !h.options.NoHeaders {
+		fmt.Fprintln(output)
+	}
+
+	if err := printRowsForHandlerEntry(output, defaultHandlerEntry, obj, h.options, includeHeaders); err != nil {
+		return err
+	}
+	h.lastType = defaultHandlerEntry
+	return nil
+}
+
+// printTable prints a table to the provided output respecting the filtering rules for options
+// for wide columns and filtered rows. It filters out rows that are Completed. You should call
+// decorateTable if you receive a table from a remote server before calling printTable.
+func printTable(table *metav1beta1.Table, output io.Writer, options PrintOptions) error {
+	if !options.NoHeaders {
+		// avoid printing headers if we have no rows to display
+		if len(table.Rows) == 0 {
+			return nil
+		}
+
+		first := true
+		for _, column := range table.ColumnDefinitions {
+			if !options.Wide && column.Priority != 0 {
+				continue
+			}
+			if first {
+				first = false
+			} else {
+				fmt.Fprint(output, "\t")
+			}
+			fmt.Fprint(output, strings.ToUpper(column.Name))
+		}
+		fmt.Fprintln(output)
+	}
+	for _, row := range table.Rows {
+		first := true
+		for i, cell := range row.Cells {
+			if i >= len(table.ColumnDefinitions) {
+				// https://issue.k8s.io/66379
+				// don't panic in case of bad output from the server, with more cells than column definitions
+				break
+			}
+			column := table.ColumnDefinitions[i]
+			if !options.Wide && column.Priority != 0 {
+				continue
+			}
+			if first {
+				first = false
+			} else {
+				fmt.Fprint(output, "\t")
+			}
+			if cell != nil {
+				fmt.Fprint(output, cell)
+			}
+		}
+		fmt.Fprintln(output)
+	}
+	return nil
+}
+
+// decorateTable takes a table and attempts to add label columns and the
+// namespace column. It will fill empty columns with nil (if the object
+// does not expose metadata). It returns an error if the table cannot
+// be decorated.
+func decorateTable(table *metav1beta1.Table, options PrintOptions) error {
+	width := len(table.ColumnDefinitions) + len(options.ColumnLabels)
+	if options.WithNamespace {
+		width++
+	}
+	if options.ShowLabels {
+		width++
+	}
+
+	columns := table.ColumnDefinitions
+
+	nameColumn := -1
+	if options.WithKind && !options.Kind.Empty() {
+		for i := range columns {
+			if columns[i].Format == "name" && columns[i].Type == "string" {
+				nameColumn = i
+				break
+			}
+		}
+	}
+
+	if width != len(table.ColumnDefinitions) {
+		columns = make([]metav1beta1.TableColumnDefinition, 0, width)
+		if options.WithNamespace {
+			columns = append(columns, metav1beta1.TableColumnDefinition{
+				Name: "Namespace",
+				Type: "string",
+			})
+		}
+		columns = append(columns, table.ColumnDefinitions...)
+		for _, label := range formatLabelHeaders(options.ColumnLabels) {
+			columns = append(columns, metav1beta1.TableColumnDefinition{
+				Name: label,
+				Type: "string",
+			})
+		}
+		if options.ShowLabels {
+			columns = append(columns, metav1beta1.TableColumnDefinition{
+				Name: "Labels",
+				Type: "string",
+			})
+		}
+	}
+
+	rows := table.Rows
+
+	includeLabels := len(options.ColumnLabels) > 0 || options.ShowLabels
+	if includeLabels || options.WithNamespace || nameColumn != -1 {
+		for i := range rows {
+			row := rows[i]
+
+			if nameColumn != -1 {
+				row.Cells[nameColumn] = fmt.Sprintf("%s/%s", strings.ToLower(options.Kind.String()), row.Cells[nameColumn])
+			}
+
+			var m metav1.Object
+			if obj := row.Object.Object; obj != nil {
+				if acc, err := meta.Accessor(obj); err == nil {
+					m = acc
+				}
+			}
+			// if we can't get an accessor, fill out the appropriate columns with empty spaces
+			if m == nil {
+				if options.WithNamespace {
+					r := make([]interface{}, 1, width)
+					row.Cells = append(r, row.Cells...)
+				}
+				for j := 0; j < width-len(row.Cells); j++ {
+					row.Cells = append(row.Cells, nil)
+				}
+				rows[i] = row
+				continue
+			}
+
+			if options.WithNamespace {
+				r := make([]interface{}, 1, width)
+				r[0] = m.GetNamespace()
+				row.Cells = append(r, row.Cells...)
+			}
+			if includeLabels {
+				row.Cells = appendLabelCells(row.Cells, m.GetLabels(), options)
+			}
+			rows[i] = row
+		}
+	}
+
+	table.ColumnDefinitions = columns
+	table.Rows = rows
+	return nil
+}
+
+// printRowsForHandlerEntry prints the incremental table output (headers if the current type is
+// different from lastType) including all the rows in the object. It returns the current type
+// or an error, if any.
+func printRowsForHandlerEntry(output io.Writer, handler *handlerEntry, obj runtime.Object, options PrintOptions, includeHeaders bool) error {
+	var results []reflect.Value
+
+	args := []reflect.Value{reflect.ValueOf(obj), reflect.ValueOf(options)}
+	results = handler.printFunc.Call(args)
+	if !results[1].IsNil() {
+		return results[1].Interface().(error)
+	}
+
+	if includeHeaders {
+		var headers []string
+		for _, column := range handler.columnDefinitions {
+			if column.Priority != 0 && !options.Wide {
+				continue
+			}
+			headers = append(headers, strings.ToUpper(column.Name))
+		}
+		headers = append(headers, formatLabelHeaders(options.ColumnLabels)...)
+		// LABELS is always the last column.
+		headers = append(headers, formatShowLabelsHeader(options.ShowLabels)...)
+		if options.WithNamespace {
+			headers = append(withNamespacePrefixColumns, headers...)
+		}
+		printHeader(headers, output)
+	}
+
+	if results[1].IsNil() {
+		rows := results[0].Interface().([]metav1beta1.TableRow)
+		printRows(output, rows, options)
+		return nil
+	}
+	return results[1].Interface().(error)
+}
+
+// printRows writes the provided rows to output.
+func printRows(output io.Writer, rows []metav1beta1.TableRow, options PrintOptions) {
+	for _, row := range rows {
+		if options.WithNamespace {
+			if obj := row.Object.Object; obj != nil {
+				if m, err := meta.Accessor(obj); err == nil {
+					fmt.Fprint(output, m.GetNamespace())
+				}
+			}
+			fmt.Fprint(output, "\t")
+		}
+
+		for i, cell := range row.Cells {
+			if i != 0 {
+				fmt.Fprint(output, "\t")
+			} else {
+				// TODO: remove this once we drop the legacy printers
+				if options.WithKind && !options.Kind.Empty() {
+					fmt.Fprintf(output, "%s/%s", strings.ToLower(options.Kind.String()), cell)
+					continue
+				}
+			}
+			fmt.Fprint(output, cell)
+		}
+
+		hasLabels := len(options.ColumnLabels) > 0
+		if obj := row.Object.Object; obj != nil && (hasLabels || options.ShowLabels) {
+			if m, err := meta.Accessor(obj); err == nil {
+				for _, value := range labelValues(m.GetLabels(), options) {
+					output.Write([]byte("\t"))
+					output.Write([]byte(value))
+				}
+			}
+		}
+
+		output.Write([]byte("\n"))
+	}
+}
+
+func formatLabelHeaders(columnLabels []string) []string {
+	formHead := make([]string, len(columnLabels))
+	for i, l := range columnLabels {
+		p := strings.Split(l, "/")
+		formHead[i] = strings.ToUpper((p[len(p)-1]))
+	}
+	return formHead
+}
+
+// headers for --show-labels=true
+func formatShowLabelsHeader(showLabels bool) []string {
+	if showLabels {
+		return []string{"LABELS"}
+	}
+	return nil
+}
+
+// labelValues returns a slice of value columns matching the requested print options.
+func labelValues(itemLabels map[string]string, opts PrintOptions) []string {
+	var values []string
+	for _, key := range opts.ColumnLabels {
+		values = append(values, itemLabels[key])
+	}
+	if opts.ShowLabels {
+		values = append(values, labels.FormatLabels(itemLabels))
+	}
+	return values
+}
+
+// appendLabelCells returns a slice of value columns matching the requested print options.
+// Intended for use with tables.
+func appendLabelCells(values []interface{}, itemLabels map[string]string, opts PrintOptions) []interface{} {
+	for _, key := range opts.ColumnLabels {
+		values = append(values, itemLabels[key])
+	}
+	if opts.ShowLabels {
+		values = append(values, labels.FormatLabels(itemLabels))
+	}
+	return values
+}
+
+func printObjectMeta(obj runtime.Object, options PrintOptions) ([]metav1beta1.TableRow, error) {
+	if meta.IsListType(obj) {
+		rows := make([]metav1beta1.TableRow, 0, 16)
+		err := meta.EachListItem(obj, func(obj runtime.Object) error {
+			nestedRows, err := printObjectMeta(obj, options)
+			if err != nil {
+				return err
+			}
+			rows = append(rows, nestedRows...)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return rows, nil
+	}
+
+	rows := make([]metav1beta1.TableRow, 0, 1)
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	row := metav1beta1.TableRow{
+		Object: runtime.RawExtension{Object: obj},
+	}
+	row.Cells = append(row.Cells, m.GetName(), translateTimestampSince(m.GetCreationTimestamp()))
+	rows = append(rows, row)
+	return rows, nil
+}
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}

--- a/pkg/cli/printers/tabwriter.go
+++ b/pkg/cli/printers/tabwriter.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// repackaged from https://github.com/kubernetes/kubernetes/tree/v1.15.0-beta.0/pkg/printers
+// TODO remove once we can depend directly on k8s 1.15
+
+package printers
+
+import (
+	"io"
+
+	"github.com/liggitt/tabwriter"
+)
+
+const (
+	tabwriterMinWidth = 6
+	tabwriterWidth    = 4
+	tabwriterPadding  = 3
+	tabwriterPadChar  = ' '
+	tabwriterFlags    = tabwriter.RememberWidths
+)
+
+// GetNewTabWriter returns a tabwriter that translates tabbed columns in input into properly aligned text.
+func GetNewTabWriter(output io.Writer) *tabwriter.Writer {
+	return tabwriter.NewWriter(output, tabwriterMinWidth, tabwriterWidth, tabwriterPadding, tabwriterPadChar, tabwriterFlags)
+}

--- a/pkg/cli/sort.go
+++ b/pkg/cli/sort.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"reflect"
+	"sort"
+)
+
+func SortByNamespaceAndName(s interface{}) {
+	v := reflect.ValueOf(s)
+	sort.SliceStable(s, func(i, j int) bool {
+		vi, vj := v.Index(i), v.Index(j)
+
+		viName, viNamespace := vi.FieldByName("Name").String(), vi.FieldByName("Namespace").String()
+		vjName, vjNamespace := vj.FieldByName("Name").String(), vj.FieldByName("Namespace").String()
+
+		switch {
+		case viNamespace != vjNamespace:
+			return viNamespace < vjNamespace
+		default:
+			return viName < vjName
+		}
+	})
+}

--- a/pkg/riff/commands/credential_list.go
+++ b/pkg/riff/commands/credential_list.go
@@ -21,9 +21,13 @@ import (
 	"fmt"
 
 	"github.com/projectriff/riff/pkg/cli"
+	"github.com/projectriff/riff/pkg/cli/printers"
 	"github.com/projectriff/system/pkg/apis/build"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type CredentialListOptions struct {
@@ -57,17 +61,59 @@ func NewCredentialListCommand(c *cli.Config) *cobra.Command {
 
 			if len(secrets.Items) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "No credentials found.")
-			}
-			for _, secret := range secrets.Items {
-				// TODO pick a generic table formatter
-				fmt.Fprintln(cmd.OutOrStdout(), secret.Name)
+				return nil
 			}
 
-			return nil
+			tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
+				WithNamespace: opts.AllNamespaces,
+			}).With(func(h printers.PrintHandler) {
+				columns := printCredentialColumns()
+				h.TableHandler(columns, printCredentialList)
+				h.TableHandler(columns, printCredential)
+			})
+
+			secrets = secrets.DeepCopy()
+			cli.SortByNamespaceAndName(secrets.Items)
+
+			return tablePrinter.PrintObj(secrets, cmd.OutOrStdout())
 		},
 	}
 
 	cli.AllNamespacesFlag(cmd, c, &opts.Namespace, &opts.AllNamespaces)
 
 	return cmd
+}
+
+func printCredentialList(credentials *corev1.SecretList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+	rows := make([]metav1beta1.TableRow, 0, len(credentials.Items))
+	for i := range credentials.Items {
+		r, err := printCredential(&credentials.Items[i], opts)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+func printCredential(credential *corev1.Secret, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+	row := metav1beta1.TableRow{
+		Object: runtime.RawExtension{Object: credential.DeepCopy()},
+	}
+	row.Cells = append(row.Cells,
+		credential.Name,
+		credential.Labels[build.CredentialLabelKey],
+		credential.Annotations["build.knative.dev/docker-0"],
+		cli.FormatTimestampSince(credential.CreationTimestamp),
+	)
+	return []metav1beta1.TableRow{row}, nil
+}
+
+func printCredentialColumns() []metav1beta1.TableColumnDefinition {
+	return []metav1beta1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Type", Type: "string"},
+		{Name: "Registry", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
 }

--- a/pkg/riff/commands/credential_set_test.go
+++ b/pkg/riff/commands/credential_set_test.go
@@ -174,7 +174,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
 						},
@@ -195,7 +195,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "gcr"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://gcr.io",
 							"build.knative.dev/docker-1": "https://us.gcr.io",
@@ -230,7 +230,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryHost,
 						},
@@ -252,7 +252,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.dockerhub.io/projectriff",
 						},
@@ -269,7 +269,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryHost,
 						},
@@ -291,7 +291,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.dockerhub.io/projectriff",
 						},
@@ -320,7 +320,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryHost,
 						},
@@ -343,7 +343,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.dockerhub.io/projectriff",
 						},
@@ -363,7 +363,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "basic-auth"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": registryHost,
 						},
@@ -401,7 +401,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
 						},
@@ -431,7 +431,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "gcr"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://gcr.io",
 							"build.knative.dev/docker-1": "https://us.gcr.io",
@@ -483,7 +483,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
 						},
@@ -520,7 +520,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
 						},
@@ -546,7 +546,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
 						},
@@ -593,7 +593,7 @@ func TestCredentialSetCommand(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      credentialName,
 						Namespace: defaultNamespace,
-						Labels:    map[string]string{credentialLabel: ""},
+						Labels:    map[string]string{credentialLabel: "docker-hub"},
 						Annotations: map[string]string{
 							"build.knative.dev/docker-0": "https://index.docker.io/v1/",
 						},

--- a/pkg/riff/commands/function_list_test.go
+++ b/pkg/riff/commands/function_list_test.go
@@ -17,9 +17,7 @@
 package commands_test
 
 import (
-	"fmt"
-	"strings"
-
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/projectriff/riff/pkg/cli"
 	"github.com/projectriff/riff/pkg/riff/commands"
 	"github.com/projectriff/riff/pkg/testing"
@@ -67,16 +65,12 @@ func TestFunctionListCommand(t *testing.T) {
 			ShouldError: true,
 		},
 		{
-			Name: "empty",
-			Args: []string{},
-			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := output, "No functions found.\n"; actual != expected {
-					t.Errorf("expected output %q, actually %q", expected, actual)
-				}
-			},
+			Name:         "empty",
+			Args:         []string{},
+			ExpectOutput: "No functions found.\n",
 		},
 		{
-			Name: "lists a secret",
+			Name: "lists an item",
 			Args: []string{},
 			GivenObjects: []runtime.Object{
 				&buildv1alpha1.Function{
@@ -86,11 +80,10 @@ func TestFunctionListCommand(t *testing.T) {
 					},
 				},
 			},
-			Verify: func(t *testing.T, output string, err error) {
-				if actual, want := output, fmt.Sprintf("%s\n", functionName); actual != want {
-					t.Errorf("expected output %q, actually %q", want, actual)
-				}
-			},
+			ExpectOutput: `
+NAME            LATEST IMAGE   ARTIFACT   HANDLER   INVOKER   SUCCEEDED   AGE
+test-function   <empty>        <empty>    <empty>   <empty>   <unknown>   <unknown>
+`,
 		},
 		{
 			Name: "filters by namespace",
@@ -103,11 +96,7 @@ func TestFunctionListCommand(t *testing.T) {
 					},
 				},
 			},
-			Verify: func(t *testing.T, output string, err error) {
-				if actual, want := output, "No functions found.\n"; actual != want {
-					t.Errorf("expected output %q, actually %q", want, actual)
-				}
-			},
+			ExpectOutput: "No functions found.\n",
 		},
 		{
 			Name: "all namespace",
@@ -126,16 +115,42 @@ func TestFunctionListCommand(t *testing.T) {
 					},
 				},
 			},
-			Verify: func(t *testing.T, output string, err error) {
-				for _, expected := range []string{
-					fmt.Sprintf("%s\n", functionName),
-					fmt.Sprintf("%s\n", functionOtherName),
-				} {
-					if !strings.Contains(output, expected) {
-						t.Errorf("expected command output to contain %q, actually %q", expected, output)
-					}
-				}
+			ExpectOutput: `
+NAMESPACE         NAME                  LATEST IMAGE   ARTIFACT   HANDLER   INVOKER   SUCCEEDED   AGE
+default           test-function         <empty>        <empty>    <empty>   <empty>   <unknown>   <unknown>
+other-namespace   test-other-function   <empty>        <empty>    <empty>   <empty>   <unknown>   <unknown>
+`,
+		},
+		{
+			Name: "table populates all columns",
+			Args: []string{},
+			GivenObjects: []runtime.Object{
+				&buildv1alpha1.Function{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "upper",
+						Namespace: defaultNamespace,
+					},
+					Spec: buildv1alpha1.FunctionSpec{
+						Image:    "projectriff/upper",
+						Artifact: "uppercase.js",
+						Handler:  "functions.Uppercase",
+					},
+					Status: buildv1alpha1.FunctionStatus{
+						Status: duckv1alpha1.Status{
+							Conditions: []duckv1alpha1.Condition{
+								{Type: buildv1alpha1.FunctionConditionSucceeded, Status: "True"},
+							},
+						},
+						BuildStatus: buildv1alpha1.BuildStatus{
+							LatestImage: "projectriff/upper@sah256:abcdef1234",
+						},
+					},
+				},
 			},
+			ExpectOutput: `
+NAME    LATEST IMAGE                          ARTIFACT       HANDLER               INVOKER   SUCCEEDED   AGE
+upper   projectriff/upper@sah256:abcdef1234   uppercase.js   functions.Uppercase   <empty>   True        <unknown>
+`,
 		},
 		{
 			Name: "list error",

--- a/pkg/riff/commands/requestprocessor_list.go
+++ b/pkg/riff/commands/requestprocessor_list.go
@@ -21,8 +21,12 @@ import (
 	"fmt"
 
 	"github.com/projectriff/riff/pkg/cli"
+	"github.com/projectriff/riff/pkg/cli/printers"
+	requestv1alpha1 "github.com/projectriff/system/pkg/apis/request/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type RequestProcessorListOptions struct {
@@ -54,17 +58,95 @@ func NewRequestProcessorListCommand(c *cli.Config) *cobra.Command {
 
 			if len(requestprocessors.Items) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "No request processors found.")
-			}
-			for _, requestprocessor := range requestprocessors.Items {
-				// TODO pick a generic table formatter
-				fmt.Fprintln(cmd.OutOrStdout(), requestprocessor.Name)
+				return nil
 			}
 
-			return nil
+			tablePrinter := printers.NewTablePrinter(printers.PrintOptions{
+				WithNamespace: opts.AllNamespaces,
+			}).With(func(h printers.PrintHandler) {
+				columns := printRequestProcessorColumns()
+				h.TableHandler(columns, printRequestProcessorList)
+				h.TableHandler(columns, printRequestProcessor)
+			})
+
+			requestprocessors = requestprocessors.DeepCopy()
+			cli.SortByNamespaceAndName(requestprocessors.Items)
+
+			return tablePrinter.PrintObj(requestprocessors, cmd.OutOrStdout())
 		},
 	}
 
 	cli.AllNamespacesFlag(cmd, c, &opts.Namespace, &opts.AllNamespaces)
 
 	return cmd
+}
+
+func printRequestProcessorList(requestprocessors *requestv1alpha1.RequestProcessorList, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+	rows := make([]metav1beta1.TableRow, 0, len(requestprocessors.Items))
+	for i := range requestprocessors.Items {
+		r, err := printRequestProcessor(&requestprocessors.Items[i], opts)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+
+func printRequestProcessor(requestprocessor *requestv1alpha1.RequestProcessor, opts printers.PrintOptions) ([]metav1beta1.TableRow, error) {
+	row := metav1beta1.TableRow{
+		Object: runtime.RawExtension{Object: requestprocessor},
+	}
+	row.Cells = append(row.Cells,
+		requestprocessor.Name,
+		requestProcessorRefType(requestprocessor),
+		requestProcessorRef(requestprocessor),
+		cli.FormatEmptyString(requestprocessor.Status.Domain),
+		cli.FormatConditionStatus(requestprocessor.Status.GetCondition(requestv1alpha1.RequestProcessorConditionReady)),
+		cli.FormatTimestampSince(requestprocessor.CreationTimestamp),
+	)
+	return []metav1beta1.TableRow{row}, nil
+}
+
+func printRequestProcessorColumns() []metav1beta1.TableColumnDefinition {
+	return []metav1beta1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Type", Type: "string"},
+		{Name: "Ref", Type: "string"},
+		{Name: "Domain", Type: "string"},
+		{Name: "Ready", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
+}
+
+func requestProcessorRefType(requestprocessor *requestv1alpha1.RequestProcessor) string {
+	if len(requestprocessor.Spec) == 0 {
+		return "<unknown>"
+	}
+	if requestprocessor.Spec[0].Build == nil {
+		return "image"
+	}
+	if requestprocessor.Spec[0].Build.ApplicationRef != "" {
+		return "application"
+	}
+	if requestprocessor.Spec[0].Build.FunctionRef != "" {
+		return "function"
+	}
+	return "<unknown>"
+}
+
+func requestProcessorRef(requestprocessor *requestv1alpha1.RequestProcessor) string {
+	if len(requestprocessor.Spec) == 0 {
+		return "<unknown>"
+	}
+	if requestprocessor.Spec[0].Build == nil {
+		return requestprocessor.Spec[0].Template.Containers[0].Image
+	}
+	if requestprocessor.Spec[0].Build.ApplicationRef != "" {
+		return requestprocessor.Spec[0].Build.ApplicationRef
+	}
+	if requestprocessor.Spec[0].Build.FunctionRef != "" {
+		return requestprocessor.Spec[0].Build.FunctionRef
+	}
+	return requestprocessor.Spec[0].Template.Containers[0].Image
 }

--- a/pkg/testing/command_table.go
+++ b/pkg/testing/command_table.go
@@ -138,6 +138,10 @@ type CommandTableRecord struct {
 	// ShouldError indicates if the table record command execution should return an error. The
 	// test will fail if this value does not reflect the returned error.
 	ShouldError bool
+	// ExpectOutput performs a direct comparison of this content with the command's output showing
+	// a diff of any changes. The comparison is ignored for empty strings and ignores a leading
+	// new line.
+	ExpectOutput string
 	// Verify provides the command output and error for custom assertions.
 	Verify func(t *T, output string, err error)
 
@@ -341,6 +345,12 @@ func (ctr CommandTableRecord) Run(t *T, cmdFactory func(*cli.Config) *cobra.Comm
 		if actual, expected := len(actions.DeleteCollections), len(ctr.ExpectDeleteCollections); actual > expected {
 			for _, extra := range actions.DeleteCollections[expected:] {
 				t.Errorf("Extra delete-collection: %#v", extra)
+			}
+		}
+
+		if ctr.ExpectOutput != "" {
+			if diff := cmp.Diff(strings.TrimPrefix(ctr.ExpectOutput, "\n"), output.String()); diff != "" {
+				t.Errorf("Unexpected output (-expected, +actual): %s", diff)
 			}
 		}
 


### PR DESCRIPTION
Use k8s TablePrinter to define columns and map resource lists into table
rows. Each resource is able to have custom columns that are relevant to
that domain. While not exposed, the printer has the ability to render
other forms of output. The specific Printer type we use locally vendored
because it exists in k8s 1.15, but Knative requires us to compile to k8s
1.12 types.

A namespace column is added automatically for requests with
--all-namespaces. Rows are sorted by namespace then name for table
stability.

```
$ riff credential set sandbox --gcr ./token.json
Set credentials "sandbox"

$ riff credential list
NAME      TYPE   REGISTRY         AGE
sandbox   gcr    https://gcr.io   10s

$ riff function create upper --image gcr.io/<snip>/upper --git-repo https://github.com/projectriff/fats --sub-path functions/uppercase/node --artifact uppercase.js
Created function "upper"

$ riff function list
NAME    LATEST IMAGE   ARTIFACT       HANDLER   INVOKER   SUCCEEDED   AGE
upper   <empty>        uppercase.js   <empty>   <empty>   Unknown     9s

$ riff requestprocessor create upper --item main --function-ref upper
Created request processor "upper"

$ riff function list
NAME    LATEST IMAGE                                                                                  ARTIFACT       HANDLER   INVOKER   SUCCEEDED   AGE
upper   gcr.io/<snip>/upper@sha256:5ec77bbd711e3c1fbed8c2d999da0f3dc2403f5a685bbefc960987b372bef70c   uppercase.js   <empty>   <empty>   True        42s

$ riff requestprocessor list
NAME    TYPE       REF     DOMAIN                      READY   AGE
upper   function   upper   upper.default.example.com   True    19s
```