### PR TITLE
Reduce test flakes

### DIFF
--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -60,7 +60,7 @@ travis_fold end system-install
 # run test functions
 source $fats_dir/functions/helpers.sh
 
-for test in java java-boot node npm command; do
+for test in command; do
   path=${fats_dir}/functions/uppercase/${test}
   function_name=fats-cluster-uppercase-${test}
   image=$(fats_image_repo ${function_name})
@@ -72,7 +72,7 @@ for test in java java-boot node npm command; do
 done
 
 if [ "$machine" != "MinGw" ]; then
-  for test in node command; do
+  for test in command; do
     path=${fats_dir}/functions/uppercase/${test}
     function_name=fats-local-uppercase-${test}
     image=$(fats_image_repo ${function_name})

--- a/pkg/riff/commands/application_create_test.go
+++ b/pkg/riff/commands/application_create_test.go
@@ -19,6 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -667,17 +668,27 @@ Created application "my-application"
 					},
 				},
 			},
-			ExpectOutput: `
-Created application "my-application"
-...log output...
-Timeout after "1ms" waiting for "my-application" to become ready
-To view status run: riff application list --namespace default
-To continue watching logs run: riff application tail my-application --namespace default
-`,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
 				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
 					t.Errorf("expected error %q, actual %q", expected, actual)
+				}
+				for _, line := range []string{
+					`
+Created application "my-application"
+`,
+					`
+...log output...
+`,
+					`
+Timeout after "1ms" waiting for "my-application" to become ready
+To view status run: riff application list --namespace default
+To continue watching logs run: riff application tail my-application --namespace default
+`,
+				} {
+					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
+						t.Errorf("expected output to contain %q, actual %q", expected, actual)
+					}
 				}
 			},
 		},

--- a/pkg/riff/commands/function_create_test.go
+++ b/pkg/riff/commands/function_create_test.go
@@ -19,6 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -694,17 +695,27 @@ Created function "my-function"
 					},
 				},
 			},
-			ExpectOutput: `
-Created function "my-function"
-...log output...
-Timeout after "1ms" waiting for "my-function" to become ready
-To view status run: riff function list --namespace default
-To continue watching logs run: riff function tail my-function --namespace default
-`,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
 				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
 					t.Errorf("expected error %q, actual %q", expected, actual)
+				}
+				for _, line := range []string{
+					`
+Created function "my-function"
+`,
+					`
+...log output...
+`,
+					`
+Timeout after "1ms" waiting for "my-function" to become ready
+To view status run: riff function list --namespace default
+To continue watching logs run: riff function tail my-function --namespace default
+`,
+				} {
+					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
+						t.Errorf("expected output to contain %q, actual %q", expected, actual)
+					}
 				}
 			},
 		},

--- a/pkg/riff/commands/handler_create_test.go
+++ b/pkg/riff/commands/handler_create_test.go
@@ -19,6 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -440,6 +441,23 @@ To continue watching logs run: riff handler tail my-handler --namespace default
 			Verify: func(t *testing.T, output string, err error) {
 				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
 					t.Errorf("expected error %q, actual %q", expected, actual)
+				}
+				for _, line := range []string{
+					`
+Created handler "my-handler"
+`,
+					`
+...log output...
+`,
+					`
+Timeout after "1ms" waiting for "my-handler" to become ready
+To view status run: riff handler list --namespace default
+To continue watching logs run: riff handler tail my-handler --namespace default
+`,
+				} {
+					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
+						t.Errorf("expected output to contain %q, actual %q", expected, actual)
+					}
 				}
 			},
 		},

--- a/pkg/riff/commands/processor_create_test.go
+++ b/pkg/riff/commands/processor_create_test.go
@@ -19,6 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -326,17 +327,27 @@ Created processor "my-processor"
 					},
 				},
 			},
-			ExpectOutput: `
-Created processor "my-processor"
-...log output...
-Timeout after "1ms" waiting for "my-processor" to become ready
-To view status run: riff processor list --namespace default
-To continue watching logs run: riff processor tail my-processor --namespace default
-`,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
 				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
 					t.Errorf("expected error %q, actual %q", expected, actual)
+				}
+				for _, line := range []string{
+					`
+Created processor "my-processor"
+`,
+					`
+...log output...
+`,
+					`
+Timeout after "1ms" waiting for "my-processor" to become ready
+To view status run: riff processor list --namespace default
+To continue watching logs run: riff processor tail my-processor --namespace default
+`,
+				} {
+					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
+						t.Errorf("expected output to contain %q, actual %q", expected, actual)
+					}
 				}
 			},
 		},


### PR DESCRIPTION
- only run command function, other languages are tested as part of
  creating the builder image and creating the bundle
- assert chucks of output for racy commands. Logs are emitted from
  different goroutines. For real commands enough wall time will have
  elapsed to make race meaningless