### PR TITLE
clean without error when ./riff is not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: build test docs
 
 .PHONY: clean
 clean:
-	rm riff
+	rm -f $(OUTPUT)
 	rm -f riff-darwin-amd64.tgz
 	rm -f riff-linux-amd64.tgz
 	rm -f riff-windows-amd64.zip


### PR DESCRIPTION
Fixes error below when using `make clean` before `./riff` exists.

```
$ make clean
rm riff
rm: riff: No such file or directory
make: *** [clean] Error 1
```