### PR TITLE
Drop FATS lite

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,36 +27,6 @@ jobs:
 
   displayName: 'Unit test'
 
-- job: fats_lite
-  dependsOn: unit
-  strategy:
-    matrix:
-      minikube:
-        imageName: ubuntu-16.04
-        qualifier: minikube
-        cluster: minikube
-        # TODO restore registry
-        # registry: minikube
-        registry: docker-daemon
-  pool:
-    vmImage: $(imageName)
-  variables:
-    CLUSTER:  '$(cluster)'
-    REGISTRY: '$(registry)'
-    CLUSTER_NAME: 'riff-$(Build.BuildId)-$(qualifier)'
-    NAMESPACE: '$(CLUSTER_NAME)'
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-  steps:
-  - bash: ./ci/fats.sh lite
-    displayName: 'Run FATS'
-  - template: ci/dump-diagnostics-steps.yml
-  - bash: ./ci/fats-cleanup.sh
-    env:
-      TRAVIS_TEST_RESULT: '' # TODO remove this
-    condition: always()
-    displayName: 'Cleanup FATS'
-  displayName: 'FATS lite'
-
 - job: stage
   dependsOn: unit
   pool:
@@ -81,11 +51,17 @@ jobs:
   dependsOn: stage
   strategy:
     matrix:
-      minikube:
+      linux:
         imageName: ubuntu-16.04
         qualifier: minikube
         cluster: minikube
         registry: dockerhub
+      # TODO restore windows support once we have a linux docker daemon available
+      # windows:
+      #   imageName: windows-2019
+      #   qualifier: windows
+      #   cluster: gke
+      #   registry: gcr
   pool:
     vmImage: $(imageName)
   variables:

--- a/ci/fats.sh
+++ b/ci/fats.sh
@@ -4,7 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-mode=${1:-full}
 version=`cat VERSION`
 commit=$(git rev-parse HEAD)
 
@@ -22,18 +21,13 @@ $fats_dir/install.sh duffle
 # install riff-cli
 travis_fold start install-riff
 echo "Installing riff"
-if [ "$mode" = "full" ]; then
-  if [ "$machine" == "MinGw" ]; then
-    curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${version}-${commit}/riff-windows-amd64.zip > riff.zip
-    unzip riff.zip -d /usr/bin/
-    rm riff.zip
-  else
-    curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${version}-${commit}/riff-linux-amd64.tgz | tar xz
-    chmod +x riff
-    sudo cp riff /usr/bin/riff
-  fi
+if [ "$machine" == "MinGw" ]; then
+  curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${version}-${commit}/riff-windows-amd64.zip > riff.zip
+  unzip riff.zip -d /usr/bin/
+  rm riff.zip
 else
-  make build
+  curl https://storage.googleapis.com/projectriff/riff-cli/releases/builds/v${version}-${commit}/riff-linux-amd64.tgz | tar xz
+  chmod +x riff
   sudo cp riff /usr/bin/riff
 fi
 travis_fold end install-riff
@@ -60,13 +54,7 @@ travis_fold end system-install
 # run test functions
 source $fats_dir/functions/helpers.sh
 
-if [ "$mode" = "full" ]; then
-  functions=(java java-boot node npm command)
-else
-  functions=(command)
-fi
-
-for test in "${functions[@]}"; do
+for test in command; do
   path=${fats_dir}/functions/uppercase/${test}
   function_name=fats-cluster-uppercase-${test}
   image=$(fats_image_repo ${function_name})
@@ -78,7 +66,7 @@ for test in "${functions[@]}"; do
 done
 
 if [ "$machine" != "MinGw" ]; then
-  for test in "${functions[@]}"; do
+  for test in command; do
     path=${fats_dir}/functions/uppercase/${test}
     function_name=fats-local-uppercase-${test}
     image=$(fats_image_repo ${function_name})


### PR DESCRIPTION
For pull requests, FATS provides more friction than benefit. The
important thing is for the cli to be fully tested before release
artifacts are published. We still run FATS for pushed commits, it is
only skipped for pull requests.

...also adding a TODO to add Windows FATS tests.