### PR TITLE
Normalize READY/SUCCEEDED columns in listings

### DIFF
--- a/pkg/cli/format.go
+++ b/pkg/cli/format.go
@@ -45,17 +45,31 @@ func FormatConditionStatus(cond *duckv1alpha1.Condition) string {
 	status := string(cond.Status)
 	switch status {
 	case "True":
-		return Ssuccessf(status)
+		return Ssuccessf(string(cond.Type))
 	case "False":
-		return Serrorf(status)
+		if cond.Reason == "" {
+			// display something if there is no reason
+			return Serrorf("not-" + string(cond.Type))
+		}
+		return Serrorf(cond.Reason)
 	default:
 		return Sinfof(status)
 	}
 }
 
 func FormatConditionMessage(cond *duckv1alpha1.Condition) string {
-	if cond == nil {
+	switch {
+	case cond == nil:
 		return Swarnf("<unknown>")
+	case cond.Message == "":
+		return FormatEmptyString(cond.Message)
+	case cond.IsFalse():
+		return Serrorf(cond.Message)
+	case cond.IsTrue():
+		return Ssuccessf(cond.Message)
+	case cond.IsUnknown():
+		return Sinfof(cond.Message)
+	default:
+		return Swarnf(cond.Message)
 	}
-	return FormatEmptyString(cond.Message)
 }

--- a/pkg/riff/commands/application_list.go
+++ b/pkg/riff/commands/application_list.go
@@ -119,7 +119,7 @@ func printApplicationColumns() []metav1beta1.TableColumnDefinition {
 	return []metav1beta1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "Latest Image", Type: "string"},
-		{Name: "Succeeded", Type: "string"},
+		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}
 }

--- a/pkg/riff/commands/application_list_test.go
+++ b/pkg/riff/commands/application_list_test.go
@@ -85,7 +85,7 @@ No applications found.
 				},
 			},
 			ExpectOutput: `
-NAME               LATEST IMAGE   SUCCEEDED   AGE
+NAME               LATEST IMAGE   STATUS      AGE
 test-application   <empty>        <unknown>   <unknown>
 `,
 		},
@@ -122,7 +122,7 @@ No applications found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                     LATEST IMAGE   SUCCEEDED   AGE
+NAMESPACE         NAME                     LATEST IMAGE   STATUS      AGE
 default           test-application         <empty>        <unknown>   <unknown>
 other-namespace   test-other-application   <empty>        <unknown>   <unknown>
 `,
@@ -152,8 +152,8 @@ other-namespace   test-other-application   <empty>        <unknown>   <unknown>
 				},
 			},
 			ExpectOutput: `
-NAME        LATEST IMAGE                              SUCCEEDED   AGE
-petclinic   projectriff/petclinic@sah256:abcdef1234   True        <unknown>
+NAME        LATEST IMAGE                              STATUS      AGE
+petclinic   projectriff/petclinic@sah256:abcdef1234   Succeeded   <unknown>
 `,
 		},
 		{

--- a/pkg/riff/commands/function_list.go
+++ b/pkg/riff/commands/function_list.go
@@ -125,7 +125,7 @@ func printFunctionColumns() []metav1beta1.TableColumnDefinition {
 		{Name: "Artifact", Type: "string"},
 		{Name: "Handler", Type: "string"},
 		{Name: "Invoker", Type: "string"},
-		{Name: "Succeeded", Type: "string"},
+		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}
 }

--- a/pkg/riff/commands/function_list_test.go
+++ b/pkg/riff/commands/function_list_test.go
@@ -85,7 +85,7 @@ No functions found.
 				},
 			},
 			ExpectOutput: `
-NAME            LATEST IMAGE   ARTIFACT   HANDLER   INVOKER   SUCCEEDED   AGE
+NAME            LATEST IMAGE   ARTIFACT   HANDLER   INVOKER   STATUS      AGE
 test-function   <empty>        <empty>    <empty>   <empty>   <unknown>   <unknown>
 `,
 		},
@@ -122,7 +122,7 @@ No functions found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                  LATEST IMAGE   ARTIFACT   HANDLER   INVOKER   SUCCEEDED   AGE
+NAMESPACE         NAME                  LATEST IMAGE   ARTIFACT   HANDLER   INVOKER   STATUS      AGE
 default           test-function         <empty>        <empty>    <empty>   <empty>   <unknown>   <unknown>
 other-namespace   test-other-function   <empty>        <empty>    <empty>   <empty>   <unknown>   <unknown>
 `,
@@ -154,8 +154,8 @@ other-namespace   test-other-function   <empty>        <empty>    <empty>   <emp
 				},
 			},
 			ExpectOutput: `
-NAME    LATEST IMAGE                          ARTIFACT       HANDLER               INVOKER   SUCCEEDED   AGE
-upper   projectriff/upper@sah256:abcdef1234   uppercase.js   functions.Uppercase   <empty>   True        <unknown>
+NAME    LATEST IMAGE                          ARTIFACT       HANDLER               INVOKER   STATUS      AGE
+upper   projectriff/upper@sah256:abcdef1234   uppercase.js   functions.Uppercase   <empty>   Succeeded   <unknown>
 `,
 		},
 		{

--- a/pkg/riff/commands/handler_list.go
+++ b/pkg/riff/commands/handler_list.go
@@ -124,7 +124,7 @@ func printHandlerColumns() []metav1beta1.TableColumnDefinition {
 		{Name: "Type", Type: "string"},
 		{Name: "Ref", Type: "string"},
 		{Name: "Domain", Type: "string"},
-		{Name: "Ready", Type: "string"},
+		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}
 }

