### PR TITLE
Properly control flow waiting for a resource to become ready

### DIFF
--- a/cmd/riff/main.go
+++ b/cmd/riff/main.go
@@ -34,10 +34,14 @@ func main() {
 
 	cmd.SilenceErrors = true
 	if err := cmd.Execute(); err != nil {
-		c.Errorf("Error executing command:\n")
-		// errors can be multiple lines, indent each line
-		for _, line := range strings.Split(err.Error(), "\n") {
-			c.Errorf("  %s\n", line)
+		// silent errors should not log, but still exit with an error code
+		// typically the command has already been logged with more detail
+		if err != cli.ErrSilent {
+			c.Errorf("Error executing command:\n")
+			// errors can be multiple lines, indent each line
+			for _, line := range strings.Split(err.Error(), "\n") {
+				c.Errorf("  %s\n", line)
+			}
 		}
 		os.Exit(1)
 	}

--- a/cmd/riff/main.go
+++ b/cmd/riff/main.go
@@ -36,7 +36,7 @@ func main() {
 	if err := cmd.Execute(); err != nil {
 		// silent errors should not log, but still exit with an error code
 		// typically the command has already been logged with more detail
-		if err != cli.ErrSilent {
+		if !cli.IsSilent(err) {
 			c.Errorf("Error executing command:\n")
 			// errors can be multiple lines, indent each line
 			for _, line := range strings.Split(err.Error(), "\n") {

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -16,28 +16,8 @@
 
 package cli
 
-var (
-	cli_name     = "riff"
-	cli_version  = "unknown"
-	cli_gitsha   = "unknown sha"
-	cli_gitdirty = ""
+import (
+	"errors"
 )
 
-type CompiledEnv struct {
-	Name     string
-	Version  string
-	GitSha   string
-	GitDirty bool
-}
-
-var env CompiledEnv
-
-func init() {
-	// must be created inside the init function to pickup build specific params
-	env = CompiledEnv{
-		Name:     cli_name,
-		Version:  cli_version,
-		GitSha:   cli_gitsha,
-		GitDirty: cli_gitdirty == "",
-	}
-}
+var ErrSilent = errors.New("silent error")

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -16,8 +16,21 @@
 
 package cli
 
-import (
-	"errors"
-)
+type SilentError struct {
+	Err error
+}
 
-var ErrSilent = errors.New("silent error")
+func (e *SilentError) Error() string {
+	return e.Err.Error()
+}
+
+func SilenceError(err error) error {
+	return &SilentError{
+		Err: err,
+	}
+}
+
+func IsSilent(err error) bool {
+	_, ok := err.(*SilentError)
+	return ok
+}

--- a/pkg/cli/sort.go
+++ b/pkg/cli/sort.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The original author or authors
+ * Copyright 2019 The original author or authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/k8s/wait.go
+++ b/pkg/k8s/wait.go
@@ -43,6 +43,8 @@ type object interface {
 // WaitUntilReady watches for mutations of the target object until the target is ready.
 func WaitUntilReady(ctx context.Context, client rest.Interface, resource string, target object) error {
 	if client == (*rest.RESTClient)(nil) {
+		// the client is nil for tests, simulate waiting by blocking
+		<-ctx.Done()
 		return nil
 	}
 	lw := cache.NewListWatchFromClient(client, resource, target.GetNamespace(), fields.Everything())

--- a/pkg/riff/commands/application_create.go
+++ b/pkg/riff/commands/application_create.go
@@ -182,7 +182,7 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s application list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s application tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.ErrSilent
+			errChan <- cli.SilenceError(ctx.Err())
 		}
 		return <-errChan
 	}

--- a/pkg/riff/commands/application_create.go
+++ b/pkg/riff/commands/application_create.go
@@ -156,29 +156,35 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 	}
 	c.Successf("Created application %q\n", application.Name)
 	if opts.Tail {
-		// cancel ctx when application becomes ready
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		// err guarded by Validate()
+		timeout, _ := time.ParseDuration(opts.WaitTimeout)
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		errChan := make(chan error, 1)
+		defer close(errChan)
 
 		go func() {
 			defer cancel()
 			err := k8s.WaitUntilReady(ctx, c.Build().RESTClient(), "applications", application)
-			if err != nil {
-				c.Errorf("Error: %s\n", err)
+			if ctx.Err() == nil {
+				errChan <- err
+			}
+		}()
+		go func() {
+			defer cancel()
+			err := c.Kail.ApplicationLogs(ctx, application, cli.TailSinceCreateDefault, c.Stdout)
+			if ctx.Err() == nil {
+				errChan <- err
 			}
 		}()
 
-		// err guarded by Validate()
-		timeout, _ := time.ParseDuration(opts.WaitTimeout)
-		timer := time.AfterFunc(timeout, func() {
+		<-ctx.Done()
+		if ctx.Err() == context.DeadlineExceeded {
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s application list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s application tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			cancel()
-		})
-		defer timer.Stop()
-
-		return c.Kail.ApplicationLogs(ctx, application, cli.TailSinceCreateDefault, c.Stdout)
+			errChan <- cli.ErrSilent
+		}
+		return <-errChan
 	}
 	return nil
 }

--- a/pkg/riff/commands/application_create_test.go
+++ b/pkg/riff/commands/application_create_test.go
@@ -674,8 +674,8 @@ To continue watching logs run: riff application tail my-application --namespace 
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := cli.ErrSilent, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
+				if actual := err; !cli.IsSilent(err) {
+					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/application_create_test.go
+++ b/pkg/riff/commands/application_create_test.go
@@ -19,9 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/buildpack/pack"
 	"github.com/projectriff/riff/pkg/cli"
@@ -640,9 +638,8 @@ Created application "my-application"
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
 					ctx := args[0].(context.Context)
 					fmt.Fprintf(c.Stdout, "...log output...\n")
-					// wait for context to be cancelled, plus some fudge
+					// wait for context to be cancelled
 					<-ctx.Done()
-					time.Sleep(time.Millisecond)
 				})
 				return nil
 			},
@@ -668,27 +665,17 @@ Created application "my-application"
 					},
 				},
 			},
-			ShouldError: true,
-			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
-				}
-				for _, line := range []string{
-					`
+			ExpectOutput: `
 Created application "my-application"
-`,
-					`
 ...log output...
-`,
-					`
 Timeout after "1ms" waiting for "my-application" to become ready
 To view status run: riff application list --namespace default
 To continue watching logs run: riff application tail my-application --namespace default
 `,
-				} {
-					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
-						t.Errorf("expected output to contain %q, actual %q", expected, actual)
-					}
+			ShouldError: true,
+			Verify: func(t *testing.T, output string, err error) {
+				if expected, actual := cli.ErrSilent, err; expected != actual {
+					t.Errorf("expected error %q, actual %q", expected, actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/application_create_test.go
+++ b/pkg/riff/commands/application_create_test.go
@@ -617,7 +617,7 @@ Created application "my-application"
 		},
 		{
 			Name: "tail timeout",
-			Args: []string{applicationName, cli.ImageFlagName, imageTag, cli.GitRepoFlagName, gitRepo, cli.TailFlagName, cli.WaitTimeoutFlagName, "1ms"},
+			Args: []string{applicationName, cli.ImageFlagName, imageTag, cli.GitRepoFlagName, gitRepo, cli.TailFlagName, cli.WaitTimeoutFlagName, "5ms"},
 			Prepare: func(t *testing.T, c *cli.Config) error {
 				kail := &kailtesting.Logger{}
 				c.Kail = kail
@@ -668,7 +668,7 @@ Created application "my-application"
 			ExpectOutput: `
 Created application "my-application"
 ...log output...
-Timeout after "1ms" waiting for "my-application" to become ready
+Timeout after "5ms" waiting for "my-application" to become ready
 To view status run: riff application list --namespace default
 To continue watching logs run: riff application tail my-application --namespace default
 `,

--- a/pkg/riff/commands/function_create.go
+++ b/pkg/riff/commands/function_create.go
@@ -198,7 +198,7 @@ func (opts *FunctionCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s function list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s function tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.ErrSilent
+			errChan <- cli.SilenceError(ctx.Err())
 		}
 		return <-errChan
 	}

--- a/pkg/riff/commands/function_create_test.go
+++ b/pkg/riff/commands/function_create_test.go
@@ -644,7 +644,7 @@ Created function "my-function"
 		},
 		{
 			Name: "tail timeout",
-			Args: []string{functionName, cli.ImageFlagName, imageTag, cli.GitRepoFlagName, gitRepo, cli.TailFlagName, cli.WaitTimeoutFlagName, "1ms"},
+			Args: []string{functionName, cli.ImageFlagName, imageTag, cli.GitRepoFlagName, gitRepo, cli.TailFlagName, cli.WaitTimeoutFlagName, "5ms"},
 			Prepare: func(t *testing.T, c *cli.Config) error {
 				kail := &kailtesting.Logger{}
 				c.Kail = kail
@@ -695,7 +695,7 @@ Created function "my-function"
 			ExpectOutput: `
 Created function "my-function"
 ...log output...
-Timeout after "1ms" waiting for "my-function" to become ready
+Timeout after "5ms" waiting for "my-function" to become ready
 To view status run: riff function list --namespace default
 To continue watching logs run: riff function tail my-function --namespace default
 `,

--- a/pkg/riff/commands/function_create_test.go
+++ b/pkg/riff/commands/function_create_test.go
@@ -19,9 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/buildpack/pack"
 	"github.com/projectriff/riff/pkg/cli"
@@ -667,9 +665,8 @@ Created function "my-function"
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
 					ctx := args[0].(context.Context)
 					fmt.Fprintf(c.Stdout, "...log output...\n")
-					// wait for context to be cancelled, plus some fudge
+					// wait for context to be cancelled
 					<-ctx.Done()
-					time.Sleep(time.Millisecond)
 				})
 				return nil
 			},
@@ -695,27 +692,17 @@ Created function "my-function"
 					},
 				},
 			},
-			ShouldError: true,
-			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
-				}
-				for _, line := range []string{
-					`
+			ExpectOutput: `
 Created function "my-function"
-`,
-					`
 ...log output...
-`,
-					`
 Timeout after "1ms" waiting for "my-function" to become ready
 To view status run: riff function list --namespace default
 To continue watching logs run: riff function tail my-function --namespace default
 `,
-				} {
-					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
-						t.Errorf("expected output to contain %q, actual %q", expected, actual)
-					}
+			ShouldError: true,
+			Verify: func(t *testing.T, output string, err error) {
+				if expected, actual := cli.ErrSilent, err; expected != actual {
+					t.Errorf("expected error %q, actual %q", expected, actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/function_create_test.go
+++ b/pkg/riff/commands/function_create_test.go
@@ -701,8 +701,8 @@ To continue watching logs run: riff function tail my-function --namespace defaul
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := cli.ErrSilent, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
+				if actual := err; !cli.IsSilent(err) {
+					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/handler_create.go
+++ b/pkg/riff/commands/handler_create.go
@@ -165,7 +165,7 @@ func (opts *HandlerCreateOptions) Exec(ctx context.Context, c *cli.Config) error
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s handler list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s handler tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.ErrSilent
+			errChan <- cli.SilenceError(ctx.Err())
 		}
 		return <-errChan
 	}

--- a/pkg/riff/commands/handler_create.go
+++ b/pkg/riff/commands/handler_create.go
@@ -139,29 +139,35 @@ func (opts *HandlerCreateOptions) Exec(ctx context.Context, c *cli.Config) error
 	}
 	c.Successf("Created handler %q\n", handler.Name)
 	if opts.Tail {
-		// cancel ctx when handler becomes ready
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		// err guarded by Validate()
+		timeout, _ := time.ParseDuration(opts.WaitTimeout)
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		errChan := make(chan error, 1)
+		defer close(errChan)
 
 		go func() {
 			defer cancel()
 			err := k8s.WaitUntilReady(ctx, c.Request().RESTClient(), "handlers", handler)
-			if err != nil {
-				c.Errorf("Error: %s\n", err)
+			if ctx.Err() == nil {
+				errChan <- err
+			}
+		}()
+		go func() {
+			defer cancel()
+			err := c.Kail.HandlerLogs(ctx, handler, cli.TailSinceCreateDefault, c.Stdout)
+			if ctx.Err() == nil {
+				errChan <- err
 			}
 		}()
 
-		// err guarded by Validate()
-		timeout, _ := time.ParseDuration(opts.WaitTimeout)
-		timer := time.AfterFunc(timeout, func() {
+		<-ctx.Done()
+		if ctx.Err() == context.DeadlineExceeded {
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s handler list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s handler tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			cancel()
-		})
-		defer timer.Stop()
-
-		return c.Kail.HandlerLogs(ctx, handler, cli.TailSinceCreateDefault, c.Stdout)
+			errChan <- cli.ErrSilent
+		}
+		return <-errChan
 	}
 	return nil
 }

--- a/pkg/riff/commands/handler_create_test.go
+++ b/pkg/riff/commands/handler_create_test.go
@@ -436,8 +436,8 @@ To continue watching logs run: riff handler tail my-handler --namespace default
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := cli.ErrSilent, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
+				if actual := err; !cli.IsSilent(err) {
+					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/handler_create_test.go
+++ b/pkg/riff/commands/handler_create_test.go
@@ -387,7 +387,7 @@ Created handler "my-handler"
 		},
 		{
 			Name: "tail timeout",
-			Args: []string{handlerName, cli.ImageFlagName, image, cli.TailFlagName, cli.WaitTimeoutFlagName, "1ms"},
+			Args: []string{handlerName, cli.ImageFlagName, image, cli.TailFlagName, cli.WaitTimeoutFlagName, "5ms"},
 			Prepare: func(t *testing.T, c *cli.Config) error {
 				kail := &kailtesting.Logger{}
 				c.Kail = kail
@@ -430,7 +430,7 @@ Created handler "my-handler"
 			ExpectOutput: `
 Created handler "my-handler"
 ...log output...
-Timeout after "1ms" waiting for "my-handler" to become ready
+Timeout after "5ms" waiting for "my-handler" to become ready
 To view status run: riff handler list --namespace default
 To continue watching logs run: riff handler tail my-handler --namespace default
 `,

--- a/pkg/riff/commands/handler_create_test.go
+++ b/pkg/riff/commands/handler_create_test.go
@@ -19,9 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/projectriff/riff/pkg/cli"
 	"github.com/projectriff/riff/pkg/k8s"
@@ -406,9 +404,8 @@ Created handler "my-handler"
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
 					ctx := args[0].(context.Context)
 					fmt.Fprintf(c.Stdout, "...log output...\n")
-					// wait for context to be cancelled, plus some fudge
+					// wait for context to be cancelled
 					<-ctx.Done()
-					time.Sleep(time.Millisecond)
 				})
 				return nil
 			},
@@ -430,27 +427,17 @@ Created handler "my-handler"
 					},
 				},
 			},
