### PR TITLE
Add riff doctor

### DIFF
--- a/docs/riff.md
+++ b/docs/riff.md
@@ -20,6 +20,7 @@ riff is for functions
 * [riff application](riff_application.md)	 - applications built from source using application buildpacks
 * [riff completion](riff_completion.md)	 - generate shell completion script
 * [riff credential](riff_credential.md)	 - credentials for container registries
+* [riff doctor](riff_doctor.md)	 - check riff's requirements are installed
 * [riff function](riff_function.md)	 - functions built from source using function buildpacks
 * [riff handler](riff_handler.md)	 - handlers map HTTP requests to applications, functions or images
 * [riff processor](riff_processor.md)	 - processors apply functions to messages on streams

--- a/docs/riff_doctor.md
+++ b/docs/riff_doctor.md
@@ -1,0 +1,36 @@
+## riff doctor
+
+check riff's requirements are installed
+
+### Synopsis
+
+<todo>
+
+```
+riff doctor [flags]
+```
+
+### Examples
+
+```
+riff doctor
+```
+
+### Options
+
+```
+  -h, --help   help for doctor
+```
+
+### Options inherited from parent commands
+
+```
+      --config file        config file (default is $HOME/.riff.yaml)
+      --kube-config file   kubectl config file (default is $HOME/.kube/config)
+      --no-color           disable color output in terminals
+```
+
+### SEE ALSO
+
+* [riff](riff.md)	 - riff is for functions
+

