### PR TITLE
Add `--dry-run` flag for all create/apply commands

### DIFF
--- a/docs/riff_application_create.md
+++ b/docs/riff_application_create.md
@@ -21,6 +21,7 @@ riff application create my-app --image registry.example.com/image --local-path .
 
 ```
       --cache-size size         size of persistent volume to cache resources between builds
+      --dry-run                 print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
       --git-repo url            git url to remote source code
       --git-revision refspec    refspec within the git repo to checkout (default "master")
   -h, --help                    help for create

--- a/docs/riff_credential_apply.md
+++ b/docs/riff_credential_apply.md
@@ -26,6 +26,7 @@ riff credential apply my-registry-creds --registry http://registry.example.com -
 ```
       --default-image-prefix repository   default repository prefix for built images, implies --set-default-image-prefix
       --docker-hub username               Docker Hub username, the password must be provided via stdin
+      --dry-run                           print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
       --gcr file                          path to Google Container Registry service account token file
   -h, --help                              help for apply
   -n, --namespace name                    kubernetes namespace (defaulted from kube config)

--- a/docs/riff_function_create.md
+++ b/docs/riff_function_create.md
@@ -22,6 +22,7 @@ riff function create my-func --image registry.example.com/image --local-path ./m
 ```
       --artifact file           file containing the function within the build workspace (detected by default)
       --cache-size size         size of persistent volume to cache resources between builds
+      --dry-run                 print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
       --git-repo url            git url to remote source code
       --git-revision refspec    refspec within the git repo to checkout (default "master")
       --handler name            name of the method or class to invoke, depends on the invoker (detected by default)

--- a/docs/riff_handler_create.md
+++ b/docs/riff_handler_create.md
@@ -22,6 +22,7 @@ riff handler create my-image-handler --image registry.example.com/my-image:lates
 
 ```
       --application-ref name    name of application to deploy
+      --dry-run                 print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
       --env variable            environment variable defined as a key value pair separated by an equals sign, example "--env MY_VAR=my-value" (may be set multiple times)
       --env-from variable       environment variable from a config map or secret, example "--env-from MY_SECRET_VALUE=secretKeyRef:my-secret-name:key-in-secret", "--env-from MY_CONFIG_MAP_VALUE=configMapKeyRef:my-config-map-name:key-in-config-map" (may be set multiple times)
       --function-ref name       name of function to deploy

--- a/docs/riff_processor_create.md
+++ b/docs/riff_processor_create.md
@@ -20,6 +20,7 @@ riff processor create my-processor --function-ref my-func --input my-input-strea
 ### Options
 
 ```
+      --dry-run                 print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
       --function-ref name       name of function build to deploy
   -h, --help                    help for create
       --input name              name of stream to read messages from (may be set multiple times)

--- a/docs/riff_stream_create.md
+++ b/docs/riff_stream_create.md
@@ -20,6 +20,7 @@ riff stream create --provider my-provider
 
 ```
       --content-type MIME type   MIME type for message payloads accepted by the stream
+      --dry-run                  print kubernetes resources to stdout rather than apply them to the cluster, messages normally on stdout will be sent to stderr
   -h, --help                     help for create
   -n, --namespace name           kubernetes namespace (defaulted from kube config)
       --provider name            name of stream provider

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/boz/kail v0.10.1
 	github.com/buildpack/pack v0.2.0
 	github.com/fatih/color v1.7.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/knative/pkg v0.0.0-20190510233738-9e0db8f0a7f4

--- a/pkg/cli/dryrun.go
+++ b/pkg/cli/dryrun.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/ghodss/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func DryRunResource(ctx context.Context, resource runtime.Object, gvk schema.GroupVersionKind) {
+	stdout := stdoutFromContext(ctx)
+	resource = defaultTypeMeta(resource, gvk)
+	b, _ := yaml.Marshal(resource)
+	fmt.Fprintf(stdout, "---\n%s\n", b)
+}
+
+func defaultTypeMeta(resource runtime.Object, gvk schema.GroupVersionKind) runtime.Object {
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	tm := metav1.TypeMeta{
+		APIVersion: apiVersion,
+		Kind:       kind,
+	}
+	reflect.ValueOf(resource).Elem().FieldByName("TypeMeta").Set(reflect.ValueOf(tm))
+	return resource
+}
+
+type stdoutKey struct{}
+
+func withStdout(ctx context.Context, stdout io.Writer) context.Context {
+	return context.WithValue(ctx, stdoutKey{}, stdout)
+}
+
+func stdoutFromContext(ctx context.Context) io.Writer {
+	stdout, _ := ctx.Value(stdoutKey{}).(io.Writer)
+	return stdout
+}

