### PR TITLE
Backport CI artifact publishing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,3 +19,27 @@ jobs:
   steps:
   - template: ci/unit-test-steps.yml
   displayName: 'Unit test'
+
+- job: publish
+  dependsOn: unit
+  pool:
+    vmImage: ubuntu-16.04
+  condition: |
+    and(
+      succeeded(),
+      ne(variables['Build.Reason'], 'PullRequest'),
+      or(
+        eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+        and(
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/v'),
+          endsWith(variables['Build.SourceBranch'], 'x')
+        )
+      )
+    )
+  steps:
+  - template: ci/install-gcloud.yml
+  - bash: ./ci/publish.sh $(Build.SourceBranchName)
+    env:
+      GCLOUD_CLIENT_SECRET: '$(GcloudClientSecret)'
+    displayName: 'Publish riff release artifacts'
+  displayName: 'Publish'

--- a/ci/install-gcloud.yml
+++ b/ci/install-gcloud.yml
@@ -1,0 +1,8 @@
+steps:
+- bash: |
+    # from https://cloud.google.com/sdk/docs/downloads-apt-get
+    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    sudo apt-get update && sudo apt-get install google-cloud-sdk
+  displayName: 'Install gcloud'

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version=`cat VERSION`
+commit=$(git rev-parse HEAD)
+branch="${1:-}"
+
+gcloud auth activate-service-account --key-file <(echo $GCLOUD_CLIENT_SECRET | base64 --decode)
+
+bucket=gs://projectriff/riff-cli/releases
+
+gsutil rsync -a public-read -d ${bucket}/builds/v${version}-${commit} ${bucket}/v${version}
+if [[ "$branch" == "master" ]]; then
+  gsutil rsync -a public-read -d ${bucket}/builds/v${version}-${commit} ${bucket}/latest
+fi


### PR DESCRIPTION
changes from v0.3.0:
- publish depends directly on unit since there are no fats test (yet)
- TRAVIS_BRANCH has been removed in favor of an argument