--- a/pkg/riff/commands/doctor.go
+++ b/pkg/riff/commands/doctor.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/projectriff/riff/pkg/cli"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type DoctorOptions struct {
+}
+
+var RequiredNamespaces = []string{
+	"istio-system",
+	"knative-build",
+	"knative-serving",
+	"riff-system",
+}
+
+func (opts *DoctorOptions) Validate(ctx context.Context) *cli.FieldError {
+	return cli.EmptyFieldError
+}
+
+func (opts *DoctorOptions) Exec(ctx context.Context, c *cli.Config) error {
+	missingNamespaces, err := checkMissingNamespaces(c)
+
+	if err != nil {
+		c.Errorf(err.Error())
+		return err
+	} else if len(missingNamespaces) > 0 {
+		msg := "Something is wrong!\n"
+		for _, namespace := range missingNamespaces {
+			msg += fmt.Sprintf("missing %s\n", namespace)
+		}
+		c.Errorf(msg)
+	} else {
+		c.Successf("Installation is OK\n")
+	}
+	return nil
+}
+
+func NewDoctorCommand(c *cli.Config) *cobra.Command {
+	opts := &DoctorOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "check riff's requirements are installed",
+		Long: strings.TrimSpace(`
+    <todo>
+    `),
+		Example: "riff doctor",
+		Args:    cli.Args(),
+		PreRunE: cli.ValidateOptions(opts),
+		RunE:    cli.ExecOptions(c, opts),
+	}
+
+	return cmd
+}
+
+func checkMissingNamespaces(c *cli.Config) ([]string, error) {
+	missingNamespaces := []string{}
+	namespaces, err := c.Core().Namespaces().List(metav1.ListOptions{})
+
+	if namespaces == nil || len(namespaces.Items) == 0 {
+		missingNamespaces = RequiredNamespaces
+	} else {
+		names := []string{}
+		for _, namespace := range namespaces.Items {
+			names = append(names, namespace.Name)
+		}
+		for _, requiredNamespace := range RequiredNamespaces {
+			if !stringInSlice(requiredNamespace, names) {
+				missingNamespaces = append(missingNamespaces, requiredNamespace)
+			}
+		}
+	}
+
+	return missingNamespaces, err
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/riff/commands/doctor_test.go
+++ b/pkg/riff/commands/doctor_test.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/projectriff/riff/pkg/riff/commands"
+	rifftesting "github.com/projectriff/riff/pkg/testing"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestDoctorOptions(t *testing.T) {
+	table := rifftesting.OptionsTable{
+		{
+			Name:           "valid list",
+			Options:        &commands.DoctorOptions{},
+			ShouldValidate: true,
+		},
+	}
+
+	table.Run(t)
+}
+
+func TestDoctorCommand(t *testing.T) {
+	table := rifftesting.CommandTable{
+		{
+			Name:         "installation is ok",
+			Args:         []string{},
+			GivenObjects: requiredNamespacesMocks(commands.RequiredNamespaces),
+			ExpectOutput: `
+Installation is OK
+`,
+		},
+		{
+			Name:         "istio-system is missing",
+			Args:         []string{},
+			GivenObjects: requiredNamespacesMocks(remove(commands.RequiredNamespaces, "istio-system")),
+			ExpectOutput: `
+Something is wrong!
+missing istio-system
+`,
+		},
+		{
+			Name:         "multiple namespaces are missing",
+			Args:         []string{},
+			GivenObjects: requiredNamespacesMocks(remove(remove(commands.RequiredNamespaces, "istio-system"), "riff-system")),
+			ExpectOutput: `
+Something is wrong!
+missing istio-system
+missing riff-system
+`,
+		},
+		{
+			Name: "error",
+			Args: []string{},
+			WithReactors: []rifftesting.ReactionFunc{
+				rifftesting.InduceFailure("list", "namespaces"),
+			},
+			ShouldError:  true,
+			ExpectOutput: `inducing failure for list namespaces`,
+		},
+	}
+
+	table.Run(t, commands.NewDoctorCommand)
+}
+
+func requiredNamespacesMocks(namespaces []string) []runtime.Object {
+	mockObjects := []runtime.Object{}
+	for _, namespace := range namespaces {
+		mockNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+
+		mockObjects = append(mockObjects, mockNamespace)
+	}
+
+	return mockObjects
+}
+
+func remove(s []string, r string) []string {
+	newList := []string{}
+	for i, v := range s {
+		if v != r {
+			newList = append(newList, s[i])
+		}
+	}
+	return newList
+}

--- a/pkg/riff/commands/riff.go
+++ b/pkg/riff/commands/riff.go
@@ -39,6 +39,7 @@ func NewRiffCommand(c *cli.Config) *cobra.Command {
 	cmd.AddCommand(NewHandlerCommand(c))
 	cmd.AddCommand(NewStreamCommand(c))
 	cmd.AddCommand(NewProcessorCommand(c))
+	cmd.AddCommand(NewDoctorCommand(c))
 
 	return cmd
 }

--- a/pkg/riff/commands/riff_test.go
+++ b/pkg/riff/commands/riff_test.go
@@ -17,6 +17,7 @@
 package commands_test
 
 import (
+	"github.com/projectriff/riff/pkg/cli"
 	"testing"
 
 	"github.com/projectriff/riff/pkg/riff/commands"
@@ -32,4 +33,15 @@ func TestRiffCommand(t *testing.T) {
 	}
 
 	table.Run(t, commands.NewRiffCommand)
+}
+
+func TestRiffMainSubCommands(t *testing.T) {
+	riffCommand := commands.NewRiffCommand(cli.NewDefaultConfig())
+	commands := riffCommand.Commands()
+
+	expectedCount := 7
+	count := len(commands)
+	if count != expectedCount {
+		t.Fatalf("Expected %d riff subcommands, got %d", expectedCount, count)
+	}
 }


### PR DESCRIPTION
from hack.commit.push Paris

Added command `riff doctor` to check if the follow namespaces are installed for riff:
- istio-system
- knative-build
- knative-serving
- riff-system

like this
```
➜  riff git:(feature/riff-doctor) ./riff doctor
Installation is OK
```
or
```
➜  riff git:(feature/riff-doctor) ./riff doctor
Something is wrong!
missing istio-system
missing knative-build
missing knative-serving
missing riff-system
```

co-worked from https://github.com/davidthou & https://github.com/zhitongliu
