### PR TITLE
Wait 10 mins for a new resource to become ready

### DIFF
--- a/docs/riff_application_create.md
+++ b/docs/riff_application_create.md
@@ -20,15 +20,16 @@ riff application create my-app --image registry.example.com/image --local-path .
 ### Options
 
 ```
-      --cache-size size        size of persistent volume to cache resources between builds
-      --git-repo url           git url to remote source code
-      --git-revision refspec   refspec within the git repo to checkout (default "master")
-  -h, --help                   help for create
-      --image repository       repository where the built images are pushed (default "_")
-      --local-path directory   path to directory containing source code on the local machine
-  -n, --namespace name         kubernetes namespace (defaulted from kube config)
-      --sub-path directory     path to directory within the git repo to checkout
-      --tail                   watch build logs
+      --cache-size size         size of persistent volume to cache resources between builds
+      --git-repo url            git url to remote source code
+      --git-revision refspec    refspec within the git repo to checkout (default "master")
+  -h, --help                    help for create
+      --image repository        repository where the built images are pushed (default "_")
+      --local-path directory    path to directory containing source code on the local machine
+  -n, --namespace name          kubernetes namespace (defaulted from kube config)
+      --sub-path directory      path to directory within the git repo to checkout
+      --tail                    watch build logs
+      --wait-timeout duration   duration to wait for the application to become ready when watching logs (default "10m")
 ```
 
 ### Options inherited from parent commands

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -20,18 +20,19 @@ riff function create my-func --image registry.example.com/image --local-path ./m
 ### Options
 
 ```
-      --artifact file          file containing the function within the build workspace (detected by default)
-      --cache-size size        size of persistent volume to cache resources between builds
-      --git-repo url           git url to remote source code
-      --git-revision refspec   refspec within the git repo to checkout (default "master")
-      --handler name           name of the method or class to invoke, depends on the invoker (detected by default)
-  -h, --help                   help for create
-      --image repository       repository where the built images are pushed (default "_")
-      --invoker name           language runtime invoker name (detected by default)
-      --local-path directory   path to directory containing source code on the local machine
-  -n, --namespace name         kubernetes namespace (defaulted from kube config)
-      --sub-path directory     path to directory within the git repo to checkout
-      --tail                   watch build logs
+      --artifact file           file containing the function within the build workspace (detected by default)
+      --cache-size size         size of persistent volume to cache resources between builds
+      --git-repo url            git url to remote source code
+      --git-revision refspec    refspec within the git repo to checkout (default "master")
+      --handler name            name of the method or class to invoke, depends on the invoker (detected by default)
+  -h, --help                    help for create
+      --image repository        repository where the built images are pushed (default "_")
+      --invoker name            language runtime invoker name (detected by default)
+      --local-path directory    path to directory containing source code on the local machine
+  -n, --namespace name          kubernetes namespace (defaulted from kube config)
+      --sub-path directory      path to directory within the git repo to checkout
+      --tail                    watch build logs
+      --wait-timeout duration   duration to wait for the function to become ready when watching logs (default "10m")
 ```
 
 ### Options inherited from parent commands

--- a/docs/riff_handler_create.md
+++ b/docs/riff_handler_create.md
@@ -21,14 +21,15 @@ riff handler create my-image-handler --image registry.example.com/my-image:lates
 ### Options
 
 ```
-      --application-ref name   name of application to deploy
-      --env variable           environment variable defined as a key value pair separated by an equals sign, example "--env MY_VAR=my-value" (may be set multiple times)
-      --env-from variable      environment variable from a config map or secret, example "--env-from MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", "--env-from MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map" (may be set multiple times)
-      --function-ref name      name of function to deploy
-  -h, --help                   help for create
-      --image image            container image to deploy
-  -n, --namespace name         kubernetes namespace (defaulted from kube config)
-      --tail                   watch handler logs
+      --application-ref name    name of application to deploy
+      --env variable            environment variable defined as a key value pair separated by an equals sign, example "--env MY_VAR=my-value" (may be set multiple times)
+      --env-from variable       environment variable from a config map or secret, example "--env-from MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", "--env-from MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map" (may be set multiple times)
+      --function-ref name       name of function to deploy
+  -h, --help                    help for create
+      --image image             container image to deploy
+  -n, --namespace name          kubernetes namespace (defaulted from kube config)
+      --tail                    watch handler logs
+      --wait-timeout duration   duration to wait for the handler to become ready when watching logs (default "10m")
 ```
 
 ### Options inherited from parent commands