--- a/pkg/cli/dryrun_test.go
+++ b/pkg/cli/dryrun_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	buildv1alpha1 "github.com/projectriff/system/pkg/apis/build/v1alpha1"
+)
+
+func TestDryRunResource(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	ctx := withStdout(context.TODO(), stdout)
+	resource := &buildv1alpha1.Application{}
+
+	DryRunResource(ctx, resource, resource.GetGroupVersionKind())
+
+	expected := strings.TrimSpace(`
+---
+apiVersion: build.projectriff.io/v1alpha1
+kind: Application
+metadata:
+  creationTimestamp: null
+spec:
+  image: ""
+status: {}
+`)
+	actual := strings.TrimSpace(stdout.String())
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("Unexpected stdout (-expected, +actual): %s", diff)
+	}
+
+}

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -33,6 +33,7 @@ const (
 	DefaultImagePrefixFlagName    = "--default-image-prefix"
 	DirectoryFlagName             = "--directory"
 	DockerHubFlagName             = "--docker-hub"
+	DryRunFlagName                = "--dry-run"
 	EnvFlagName                   = "--env"
 	EnvFromFlagName               = "--env-from"
 	FunctionRefFlagName           = "--function-ref"

--- a/pkg/cli/options_test.go
+++ b/pkg/cli/options_test.go
@@ -17,6 +17,7 @@
 package cli_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -80,6 +81,7 @@ func TestValidateOptions(t *testing.T) {
 }
 
 type StubExecOptions struct {
+	dryRun  bool
 	called  bool
 	config  *cli.Config
 	cmd     *cobra.Command
@@ -91,6 +93,10 @@ func (o *StubExecOptions) Exec(ctx context.Context, c *cli.Config) error {
 	o.config = c
 	o.cmd = cli.CommandFromContext(ctx)
 	return o.execErr
+}
+
+func (o *StubExecOptions) IsDryRun() bool {
+	return o.dryRun
 }
 
 func TestExecOptions(t *testing.T) {
@@ -107,12 +113,20 @@ func TestExecOptions(t *testing.T) {
 			execErr: fmt.Errorf("test exec error"),
 		},
 		expectedErr: fmt.Errorf("test exec error"),
+	}, {
+		name: "dry run",
+		opts: &StubExecOptions{
+			dryRun: true,
+		},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
-			config := &cli.Config{}
+			config := &cli.Config{
+				Stdout: &bytes.Buffer{},
+				Stderr: &bytes.Buffer{},
+			}
 			err := cli.ExecOptions(config, test.opts)(cmd, []string{})
 
 			if expected, actual := true, test.opts.called; true != actual {
@@ -126,6 +140,15 @@ func TestExecOptions(t *testing.T) {
 			}
 			if expected, actual := cmd, test.opts.cmd; expected != actual {
 				t.Errorf("expected command to be %v, actually %v", expected, actual)
+			}
+			if test.opts.dryRun {
+				if config.Stdout != config.Stderr {
+					t.Errorf("expected stdout and stderr to be the same, actually %v %v", config.Stdout, config.Stderr)
+				}
+			} else {
+				if config.Stdout == config.Stderr {
+					t.Errorf("expected stdout and stderr to be different, actually %v %v", config.Stdout, config.Stderr)
+				}
 			}
 		})
 	}

--- a/pkg/riff/commands/completion.go
+++ b/pkg/riff/commands/completion.go
@@ -53,6 +53,10 @@ func (opts *CompletionOptions) Exec(ctx context.Context, c *cli.Config) error {
 	panic("invalid shell: " + opts.Shell)
 }
 
+func (*CompletionOptions) IsDryRun() bool {
+	return false
+}
+
 func NewCompletionCommand(c *cli.Config) *cobra.Command {
 	opts := &CompletionOptions{}
 

--- a/pkg/riff/commands/credential_apply_test.go
+++ b/pkg/riff/commands/credential_apply_test.go
@@ -116,7 +116,6 @@ func TestCredentialApplyOptions(t *testing.T) {
 				cli.ErrMultipleOneOf(cli.DockerHubFlagName, cli.GcrFlagName, cli.RegistryFlagName),
 			),
 		},
-
 		{
 			Name: "docker hub as default image prefix",
 			Options: &commands.CredentialApplyOptions{
@@ -146,6 +145,21 @@ func TestCredentialApplyOptions(t *testing.T) {
 				SetDefaultImagePrefix: true,
 			},
 			ExpectFieldError: cli.ErrInvalidValue(fmt.Sprintf("cannot be used with %s, without %s", cli.RegistryFlagName, cli.DefaultImagePrefixFlagName), cli.SetDefaultImagePrefixFlagName),
+		},
+		{
+			Name: "dry run",
+			Options: &commands.CredentialApplyOptions{
+				ResourceOptions: cli.ResourceOptions{
+					CommonOptions: cli.CommonOptions{
+						DryRun: true,
+					},
+					Namespace: "default",
+					Name:      "my-name",
+				},
+				DockerHubId:       "projectriff",
+				DockerHubPassword: []byte("1password"),
+			},
+			ShouldValidate: true,
 		},
 	}
 
@@ -681,6 +695,92 @@ Set default image prefix to "docker.io/projectriff"
 				},
 			},
 			ShouldError: true,
