### PR TITLE
Backport default image prefix support

### DIFF
--- a/docs/riff_application_create.md
+++ b/docs/riff_application_create.md
@@ -24,7 +24,7 @@ riff application create my-app --image registry.example.com/image --local-path .
       --git-repo url           git url to remote source code
       --git-revision refspec   refspec within the git repo to checkout (default "master")
   -h, --help                   help for create
-      --image repository       repository where the built images are pushed
+      --image repository       repository where the built images are pushed (default "_")
       --local-path directory   path to directory containing source code on the local machine
   -n, --namespace name         kubernetes namespace (defaulted from kube config)
       --sub-path directory     path to directory within the git repo to checkout

--- a/docs/riff_credential_apply.md
+++ b/docs/riff_credential_apply.md
@@ -14,19 +14,24 @@ riff credential apply [flags]
 
 ```
 riff credential apply my-docker-hub-creds --docker-hub my-docker-id
+riff credential apply my-docker-hub-creds --docker-hub my-docker-id --set-default-image-prefix
 riff credential apply my-gcr-creds --gcr path/to/token.json
+riff credential apply my-gcr-creds --gcr path/to/token.json --set-default-image-prefix
 riff credential apply my-registry-creds --registry http://registry.example.com --registry-user my-username
+riff credential apply my-registry-creds --registry http://registry.example.com --registry-user my-username --default-image-prefix registry.example.com/my-username
 ```
 
 ### Options
 
 ```
-      --docker-hub username      Docker Hub username, the password must be provided via stdin
-      --gcr file                 path to Google Container Registry service account token file
-  -h, --help                     help for apply
-  -n, --namespace name           kubernetes namespace (defaulted from kube config)
-      --registry url             registry url
-      --registry-user username   username for a registry, the password must be provided via stdin
+      --default-image-prefix registry   use this registry as the default for built images, implies --set-default-image-prefix
+      --docker-hub username             Docker Hub username, the password must be provided via stdin
+      --gcr file                        path to Google Container Registry service account token file
+  -h, --help                            help for apply
+  -n, --namespace name                  kubernetes namespace (defaulted from kube config)
+      --registry url                    registry url
+      --registry-user username          username for a registry, the password must be provided via stdin
+      --set-default-image-prefix        use this registry as the default for built images
 ```
 
 ### Options inherited from parent commands

--- a/docs/riff_credential_apply.md
+++ b/docs/riff_credential_apply.md
@@ -24,14 +24,14 @@ riff credential apply my-registry-creds --registry http://registry.example.com -
 ### Options
 
 ```
-      --default-image-prefix registry   use this registry as the default for built images, implies --set-default-image-prefix
-      --docker-hub username             Docker Hub username, the password must be provided via stdin
-      --gcr file                        path to Google Container Registry service account token file
-  -h, --help                            help for apply
-  -n, --namespace name                  kubernetes namespace (defaulted from kube config)
-      --registry url                    registry url
-      --registry-user username          username for a registry, the password must be provided via stdin
-      --set-default-image-prefix        use this registry as the default for built images
+      --default-image-prefix repository   default repository prefix for built images, implies --set-default-image-prefix
+      --docker-hub username               Docker Hub username, the password must be provided via stdin
+      --gcr file                          path to Google Container Registry service account token file
+  -h, --help                              help for apply
+  -n, --namespace name                    kubernetes namespace (defaulted from kube config)
+      --registry url                      registry url
+      --registry-user username            username for a registry, the password must be provided via stdin
+      --set-default-image-prefix          use this registry as the default for built images
 ```
 
 ### Options inherited from parent commands

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -26,7 +26,7 @@ riff function create my-func --image registry.example.com/image --local-path ./m
       --git-revision refspec   refspec within the git repo to checkout (default "master")
       --handler name           name of the method or class to invoke, depends on the invoker (detected by default)
   -h, --help                   help for create
-      --image repository       repository where the built images are pushed
+      --image repository       repository where the built images are pushed (default "_")
       --invoker name           language runtime invoker name (detected by default)
       --local-path directory   path to directory containing source code on the local machine
   -n, --namespace name         kubernetes namespace (defaulted from kube config)

--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,5 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20190502190224-411b2483e503 // indirect
 )