--- a/docs/riff_processor_create.md
+++ b/docs/riff_processor_create.md
@@ -20,12 +20,13 @@ riff processor create my-processor --function-ref my-func --input my-input-strea
 ### Options
 
 ```
-      --function-ref name   name of function build to deploy
-  -h, --help                help for create
-      --input name          name of stream to read messages from (may be set multiple times)
-  -n, --namespace name      kubernetes namespace (defaulted from kube config)
-      --output name         name of stream to write messages to (may be set multiple times)
-      --tail                watch processor logs
+      --function-ref name       name of function build to deploy
+  -h, --help                    help for create
+      --input name              name of stream to read messages from (may be set multiple times)
+  -n, --namespace name          kubernetes namespace (defaulted from kube config)
+      --output name             name of stream to write messages to (may be set multiple times)
+      --tail                    watch processor logs
+      --wait-timeout duration   duration to wait for the processor to become ready when watching logs (default "10m")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -57,6 +57,7 @@ const (
 	SubPathFlagName               = "--sub-path"
 	TailFlagName                  = "--tail"
 	TextFlagName                  = "--text"
+	WaitTimeoutFlagName           = "--wait-timeout"
 )
 
 func AllNamespacesFlag(cmd *cobra.Command, c *Config, namespace *string, allNamespaces *bool) {

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -25,11 +25,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	watchclient "k8s.io/client-go/tools/watch"
 )
+
+var ErrWaitTimeout = wait.ErrWaitTimeout
 
 type object interface {
 	runtime.Object

--- a/pkg/riff/commands/function_create_test.go
+++ b/pkg/riff/commands/function_create_test.go
@@ -17,11 +17,14 @@
 package commands_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/buildpack/pack"
 	"github.com/projectriff/riff/pkg/cli"
+	"github.com/projectriff/riff/pkg/k8s"
 	"github.com/projectriff/riff/pkg/riff/commands"
 	rifftesting "github.com/projectriff/riff/pkg/testing"
 	kailtesting "github.com/projectriff/riff/pkg/testing/kail"
@@ -146,6 +149,41 @@ func TestFunctionCreateOptions(t *testing.T) {
 				GitRevision:     "",
 			},
 			ExpectFieldError: cli.ErrMissingField(cli.GitRevisionFlagName),
+		},
+		{
+			Name: "git source, tail",
+			Options: &commands.FunctionCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				GitRepo:         "https://example.com/repo.git",
+				GitRevision:     "master",
+				Tail:            true,
+				WaitTimeout:     "10m",
+			},
+			ShouldValidate: true,
+		},
+		{
+			Name: "git source, tail missing timeout",
+			Options: &commands.FunctionCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				GitRepo:         "https://example.com/repo.git",
+				GitRevision:     "master",
+				Tail:            true,
+			},
+			ExpectFieldError: cli.ErrMissingField(cli.WaitTimeoutFlagName),
+		},
+		{
+			Name: "git source, tail invalid timeout",
+			Options: &commands.FunctionCreateOptions{
+				ResourceOptions: rifftesting.ValidResourceOptions,
+				Image:           "example.com/repo:tag",
+				GitRepo:         "https://example.com/repo.git",
+				GitRevision:     "master",
+				Tail:            true,
+				WaitTimeout:     "d",
+			},
+			ExpectFieldError: cli.ErrInvalidValue("d", cli.WaitTimeoutFlagName),
 		},
 	}
 
@@ -592,6 +630,67 @@ Created function "my-function"
 Created function "my-function"
 ...log output...
 `,
+		},
+		{
+			Name: "tail timeout",
+			Args: []string{functionName, cli.ImageFlagName, imageTag, cli.GitRepoFlagName, gitRepo, cli.TailFlagName, cli.WaitTimeoutFlagName, "1ms"},
+			Prepare: func(t *testing.T, c *cli.Config) error {
+				kail := &kailtesting.Logger{}
+				c.Kail = kail
+				kail.On("FunctionLogs", mock.Anything, &buildv1alpha1.Function{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      functionName,
+					},
+					Spec: buildv1alpha1.FunctionSpec{
+						Image: imageTag,
+						Source: &buildv1alpha1.Source{
+							Git: &buildv1alpha1.GitSource{
+								URL:      gitRepo,
+								Revision: gitMaster,
+							},
+						},
+					},
+				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
+					ctx := args[0].(context.Context)
+					fmt.Fprintf(c.Stdout, "...log output...\n")
+					// wait for context to be cancelled, plus some fudge
+					<-ctx.Done()
+					time.Sleep(2 * time.Millisecond)
+				})
+				return nil
+			},
+			CleanUp: func(t *testing.T, c *cli.Config) error {
+				kail := c.Kail.(*kailtesting.Logger)
+				kail.AssertExpectations(t)
+				return nil
+			},
+			ExpectCreates: []runtime.Object{
+				&buildv1alpha1.Function{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      functionName,
+					},
+					Spec: buildv1alpha1.FunctionSpec{
+						Image: imageTag,
+						Source: &buildv1alpha1.Source{
+							Git: &buildv1alpha1.GitSource{
+								URL:      gitRepo,
+								Revision: gitMaster,
+							},
+						},
+					},
+				},
+			},
+			ExpectOutput: `
+Created function "my-function"
+...log output...
+Timeout after "1ms" waiting for "my-function" to become ready
+To view status run: riff function list --namespace default
+To continue watching logs run: riff function tail my-function --namespace default
+Error: timed out waiting for the condition
+`,
+			ShouldError: true,
 		},
 		{
 			Name: "tail error",


### PR DESCRIPTION
By default, wait 10 minutes for a created resource to become ready. This
value can be overridden with the --wait-timeout flag. When a timeout
occurs the user is given commands to check the resource status and
continue watching logs.