--- a/pkg/riff/commands/handler_list_test.go
+++ b/pkg/riff/commands/handler_list_test.go
@@ -86,7 +86,7 @@ No handlers found.
 				},
 			},
 			ExpectOutput: `
-NAME           TYPE        REF         DOMAIN    READY       AGE
+NAME           TYPE        REF         DOMAIN    STATUS      AGE
 test-handler   <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 `,
 		},
@@ -123,7 +123,7 @@ No handlers found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                 TYPE        REF         DOMAIN    READY       AGE
+NAMESPACE         NAME                 TYPE        REF         DOMAIN    STATUS      AGE
 default           test-handler         <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 other-namespace   test-other-handler   <unknown>   <unknown>   <empty>   <unknown>   <unknown>
 `,
@@ -189,10 +189,10 @@ other-namespace   test-other-handler   <unknown>   <unknown>   <empty>   <unknow
 				},
 			},
 			ExpectOutput: `
-NAME   TYPE          REF                 DOMAIN                      READY   AGE
-app    application   petclinic           app.default.example.com     True    <unknown>
-func   function      square              func.default.example.com    True    <unknown>
-img    image         projectriff/upper   image.default.example.com   True    <unknown>
+NAME   TYPE          REF                 DOMAIN                      STATUS   AGE
+app    application   petclinic           app.default.example.com     Ready    <unknown>
+func   function      square              func.default.example.com    Ready    <unknown>
+img    image         projectriff/upper   image.default.example.com   Ready    <unknown>
 `,
 		},
 		{

--- a/pkg/riff/commands/processor_list.go
+++ b/pkg/riff/commands/processor_list.go
@@ -123,7 +123,7 @@ func printProcessorColumns() []metav1beta1.TableColumnDefinition {
 		{Name: "Function", Type: "string"},
 		{Name: "Inputs", Type: "string"},
 		{Name: "Outputs", Type: "string"},
-		{Name: "Ready", Type: "string"},
+		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}
 }

--- a/pkg/riff/commands/processor_list_test.go
+++ b/pkg/riff/commands/processor_list_test.go
@@ -85,7 +85,7 @@ No processors found.
 				},
 			},
 			ExpectOutput: `
-NAME             FUNCTION   INPUTS    OUTPUTS   READY       AGE
+NAME             FUNCTION   INPUTS    OUTPUTS   STATUS      AGE
 test-processor   <empty>    <empty>   <empty>   <unknown>   <unknown>
 `,
 		},
@@ -122,7 +122,7 @@ No processors found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                   FUNCTION   INPUTS    OUTPUTS   READY       AGE
+NAMESPACE         NAME                   FUNCTION   INPUTS    OUTPUTS   STATUS      AGE
 default           test-processor         <empty>    <empty>   <empty>   <unknown>   <unknown>
 other-namespace   test-other-processor   <empty>    <empty>   <empty>   <unknown>   <unknown>
 `,
@@ -151,8 +151,8 @@ other-namespace   test-other-processor   <empty>    <empty>   <empty>   <unknown
 				},
 			},
 			ExpectOutput: `
-NAME     FUNCTION   INPUTS                OUTPUTS   READY   AGE
-square   square     numbers,morenumbers   squares   True    <unknown>
+NAME     FUNCTION   INPUTS                OUTPUTS   STATUS   AGE
+square   square     numbers,morenumbers   squares   Ready    <unknown>
 `,
 		},
 		{

--- a/pkg/riff/commands/stream_list.go
+++ b/pkg/riff/commands/stream_list.go
@@ -123,7 +123,7 @@ func printStreamColumns() []metav1beta1.TableColumnDefinition {
 		{Name: "Topic", Type: "string"},
 		{Name: "Gateway", Type: "string"},
 		{Name: "Provider", Type: "string"},
-		{Name: "Ready", Type: "string"},
+		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}
 }

--- a/pkg/riff/commands/stream_list_test.go
+++ b/pkg/riff/commands/stream_list_test.go
@@ -85,7 +85,7 @@ No streams found.
 				},
 			},
 			ExpectOutput: `
-NAME          TOPIC     GATEWAY   PROVIDER   READY       AGE
+NAME          TOPIC     GATEWAY   PROVIDER   STATUS      AGE
 test-stream   <empty>   <empty>   <empty>    <unknown>   <unknown>
 `,
 		},
@@ -122,7 +122,7 @@ No streams found.
 				},
 			},
 			ExpectOutput: `
-NAMESPACE         NAME                TOPIC     GATEWAY   PROVIDER   READY       AGE
+NAMESPACE         NAME                TOPIC     GATEWAY   PROVIDER   STATUS      AGE
 default           test-stream         <empty>   <empty>   <empty>    <unknown>   <unknown>
 other-namespace   test-other-stream   <empty>   <empty>   <empty>    <unknown>   <unknown>
 `,
@@ -153,8 +153,8 @@ other-namespace   test-other-stream   <empty>   <empty>   <empty>    <unknown>  
 				},
 			},
 			ExpectOutput: `
-NAME    TOPIC   GATEWAY             PROVIDER   READY   AGE
-words   words   test-gateway:1234   kafka      True    <unknown>
+NAME    TOPIC   GATEWAY             PROVIDER   STATUS   AGE
+words   words   test-gateway:1234   kafka      Ready    <unknown>
 `,
 		},
 		{


### PR DESCRIPTION
The READY and SUCCEEDED columns are now a uniform STATUS column, the
value within the column is no longer "True", but "Ready" or "Succeeded"
depending on the condition type.

If the condition is false, the reason is printed as an error.