+		},
+		{
+			Name:  "create dry run",
+			Args:  []string{credentialName, cli.DockerHubFlagName, dockerHubId, cli.SetDefaultImagePrefixFlagName, cli.DryRunFlagName},
+			Stdin: []byte(dockerHubPassword),
+			ExpectOutput: `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    build.knative.dev/docker-0: https://index.docker.io/v1/
+  creationTimestamp: null
+  labels:
+    build.projectriff.io/credential: docker-hub
+  name: test-credential
+  namespace: default
+stringData:
+  password: docker-password
+  username: projectriff
+type: kubernetes.io/basic-auth
+
+Apply credentials "test-credential"
+---
+apiVersion: v1
+data:
+  default-image-prefix: docker.io/projectriff
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: riff-build
+  namespace: default
+
+Set default image prefix to "docker.io/projectriff"
+`,
+		},
+		{
+			Name:  "update dry run",
+			Args:  []string{credentialName, cli.DockerHubFlagName, dockerHubId, cli.SetDefaultImagePrefixFlagName, cli.DryRunFlagName},
+			Stdin: []byte(dockerHubPassword),
+			GivenObjects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      credentialName,
+						Namespace: defaultNamespace,
+						Labels:    map[string]string{credentialLabel: ""},
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: defaultNamespace,
+						Name:      "riff-build",
+					},
+					Data: map[string]string{},
+				},
+			},
+			ExpectOutput: `
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    build.knative.dev/docker-0: https://index.docker.io/v1/
+  creationTimestamp: null
+  labels:
+    build.projectriff.io/credential: docker-hub
+  name: test-credential
+  namespace: default
+stringData:
+  password: docker-password
+  username: projectriff
+type: kubernetes.io/basic-auth
+
+Apply credentials "test-credential"
+---
+apiVersion: v1
+data:
+  default-image-prefix: docker.io/projectriff
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: riff-build
+  namespace: default
+
+Set default image prefix to "docker.io/projectriff"
+`,
 		},
 	}
 

--- a/pkg/riff/commands/handler_create_test.go
+++ b/pkg/riff/commands/handler_create_test.go
@@ -152,6 +152,36 @@ func TestHandlerCreateOptions(t *testing.T) {
 			},
 			ExpectFieldError: cli.ErrInvalidValue("d", cli.WaitTimeoutFlagName),
 		},
+		{
+			Name: "dry run",
+			Options: &commands.HandlerCreateOptions{
+				ResourceOptions: cli.ResourceOptions{
+					CommonOptions: cli.CommonOptions{
+						DryRun: true,
+					},
+					Namespace: "default",
+					Name:      "my-name",
+				},
+				Image: "example.com/repo:tag",
+			},
+			ShouldValidate: true,
+		},
+		{
+			Name: "dry run, tail",
+			Options: &commands.HandlerCreateOptions{
+				ResourceOptions: cli.ResourceOptions{
+					CommonOptions: cli.CommonOptions{
+						DryRun: true,
+					},
+					Namespace: "default",
+					Name:      "my-name",
+				},
+				Image:       "example.com/repo:tag",
+				Tail:        true,
+				WaitTimeout: "10m",
+			},
+			ExpectFieldError: cli.ErrMultipleOneOf(cli.DryRunFlagName, cli.TailFlagName),
+		},
 	}
 
 	table.Run(t)
@@ -237,6 +267,28 @@ Created handler "my-handler"
 				},
 			},
 			ExpectOutput: `
+Created handler "my-handler"
+`,
+		},
+		{
+			Name: "dry run",
+			Args: []string{handlerName, cli.ImageFlagName, image, cli.DryRunFlagName},
+			ExpectOutput: `
+---
+apiVersion: request.projectriff.io/v1alpha1
+kind: Handler
+metadata:
+  creationTimestamp: null
+  name: my-handler
+  namespace: default
+spec:
+  template:
+    containers:
+    - image: registry.example.com/repo@sha256:deadbeefdeadbeefdeadbeefdeadbeef
+      name: ""
+      resources: {}
+status: {}
+
 Created handler "my-handler"
 `,
 		},