+
+replace github.com/projectriff/system => github.com/scothis/system v0.0.0-20190524145535-d6ef5f49dc76

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectriff/system v0.0.0-20190520215811-c1726686672a h1:vvrojxgk8fMEVaqKUcZQeU0OlOCRkEYLtxjc02g8M8c=
-github.com/projectriff/system v0.0.0-20190520215811-c1726686672a/go.mod h1:C2DnqACuw6IrFJudIGhETAlqBkF2KVyKj24VedxZxq0=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -243,6 +241,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sclevine/spec v1.2.0 h1:1Jwdf9jSfDl9NVmt8ndHqbTZ7XCCPbh1jI3hkDBHVYA=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/scothis/system v0.0.0-20190524145535-d6ef5f49dc76 h1:Bc+KcDEBzG7bmpARfjcQ4ewBjZ7IcWB6+gfmtC0m7D8=
+github.com/scothis/system v0.0.0-20190524145535-d6ef5f49dc76/go.mod h1:rpYGchushJTA5WGX2kh92XyDNVcGSkfcZcNoVGnWXao=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -29,6 +29,7 @@ const (
 	ArtifactFlagName              = "--artifact"
 	CacheSizeFlagName             = "--cache-size"
 	ConfigFlagName                = "--config"
+	DefaultImagePrefixFlagName    = "--default-image-prefix"
 	DirectoryFlagName             = "--directory"
 	DockerHubFlagName             = "--docker-hub"
 	EnvFlagName                   = "--env"

--- a/pkg/riff/commands/application_create.go
+++ b/pkg/riff/commands/application_create.go
@@ -107,8 +107,19 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 		}
 	}
 	if opts.LocalPath != "" {
+		targetImage := opts.Image
+		if strings.HasPrefix(targetImage, "_") {
+			riffBuildConfig, err := c.Core().ConfigMaps(application.Namespace).Get("riff-build", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			targetImage, err = buildv1alpha1.ResolveDefaultImage(application, riffBuildConfig.Data["default-image-prefix"])
+			if err != nil {
+				return err
+			}
+		}
 		err := c.Pack.Build(ctx, pack.BuildOptions{
-			Image:  opts.Image,
+			Image:  targetImage,
 			AppDir: opts.LocalPath,
 			// TODO lookup builder from ClusterBuildTemplate/cf-cnb
 			Builder: "cloudfoundry/cnb:bionic",
@@ -148,7 +159,7 @@ func NewApplicationCreateCommand(c *cli.Config) *cobra.Command {
 	}
 
 	cli.NamespaceFlag(cmd, c, &opts.Namespace)
-	cmd.Flags().StringVar(&opts.Image, cli.StripDash(cli.ImageFlagName), "", "`repository` where the built images are pushed")
+	cmd.Flags().StringVar(&opts.Image, cli.StripDash(cli.ImageFlagName), "_", "`repository` where the built images are pushed")
 	cmd.Flags().StringVar(&opts.CacheSize, cli.StripDash(cli.CacheSizeFlagName), "", "`size` of persistent volume to cache resources between builds")
 	cmd.Flags().StringVar(&opts.LocalPath, cli.StripDash(cli.LocalPathFlagName), "", "path to `directory` containing source code on the local machine")
 	cmd.Flags().StringVar(&opts.GitRepo, cli.StripDash(cli.GitRepoFlagName), "", "git `url` to remote source code")

--- a/pkg/riff/commands/credential_apply.go
+++ b/pkg/riff/commands/credential_apply.go
@@ -162,7 +162,7 @@ func NewCredentialApplyCommand(c *cli.Config) *cobra.Command {
 	cmd.Flags().StringVar(&opts.GcrTokenPath, cli.StripDash(cli.GcrFlagName), "", "path to Google Container Registry service account token `file`")
 	cmd.Flags().StringVar(&opts.Registry, cli.StripDash(cli.RegistryFlagName), "", "registry `url`")
 	cmd.Flags().StringVar(&opts.RegistryUser, cli.StripDash(cli.RegistryUserFlagName), "", "`username` for a registry, the password must be provided via stdin")
-	cmd.Flags().StringVar(&opts.DefaultImagePrefix, cli.StripDash(cli.DefaultImagePrefixFlagName), "", fmt.Sprintf("use this `registry` as the default for built images, implies %s", cli.SetDefaultImagePrefixFlagName))
+	cmd.Flags().StringVar(&opts.DefaultImagePrefix, cli.StripDash(cli.DefaultImagePrefixFlagName), "", fmt.Sprintf("default `repository` prefix for built images, implies %s", cli.SetDefaultImagePrefixFlagName))
 	cmd.Flags().BoolVar(&opts.SetDefaultImagePrefix, cli.StripDash(cli.SetDefaultImagePrefixFlagName), false, "use this registry as the default for built images")
 
 	return cmd


### PR DESCRIPTION
The --image flag is now optional for applications and functions. The
default value is `_`, which applies the configured default prefix
with the application/function's name. A custom repo or tag can be
specified like `_/repo:tag`.

For in-cluser builds this resolution occurs in the reconciler. For local
builds, it occurs within the CLI. In both cases, the resolution logic is
defined within projectriff/system.

Depends on https://github.com/projectriff/system/pull/21