### PR TITLE
Normalize tail control flow

### DIFF
--- a/pkg/riff/commands/function_create.go
+++ b/pkg/riff/commands/function_create.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildpack/pack"
 	"github.com/projectriff/riff/pkg/cli"
 	"github.com/projectriff/riff/pkg/k8s"
+	"github.com/projectriff/riff/pkg/util"
 	buildv1alpha1 "github.com/projectriff/system/pkg/apis/build/v1alpha1"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -174,33 +175,23 @@ func (opts *FunctionCreateOptions) Exec(ctx context.Context, c *cli.Config) erro
 	if opts.Tail {
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 3)
-		defer close(errChan)
-
-		go func() {
-			defer cancel()
-			err := k8s.WaitUntilReady(ctx, c.Build().RESTClient(), "functions", function)
-			if ctx.Err() == nil {
-				errChan <- err
-			}
-		}()
-		go func() {
-			defer cancel()
-			err := c.Kail.FunctionLogs(ctx, function, cli.TailSinceCreateDefault, c.Stdout)
-			if ctx.Err() == nil {
-				errChan <- err
-			}
-		}()
-
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded {
+		err := util.RaceUntil(ctx, timeout,
+			func(ctx context.Context) error {
+				return k8s.WaitUntilReady(ctx, c.Build().RESTClient(), "functions", function)
+			},
+			func(ctx context.Context) error {
+				return c.Kail.FunctionLogs(ctx, function, cli.TailSinceCreateDefault, c.Stdout)
+			},
+		)
+		if err == context.DeadlineExceeded {
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s function list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s function tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.SilenceError(ctx.Err())
+			err = cli.SilenceError(err)
 		}
-		return <-errChan
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/riff/commands/handler_create.go
+++ b/pkg/riff/commands/handler_create.go
@@ -25,6 +25,7 @@ import (
 	"github.com/projectriff/riff/pkg/cli"
 	"github.com/projectriff/riff/pkg/k8s"
 	"github.com/projectriff/riff/pkg/parsers"
+	"github.com/projectriff/riff/pkg/util"
 	"github.com/projectriff/riff/pkg/validation"
 	requestv1alpha1 "github.com/projectriff/system/pkg/apis/request/v1alpha1"
 	"github.com/spf13/cobra"
@@ -141,33 +142,23 @@ func (opts *HandlerCreateOptions) Exec(ctx context.Context, c *cli.Config) error
 	if opts.Tail {
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 3)
-		defer close(errChan)
-
-		go func() {
-			defer cancel()
-			err := k8s.WaitUntilReady(ctx, c.Request().RESTClient(), "handlers", handler)
-			if ctx.Err() == nil {
-				errChan <- err
-			}
-		}()
-		go func() {
-			defer cancel()
-			err := c.Kail.HandlerLogs(ctx, handler, cli.TailSinceCreateDefault, c.Stdout)
-			if ctx.Err() == nil {
-				errChan <- err
-			}
-		}()
-
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded {
+		err := util.RaceUntil(ctx, timeout,
+			func(ctx context.Context) error {
+				return k8s.WaitUntilReady(ctx, c.Request().RESTClient(), "handlers", handler)
+			},
+			func(ctx context.Context) error {
+				return c.Kail.HandlerLogs(ctx, handler, cli.TailSinceCreateDefault, c.Stdout)
+			},
+		)
+		if err == context.DeadlineExceeded {
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s handler list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s handler tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.SilenceError(ctx.Err())
+			err = cli.SilenceError(err)
 		}
-		return <-errChan
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/riff/commands/processor_create.go
+++ b/pkg/riff/commands/processor_create.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/projectriff/riff/pkg/cli"
 	"github.com/projectriff/riff/pkg/k8s"
+	"github.com/projectriff/riff/pkg/util"
 	streamv1alpha1 "github.com/projectriff/system/pkg/apis/stream/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,33 +86,23 @@ func (opts *ProcessorCreateOptions) Exec(ctx context.Context, c *cli.Config) err
 	if opts.Tail {
 		// err guarded by Validate()
 		timeout, _ := time.ParseDuration(opts.WaitTimeout)
-		ctx, cancel := context.WithTimeout(ctx, timeout)
-		errChan := make(chan error, 3)
-		defer close(errChan)
-
-		go func() {
-			defer cancel()
-			err := k8s.WaitUntilReady(ctx, c.Stream().RESTClient(), "processors", processor)
-			if ctx.Err() == nil {
-				errChan <- err
-			}
-		}()
-		go func() {
-			defer cancel()
-			err := c.Kail.ProcessorLogs(ctx, processor, cli.TailSinceCreateDefault, c.Stdout)
-			if ctx.Err() == nil {
-				errChan <- err
-			}
-		}()
-
-		<-ctx.Done()
-		if ctx.Err() == context.DeadlineExceeded {
+		err := util.RaceUntil(ctx, timeout,
+			func(ctx context.Context) error {
+				return k8s.WaitUntilReady(ctx, c.Stream().RESTClient(), "processors", processor)
+			},
+			func(ctx context.Context) error {
+				return c.Kail.ProcessorLogs(ctx, processor, cli.TailSinceCreateDefault, c.Stdout)
+			},
+		)
+		if err == context.DeadlineExceeded {
 			c.Errorf("Timeout after %q waiting for %q to become ready\n", opts.WaitTimeout, opts.Name)
 			c.Infof("To view status run: %s processor list %s %s\n", c.Name, cli.NamespaceFlagName, opts.Namespace)
 			c.Infof("To continue watching logs run: %s processor tail %s %s %s\n", c.Name, opts.Name, cli.NamespaceFlagName, opts.Namespace)
-			errChan <- cli.SilenceError(ctx.Err())
+			err = cli.SilenceError(err)
 		}
-		return <-errChan
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/util/timeout.go
+++ b/pkg/util/timeout.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"context"
+	"time"
+)
+
+type RaceTask func(ctx context.Context) error
+
+// RaceUntil runs each task in go routine and returns the result of the first task to
+// complete (or error). A timeout is specified to limit the whole process. Each task
+// should observe the context to exit once the context is done.
+func RaceUntil(ctx context.Context, timeout time.Duration, tasks ...RaceTask) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	errChan := make(chan error, len(tasks)+1)
+	defer close(errChan)
+
+	for _, task := range tasks {
+		go func(task RaceTask) {
+			defer cancel()
+			err := task(ctx)
+			if ctx.Err() == nil {
+				errChan <- err
+			}
+		}(task)
+	}
+
+	<-ctx.Done()
+	errChan <- ctx.Err()
+
+	return <-errChan
+}

--- a/pkg/util/timeout_test.go
+++ b/pkg/util/timeout_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/projectriff/riff/pkg/util"
+)
+
+func TestRaceUntil(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		tasks   []util.RaceTask
+		err     error
+	}{{
+		name:    "empty",
+		timeout: time.Millisecond,
+		err:     context.DeadlineExceeded,
+	}, {
+		name:    "return immediately",
+		timeout: time.Minute,
+		tasks: []util.RaceTask{
+			func(ctx context.Context) error {
+				return nil
+			},
+		},
+	}, {
+		name:    "error immediately",
+		timeout: time.Minute,
+		tasks: []util.RaceTask{
+			func(ctx context.Context) error {
+				return fmt.Errorf("test error")
+			},
+		},
+		err: fmt.Errorf("test error"),
+	}, {
+		name:    "block until canceled",
+		timeout: time.Millisecond,
+		tasks: []util.RaceTask{
+			func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+		},
+		err: context.DeadlineExceeded,
+	}, {
+		name:    "take first function to return",
+		timeout: time.Minute,
+		tasks: []util.RaceTask{
+			func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+			func(ctx context.Context) error {
+				return nil
+			},
+		},
+	}, {
+		name:    "take first function to error",
+		timeout: time.Minute,
+		tasks: []util.RaceTask{
+			func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+			func(ctx context.Context) error {
+				return fmt.Errorf("test error")
+			},
+		},
+		err: fmt.Errorf("test error"),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.TODO()
+			err := util.RaceUntil(ctx, test.timeout, test.tasks...)
+			if expected, actual := fmt.Sprintf("%s", test.err), fmt.Sprintf("%s", err); expected != actual {
+				t.Errorf("Expected error to be %q, actually %q", expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Create a race util that will return with the first task to complete.
Each task is run in an independent go routine. If no task completes the
whole process will timeout.