### PR TITLE
Add codecov config file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+- pkg/cli/printers
+- pkg/testing
+- vendor


### PR DESCRIPTION
The codecov agent was detecting a config file from a vendor directory.
Adding our own file should preempt the vendor config.