### PR TITLE
Provide a help target for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,52 +9,56 @@ LDFLAGS_VERSION = -X github.com/projectriff/riff/pkg/cli.cli_name=riff \
 				  -X github.com/projectriff/riff/pkg/cli.cli_gitdirty=$(GITDIRTY)
 
 .PHONY: all
-all: build test docs
+all: build test docs ## Build, test, and regenerate docs
 
 .PHONY: clean
-clean:
+clean: ## Delete build output
 	rm -f $(OUTPUT)
 	rm -f riff-darwin-amd64.tgz
 	rm -f riff-linux-amd64.tgz
 	rm -f riff-windows-amd64.zip
 
 .PHONY: build
-build: $(OUTPUT)
+build: $(OUTPUT) ## Build riff
 
 .PHONY: test
-test:
+test: ## Run the tests
 	go test -mod=vendor ./...
 
 .PHONY: coverage
-coverage:
+coverage: ## Run the tests with coverage and race detection
 	go test -mod=vendor -v --race -coverprofile=coverage.txt -covermode=atomic ./...
 
 $(OUTPUT): $(GO_SOURCES) VERSION
 	go build -mod=vendor -o $(OUTPUT) -ldflags "$(LDFLAGS_VERSION)" ./cmd/riff
 
 .PHONY: release
-release: $(GO_SOURCES) VERSION
+release: $(GO_SOURCES) VERSION $$ Cross-compile riff for various operating systems
 	GOOS=darwin   GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-darwin-amd64.tgz $(OUTPUT)     && rm -f $(OUTPUT)
 	GOOS=linux    GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-linux-amd64.tgz  $(OUTPUT)     && rm -f $(OUTPUT)
 	GOOS=windows  GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT).exe ./cmd/riff && zip -mq riff-windows-amd64.zip $(OUTPUT).exe && rm -f $(OUTPUT).exe
 
-docs: $(OUTPUT) clean-docs
+docs: $(OUTPUT) clean-docs   ## Generate documentation
 	$(OUTPUT) docs
 
 .PHONY: verify-docs
-verify-docs: docs
+verify-docs: docs ## Verify the generated docs are up to date
 	git diff --exit-code docs
 
-.PHONY: clean-docs
+.PHONY: clean-docs ## Delete the generated docs
 clean-docs:
 	rm -fR docs
 
 .PHONY: check-mockery
-check-mockery:
+check-mockery: ## Check that mockery is available and print installation instructions if it isn't
     # Use go get in GOPATH mode to install/update mockery. This avoids polluting go.mod/go.sum.
 	@which mockery > /dev/null || (echo mockery not found: issue \"GO111MODULE=off go get -u  github.com/vektra/mockery/.../\" && false)
 
 .PHONY: gen-mocks
-gen-mocks: check-mockery
+gen-mocks: check-mockery ## Generate mocks
 	mockery -output ./pkg/testing/pack -outpkg pack -dir ./pkg/pack -name Client
 	mockery -output ./pkg/testing/kail -outpkg kail -dir ./pkg/kail -name Logger
+
+# Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print help for each make target
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(OUTPUT): $(GO_SOURCES) VERSION
 	go build -mod=vendor -o $(OUTPUT) -ldflags "$(LDFLAGS_VERSION)" ./cmd/riff
 
 .PHONY: release
-release: $(GO_SOURCES) VERSION $$ Cross-compile riff for various operating systems
+release: $(GO_SOURCES) VERSION ## Cross-compile riff for various operating systems
 	GOOS=darwin   GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-darwin-amd64.tgz $(OUTPUT)     && rm -f $(OUTPUT)
 	GOOS=linux    GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-linux-amd64.tgz  $(OUTPUT)     && rm -f $(OUTPUT)
 	GOOS=windows  GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT).exe ./cmd/riff && zip -mq riff-windows-amd64.zip $(OUTPUT).exe && rm -f $(OUTPUT).exe

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ release: $(GO_SOURCES) VERSION ## Cross-compile riff for various operating syste
 	GOOS=linux    GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT)     ./cmd/riff && tar -czf riff-linux-amd64.tgz  $(OUTPUT)     && rm -f $(OUTPUT)
 	GOOS=windows  GOARCH=amd64 go build -mod=vendor -ldflags "$(LDFLAGS_VERSION)" -o $(OUTPUT).exe ./cmd/riff && zip -mq riff-windows-amd64.zip $(OUTPUT).exe && rm -f $(OUTPUT).exe
 
-docs: $(OUTPUT) clean-docs   ## Generate documentation
+docs: $(OUTPUT) clean-docs ## Generate documentation
 	$(OUTPUT) docs
 
 .PHONY: verify-docs


### PR DESCRIPTION
I came across this on another project and wondered if it had any value here:
```
$ make help
all                            Build, test, and regenerate docs
clean                          Delete build output
build                          Build riff
test                           Run the tests
coverage                       Run the tests with coverage and race detection
docs                           Generate documentation
verify-docs                    Verify the generated docs are up to date
check-mockery                  Check that mockery is available and print installation instructions if it isn't
gen-mocks                      Generate mocks
help                           Print help for each make target

```
