### PR TITLE
Avoid deadlocks during create

### DIFF
--- a/pkg/riff/commands/application_create.go
+++ b/pkg/riff/commands/application_create.go
@@ -159,7 +159,7 @@ func (opts *ApplicationCreateOptions) Exec(ctx context.Context, c *cli.Config) e
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 1)
+		errChan := make(chan error, 3)
 		defer close(errChan)
 
 		go func() {

--- a/pkg/riff/commands/function_create.go
+++ b/pkg/riff/commands/function_create.go
@@ -175,7 +175,7 @@ func (opts *FunctionCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 1)
+		errChan := make(chan error, 3)
 		defer close(errChan)
 
 		go func() {

--- a/pkg/riff/commands/handler_create.go
+++ b/pkg/riff/commands/handler_create.go
@@ -142,7 +142,7 @@ func (opts *HandlerCreateOptions) Exec(ctx context.Context, c *cli.Config) error
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 1)
+		errChan := make(chan error, 3)
 		defer close(errChan)
 
 		go func() {

--- a/pkg/riff/commands/processor_create.go
+++ b/pkg/riff/commands/processor_create.go
@@ -86,7 +86,7 @@ func (opts *ProcessorCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
 		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 1)
+		errChan := make(chan error, 3)
 		defer close(errChan)
 
 		go func() {


### PR DESCRIPTION
Since we can’t rule out the case where either WaitUntilReady() or
ApplicationLogs() (or both) return an error just before the context expires,
the current code can deadlock. See this example flow in the case of both
failing: https://play.golang.org/p/76Dcr9VlAXo. A solution is to increase the
buffer size to 3 so that the main thread will never block on sending an error
to the channel.