### PR TITLE
Stop generating HTML coverage reports

### DIFF
--- a/ci/install-coverage-steps.yml
+++ b/ci/install-coverage-steps.yml
@@ -7,5 +7,4 @@ steps:
     go get github.com/jstemmer/go-junit-report
     go get github.com/axw/gocov/gocov
     go get github.com/AlekSi/gocov-xml
-    go get -u github.com/matm/gocov-html
   displayName: 'Install coverage tools'

--- a/ci/report-coverage-steps.yml
+++ b/ci/report-coverage-steps.yml
@@ -7,8 +7,6 @@ steps:
     if [ -f "coverage.txt" ]; then
       gocov convert coverage.txt > coverage.json
       gocov-xml < coverage.json > coverage.xml
-      mkdir coverage
-      gocov-html < coverage.json > coverage/index.html
     fi
   condition: succeededOrFailed()
   workingDirectory: '$(modulePath)'
@@ -25,4 +23,3 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: $(System.DefaultWorkingDirectory)/**/coverage.xml
-    reportDirectory: $(System.DefaultWorkingDirectory)/**/coverage


### PR DESCRIPTION
...Azure Pipelines generates HTML directly from the coverage.xml, and
ignores what we generate.