--- a/pkg/riff/commands/processor_create_test.go
+++ b/pkg/riff/commands/processor_create_test.go
@@ -95,6 +95,38 @@ func TestProcessorCreateOptions(t *testing.T) {
 			},
 			ExpectFieldError: cli.ErrInvalidValue("d", cli.WaitTimeoutFlagName),
 		},
+		{
+			Name: "dry run",
+			Options: &commands.ProcessorCreateOptions{
+				ResourceOptions: cli.ResourceOptions{
+					CommonOptions: cli.CommonOptions{
+						DryRun: true,
+					},
+					Namespace: "default",
+					Name:      "my-name",
+				},
+				FunctionRef: "my-function",
+				Inputs:      []string{"input"},
+			},
+			ShouldValidate: true,
+		},
+		{
+			Name: "dry run, tail",
+			Options: &commands.ProcessorCreateOptions{
+				ResourceOptions: cli.ResourceOptions{
+					CommonOptions: cli.CommonOptions{
+						DryRun: true,
+					},
+					Namespace: "default",
+					Name:      "my-name",
+				},
+				FunctionRef: "my-function",
+				Inputs:      []string{"input"},
+				Tail:        true,
+				WaitTimeout: "10m",
+			},
+			ExpectFieldError: cli.ErrMultipleOneOf(cli.DryRunFlagName, cli.TailFlagName),
+		},
 	}
 
 	table.Run(t)
@@ -131,6 +163,27 @@ func TestProcessorCreateCommand(t *testing.T) {
 				},
 			},
 			ExpectOutput: `
+Created processor "my-processor"
+`,
+		},
+		{
+			Name: "dry run",
+			Args: []string{processorName, cli.FunctionRefFlagName, functionRef, cli.InputFlagName, inputName, cli.DryRunFlagName},
+			ExpectOutput: `
+---
+apiVersion: stream.projectriff.io/v1alpha1
+kind: Processor
+metadata:
+  creationTimestamp: null
+  name: my-processor
+  namespace: default
+spec:
+  functionRef: my-func
+  inputs:
+  - input
+  outputs: []
+status: {}
+
 Created processor "my-processor"
 `,
 		},

--- a/pkg/riff/commands/stream_create_test.go
+++ b/pkg/riff/commands/stream_create_test.go
@@ -66,10 +66,24 @@ func TestStreamCreateOptions(t *testing.T) {
 			Name: "with invalid content-type",
 			Options: &commands.StreamCreateOptions{
 				ResourceOptions: rifftesting.ValidResourceOptions,
-				Provider: "test-provider",
-				ContentType: "invalid-content-type",
+				Provider:        "test-provider",
+				ContentType:     "invalid-content-type",
 			},
 			ExpectFieldError: cli.ErrInvalidValue("invalid-content-type", cli.ContentTypeName),
+		},
+		{
+			Name: "dry run",
+			Options: &commands.StreamCreateOptions{
+				ResourceOptions: cli.ResourceOptions{
+					CommonOptions: cli.CommonOptions{
+						DryRun: true,
+					},
+					Namespace: "default",
+					Name:      "my-name",
+				},
+				Provider: "test-provider",
+			},
+			ShouldValidate: true,
 		},
 	}
 
@@ -105,6 +119,26 @@ func TestStreamCreateCommand(t *testing.T) {
 				},
 			},
 			ExpectOutput: `
+Created stream "my-stream"
+`,
+		},
+		{
+			Name: "dry run",
+			Args: []string{streamName, cli.ProviderFlagName, provider, cli.DryRunFlagName},
+			ExpectOutput: `
+---
+apiVersion: stream.projectriff.io/v1alpha1
+kind: Stream
+metadata:
+  creationTimestamp: null
+  name: my-stream
+  namespace: default
+spec:
+  contentType: ""
+  provider: test-provider
+status:
+  address: {}
+
 Created stream "my-stream"
 `,
 		},


### PR DESCRIPTION
Dry run will print resources to stdout rather than apply them to the k8s cluster. Messages normally on stdout will be sent to stderr instead. This allows using the riff cli to scaffold yaml and apply local mutations before sending the configuration to the API server.

Note: this is not side effect free. While the k8s API server will not be updated, local builds will still run and push images.

I'm open to names other than dry-run.