-			ShouldError: true,
-			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
-				}
-				for _, line := range []string{
-					`
+			ExpectOutput: `
 Created handler "my-handler"
-`,
-					`
 ...log output...
-`,
-					`
 Timeout after "1ms" waiting for "my-handler" to become ready
 To view status run: riff handler list --namespace default
 To continue watching logs run: riff handler tail my-handler --namespace default
 `,
-				} {
-					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
-						t.Errorf("expected output to contain %q, actual %q", expected, actual)
-					}
+			ShouldError: true,
+			Verify: func(t *testing.T, output string, err error) {
+				if expected, actual := cli.ErrSilent, err; expected != actual {
+					t.Errorf("expected error %q, actual %q", expected, actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/processor_create.go
+++ b/pkg/riff/commands/processor_create.go
@@ -83,29 +83,35 @@ func (opts *ProcessorCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 	}
 	c.Successf("Created processor %q\n", processor.Name)
 	if opts.Tail {
-		// cancel ctx when processor becomes ready
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		// err guarded by Validate()
+		timeout, _ := time.ParseDuration(opts.WaitTimeout)
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		errChan := make(chan error, 1)
+		defer close(errChan)
 
 		go func() {
 			defer cancel()
 			err := k8s.WaitUntilReady(ctx, c.Stream().RESTClient(), "processors", processor)
-			if err != nil {
-				c.Errorf("Error: %s\n", err)
+			if ctx.Err() == nil {
+				errChan <- err
+			}
+		}()
+		go func() {
+			defer cancel()
+			err := c.Kail.ProcessorLogs(ctx, processor, cli.TailSinceCreateDefault, c.Stdout)
+			if ctx.Err() == nil {
+				errChan <- err
 			}
 		}()
 
-		// err guarded by Validate()
-		timeout, _ := time.ParseDuration(opts.WaitTimeout)
-		timer := time.AfterFunc(timeout, func() {
+		<-ctx.Done()
+		if ctx.Err() == context.DeadlineExceeded {
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s processor list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s processor tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			cancel()
-		})
-		defer timer.Stop()
-
-		return c.Kail.ProcessorLogs(ctx, processor, cli.TailSinceCreateDefault, c.Stdout)
+			errChan <- cli.ErrSilent
+		}
+		return <-errChan
 	}
 	return nil
 }

--- a/pkg/riff/commands/processor_create.go
+++ b/pkg/riff/commands/processor_create.go
@@ -109,7 +109,7 @@ func (opts *ProcessorCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s processor list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s processor tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.ErrSilent
+			errChan <- cli.SilenceError(ctx.Err())
 		}
 		return <-errChan
 	}

--- a/pkg/riff/commands/processor_create_test.go
+++ b/pkg/riff/commands/processor_create_test.go
@@ -284,7 +284,7 @@ Created processor "my-processor"
 		},
 		{
 			Name: "tail timeout",
-			Args: []string{processorName, cli.FunctionRefFlagName, functionRef, cli.InputFlagName, inputName, cli.TailFlagName, cli.WaitTimeoutFlagName, "1ms"},
+			Args: []string{processorName, cli.FunctionRefFlagName, functionRef, cli.InputFlagName, inputName, cli.TailFlagName, cli.WaitTimeoutFlagName, "5ms"},
 			Prepare: func(t *testing.T, c *cli.Config) error {
 				kail := &kailtesting.Logger{}
 				c.Kail = kail
@@ -327,7 +327,7 @@ Created processor "my-processor"
 			ExpectOutput: `
 Created processor "my-processor"
 ...log output...
-Timeout after "1ms" waiting for "my-processor" to become ready
+Timeout after "5ms" waiting for "my-processor" to become ready
 To view status run: riff processor list --namespace default
 To continue watching logs run: riff processor tail my-processor --namespace default
 `,

--- a/pkg/riff/commands/processor_create_test.go
+++ b/pkg/riff/commands/processor_create_test.go
@@ -19,9 +19,7 @@ package commands_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/projectriff/riff/pkg/cli"
 	"github.com/projectriff/riff/pkg/k8s"
@@ -303,9 +301,8 @@ Created processor "my-processor"
 				}, cli.TailSinceCreateDefault, mock.Anything).Return(k8s.ErrWaitTimeout).Run(func(args mock.Arguments) {
 					ctx := args[0].(context.Context)
 					fmt.Fprintf(c.Stdout, "...log output...\n")
-					// wait for context to be cancelled, plus some fudge
+					// wait for context to be cancelled
 					<-ctx.Done()
-					time.Sleep(time.Millisecond)
 				})
 				return nil
 			},
@@ -327,27 +324,17 @@ Created processor "my-processor"
 					},
 				},
 			},
-			ShouldError: true,
-			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := k8s.ErrWaitTimeout, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
-				}
-				for _, line := range []string{
-					`
+			ExpectOutput: `
 Created processor "my-processor"
-`,
-					`
 ...log output...
-`,
-					`
 Timeout after "1ms" waiting for "my-processor" to become ready
 To view status run: riff processor list --namespace default
 To continue watching logs run: riff processor tail my-processor --namespace default
 `,
-				} {
-					if expected, actual := line[1:], output; !strings.Contains(actual, expected) {
-						t.Errorf("expected output to contain %q, actual %q", expected, actual)
-					}
+			ShouldError: true,
+			Verify: func(t *testing.T, output string, err error) {
+				if expected, actual := cli.ErrSilent, err; expected != actual {
+					t.Errorf("expected error %q, actual %q", expected, actual)
 				}
 			},
 		},

--- a/pkg/riff/commands/processor_create_test.go
+++ b/pkg/riff/commands/processor_create_test.go
@@ -333,8 +333,8 @@ To continue watching logs run: riff processor tail my-processor --namespace defa
 `,
 			ShouldError: true,
 			Verify: func(t *testing.T, output string, err error) {
-				if expected, actual := cli.ErrSilent, err; expected != actual {
-					t.Errorf("expected error %q, actual %q", expected, actual)
+				if actual := err; !cli.IsSilent(err) {
+					t.Errorf("expected error to be silent, actual %#v", actual)
 				}
 			},
 		},


### PR DESCRIPTION
- no more race conditions
- consistent log output
- push timeout into the context